### PR TITLE
feat: add model/pricing registry (models.ts)

### DIFF
--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MODEL, isOpusModel, MODELS, SMALL_FAST_MODEL } from "./models";
+
+describe("MODELS registry", () => {
+  it("contains all expected model keys", () => {
+    const keys = Object.keys(MODELS);
+    expect(keys).toContain("claude-opus-4-8-20260601");
+    expect(keys).toContain("claude-opus-4-7-20260601");
+    expect(keys).toContain("claude-opus-4-6");
+    expect(keys).toContain("claude-sonnet-4-6");
+    expect(keys).toContain("claude-sonnet-4-5-20250929");
+    expect(keys).toContain("claude-haiku-4-5-20251001");
+  });
+
+  it("each model has required fields", () => {
+    for (const [id, def] of Object.entries(MODELS)) {
+      expect(typeof def.displayName).toBe("string");
+      expect(def.tokenLimit).toBeGreaterThan(0);
+      expect(def.costMultiplier).toBeGreaterThan(0);
+      expect(def.pricing.input).toBeGreaterThan(0);
+      expect(def.pricing.output).toBeGreaterThan(0);
+    }
+  });
+
+  it("sonnet 4.6 has costMultiplier of 1.0 (baseline)", () => {
+    expect(MODELS["claude-sonnet-4-6"].costMultiplier).toBe(1.0);
+  });
+});
+
+describe("isOpusModel", () => {
+  it("returns true for opus model IDs", () => {
+    expect(isOpusModel("claude-opus-4-8-20260601")).toBe(true);
+    expect(isOpusModel("claude-opus-4-6")).toBe(true);
+  });
+
+  it("returns false for non-opus models", () => {
+    expect(isOpusModel("claude-sonnet-4-6")).toBe(false);
+    expect(isOpusModel("claude-haiku-4-5-20251001")).toBe(false);
+  });
+});
+
+describe("DEFAULT_MODEL and SMALL_FAST_MODEL", () => {
+  it("DEFAULT_MODEL is a valid key in MODELS", () => {
+    expect(DEFAULT_MODEL in MODELS).toBe(true);
+  });
+
+  it("SMALL_FAST_MODEL is a valid key in MODELS", () => {
+    expect(SMALL_FAST_MODEL in MODELS).toBe(true);
+  });
+
+  it("SMALL_FAST_MODEL is haiku", () => {
+    expect(SMALL_FAST_MODEL).toContain("haiku");
+  });
+});

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -13,7 +13,7 @@ describe("MODELS registry", () => {
   });
 
   it("each model has required fields", () => {
-    for (const [id, def] of Object.entries(MODELS)) {
+    for (const [_id, def] of Object.entries(MODELS)) {
       expect(typeof def.displayName).toBe("string");
       expect(def.tokenLimit).toBeGreaterThan(0);
       expect(def.costMultiplier).toBeGreaterThan(0);

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,67 @@
+export interface ModelPricing {
+  /** Per-million input tokens (USD) */
+  input: number;
+  /** Per-million output tokens (USD) */
+  output: number;
+  /** Per-million cache-read tokens (USD) */
+  cacheRead: number;
+  /** Per-million cache-write tokens (USD) */
+  cacheWrite: number;
+}
+
+export interface ModelDef {
+  displayName: string;
+  tokenLimit: number;
+  pricing: ModelPricing;
+  /** Cost multiplier relative to Sonnet 4.6 (= 1.0). */
+  costMultiplier: number;
+}
+
+export const MODELS = {
+  "claude-opus-4-8-20260601": {
+    displayName: "Opus 4.8",
+    tokenLimit: 1_000_000,
+    pricing: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+    costMultiplier: 1.67,
+  },
+  "claude-opus-4-7-20260601": {
+    displayName: "Opus 4.7",
+    tokenLimit: 1_000_000,
+    pricing: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+    costMultiplier: 1.67,
+  },
+  "claude-opus-4-6": {
+    displayName: "Opus 4.6",
+    tokenLimit: 1_000_000,
+    pricing: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+    costMultiplier: 1.67,
+  },
+  "claude-sonnet-4-6": {
+    displayName: "Sonnet 4.6",
+    tokenLimit: 1_000_000,
+    pricing: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+    costMultiplier: 1.0,
+  },
+  "claude-sonnet-4-5-20250929": {
+    displayName: "Sonnet 4.5",
+    tokenLimit: 200_000,
+    pricing: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+    costMultiplier: 1.0,
+  },
+  "claude-haiku-4-5-20251001": {
+    displayName: "Haiku 4.5",
+    tokenLimit: 200_000,
+    pricing: { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 },
+    costMultiplier: 0.33,
+  },
+} as const satisfies Record<string, ModelDef>;
+
+export type AllowedModel = keyof typeof MODELS;
+
+export function isOpusModel(model: string): boolean {
+  return model.startsWith("claude-opus");
+}
+
+export const DEFAULT_MODEL: AllowedModel = "claude-sonnet-4-6";
+
+export const SMALL_FAST_MODEL: AllowedModel = "claude-haiku-4-5-20251001";


### PR DESCRIPTION
## Summary

- Adds `src/models.ts` as single source of truth for all Claude model metadata and pricing
- Includes Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6, Sonnet 4.5, Haiku 4.5
- Provides `AllowedModel` type, `DEFAULT_MODEL`, `SMALL_FAST_MODEL`, `isOpusModel()`
- Downstream: guardrails.ts, usage-tracker, workflow-validators can derive from this registry
- Zero fanbot/fanvue references

## Test plan
- [x] `npm test` — 422 tests pass
- [x] `npx biome check .` — clean