### PR TITLE
feat: add structured error classes (errors.ts)

### DIFF
--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentNotFoundError,
+  AgentStateError,
+  ApplicationError,
+  CyclicDependencyError,
+  getErrorCode,
+  getStatusCode,
+  KillSwitchActiveError,
+  PermissionError,
+  ResourceLimitError,
+  TaskFailureError,
+  ValidationError,
+} from "./errors";
+
+describe("ApplicationError subclasses", () => {
+  it("AgentNotFoundError has correct statusCode and code", () => {
+    const e = new AgentNotFoundError("abc");
+    expect(e.statusCode).toBe(404);
+    expect(e.code).toBe("AGENT_NOT_FOUND");
+    expect(e.message).toContain("abc");
+    expect(e instanceof ApplicationError).toBe(true);
+  });
+
+  it("KillSwitchActiveError has correct statusCode and code", () => {
+    const e = new KillSwitchActiveError();
+    expect(e.statusCode).toBe(503);
+    expect(e.code).toBe("KILL_SWITCH_ACTIVE");
+  });
+
+  it("PermissionError has correct statusCode and code", () => {
+    const e = new PermissionError();
+    expect(e.statusCode).toBe(403);
+    expect(e.code).toBe("PERMISSION_DENIED");
+  });
+
+  it("ResourceLimitError stores limit details", () => {
+    const e = new ResourceLimitError("agents", 10, 5);
+    expect(e.statusCode).toBe(429);
+    expect(e.code).toBe("RESOURCE_LIMIT_EXCEEDED");
+    expect(e.limitType).toBe("agents");
+    expect(e.current).toBe(10);
+    expect(e.limit).toBe(5);
+  });
+
+  it("ResourceLimitError accepts custom statusCode", () => {
+    const e = new ResourceLimitError("agents", 1, 1, 503);
+    expect(e.statusCode).toBe(503);
+  });
+
+  it("CyclicDependencyError has correct codes", () => {
+    const e = new CyclicDependencyError();
+    expect(e.statusCode).toBe(400);
+    expect(e.code).toBe("CYCLIC_DEPENDENCY");
+  });
+
+  it("ValidationError stores optional field", () => {
+    const e = new ValidationError("bad input", "email");
+    expect(e.statusCode).toBe(400);
+    expect(e.code).toBe("VALIDATION_FAILED");
+    expect(e.field).toBe("email");
+  });
+
+  it("TaskFailureError stores optional reason", () => {
+    const e = new TaskFailureError("failed", "timeout");
+    expect(e.statusCode).toBe(400);
+    expect(e.reason).toBe("timeout");
+  });
+
+  it("AgentStateError has correct codes", () => {
+    const e = new AgentStateError();
+    expect(e.statusCode).toBe(400);
+    expect(e.code).toBe("INVALID_AGENT_STATE");
+  });
+});
+
+describe("getStatusCode", () => {
+  it("returns statusCode for ApplicationError", () => {
+    expect(getStatusCode(new AgentNotFoundError("x"))).toBe(404);
+    expect(getStatusCode(new KillSwitchActiveError())).toBe(503);
+  });
+
+  it("returns 500 for unknown errors", () => {
+    expect(getStatusCode(new Error("generic"))).toBe(500);
+    expect(getStatusCode("string error")).toBe(500);
+    expect(getStatusCode(null)).toBe(500);
+  });
+});
+
+describe("getErrorCode", () => {
+  it("returns code for ApplicationError", () => {
+    expect(getErrorCode(new AgentNotFoundError("x"))).toBe("AGENT_NOT_FOUND");
+  });
+
+  it("returns INTERNAL_ERROR for unknown errors", () => {
+    expect(getErrorCode(new Error("generic"))).toBe("INTERNAL_ERROR");
+    expect(getErrorCode("oops")).toBe("INTERNAL_ERROR");
+  });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,110 @@
+export abstract class ApplicationError extends Error {
+  abstract readonly statusCode: number;
+  abstract readonly code: string;
+
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, ApplicationError.prototype);
+  }
+}
+
+export class AgentNotFoundError extends ApplicationError {
+  readonly statusCode = 404;
+  readonly code = "AGENT_NOT_FOUND";
+
+  constructor(agentId: string) {
+    super(`Agent not found: ${agentId}`);
+    Object.setPrototypeOf(this, AgentNotFoundError.prototype);
+  }
+}
+
+export class KillSwitchActiveError extends ApplicationError {
+  readonly statusCode = 503;
+  readonly code = "KILL_SWITCH_ACTIVE";
+
+  constructor(message = "Kill switch is active") {
+    super(message);
+    Object.setPrototypeOf(this, KillSwitchActiveError.prototype);
+  }
+}
+
+export class PermissionError extends ApplicationError {
+  readonly statusCode = 403;
+  readonly code = "PERMISSION_DENIED";
+
+  constructor(message = "Permission denied") {
+    super(message);
+    Object.setPrototypeOf(this, PermissionError.prototype);
+  }
+}
+
+export class ResourceLimitError extends ApplicationError {
+  readonly statusCode: number;
+  readonly code = "RESOURCE_LIMIT_EXCEEDED";
+  readonly limitType: string;
+  readonly current: number;
+  readonly limit: number;
+
+  constructor(limitType: string, current: number, limit: number, statusCode = 429) {
+    super(`${limitType} limit exceeded: ${current}/${limit}`);
+    this.limitType = limitType;
+    this.current = current;
+    this.limit = limit;
+    this.statusCode = statusCode;
+    Object.setPrototypeOf(this, ResourceLimitError.prototype);
+  }
+}
+
+export class CyclicDependencyError extends ApplicationError {
+  readonly statusCode = 400;
+  readonly code = "CYCLIC_DEPENDENCY";
+
+  constructor(message = "Operation would create a cyclic dependency") {
+    super(message);
+    Object.setPrototypeOf(this, CyclicDependencyError.prototype);
+  }
+}
+
+export class ValidationError extends ApplicationError {
+  readonly statusCode = 400;
+  readonly code = "VALIDATION_FAILED";
+  readonly field?: string;
+
+  constructor(message: string, field?: string) {
+    super(message);
+    this.field = field;
+    Object.setPrototypeOf(this, ValidationError.prototype);
+  }
+}
+
+export class TaskFailureError extends ApplicationError {
+  readonly statusCode = 400;
+  readonly code = "TASK_FAILED";
+  readonly reason?: string;
+
+  constructor(message: string, reason?: string) {
+    super(message);
+    this.reason = reason;
+    Object.setPrototypeOf(this, TaskFailureError.prototype);
+  }
+}
+
+export class AgentStateError extends ApplicationError {
+  readonly statusCode = 400;
+  readonly code = "INVALID_AGENT_STATE";
+
+  constructor(message = "Invalid agent state") {
+    super(message);
+    Object.setPrototypeOf(this, AgentStateError.prototype);
+  }
+}
+
+export function getStatusCode(error: unknown): number {
+  if (error instanceof ApplicationError) return error.statusCode;
+  return 500;
+}
+
+export function getErrorCode(error: unknown): string {
+  if (error instanceof ApplicationError) return error.code;
+  return "INTERNAL_ERROR";
+}


### PR DESCRIPTION
## Summary

- Adds `src/errors.ts` with structured `ApplicationError` subclasses replacing generic throws
- Adds `src/errors.test.ts` with full coverage of all error classes and helpers
- Ported from Fanbot; zero fanbot/fanvue references

## Test plan
- [x] `npm test` — 427 tests pass (23 test files)
- [x] `npx biome check .` — clean