### PR TITLE
feat: add token validation for external service tokens

### DIFF
--- a/src/token-validation.test.ts
+++ b/src/token-validation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { validateToken } from "./token-validation";
+
+describe("validateToken", () => {
+  it("returns error for unknown service", async () => {
+    const result = await validateToken("unknownservice", "tok");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Unknown service");
+    expect(result.error).toContain("unknownservice");
+  });
+
+  it("includes all supported services in the error message", async () => {
+    const result = await validateToken("bad", "tok");
+    expect(result.error).toContain("github");
+    expect(result.error).toContain("linear");
+    expect(result.error).toContain("figma");
+    expect(result.error).toContain("notion");
+    expect(result.error).toContain("slack");
+  });
+});

--- a/src/token-validation.ts
+++ b/src/token-validation.ts
@@ -1,0 +1,115 @@
+import { errorMessage } from "./types";
+
+export interface ValidationResult {
+  valid: boolean;
+  user?: string;
+  scopes?: string[];
+  error?: string;
+}
+
+const TIMEOUT_MS = 10_000;
+
+async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function validateGitHub(token: string): Promise<ValidationResult> {
+  try {
+    const res = await fetchWithTimeout("https://api.github.com/user", {
+      headers: { Authorization: `token ${token}`, Accept: "application/vnd.github+json" },
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return { valid: false, error: `GitHub API returned ${res.status}: ${body.slice(0, 200)}` };
+    }
+    const data = (await res.json()) as { login?: string };
+    const scopes =
+      res.headers
+        .get("x-oauth-scopes")
+        ?.split(",")
+        .map((s) => s.trim()) ?? [];
+    return { valid: true, user: data.login, scopes };
+  } catch (err: unknown) {
+    return { valid: false, error: errorMessage(err) };
+  }
+}
+
+async function validateLinear(token: string): Promise<ValidationResult> {
+  try {
+    const res = await fetchWithTimeout("https://api.linear.app/graphql", {
+      method: "POST",
+      headers: { Authorization: token, "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "{ viewer { id name } }" }),
+    });
+    if (!res.ok) return { valid: false, error: `Linear API returned ${res.status}` };
+    const data = (await res.json()) as { data?: { viewer?: { name?: string } } };
+    return { valid: true, user: data.data?.viewer?.name ?? undefined };
+  } catch (err: unknown) {
+    return { valid: false, error: errorMessage(err) };
+  }
+}
+
+async function validateFigma(token: string): Promise<ValidationResult> {
+  try {
+    const res = await fetchWithTimeout("https://api.figma.com/v1/me", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return { valid: false, error: `Figma API returned ${res.status}` };
+    const data = (await res.json()) as { handle?: string; email?: string };
+    return { valid: true, user: data.handle || data.email || undefined };
+  } catch (err: unknown) {
+    return { valid: false, error: errorMessage(err) };
+  }
+}
+
+async function validateNotion(token: string): Promise<ValidationResult> {
+  try {
+    const res = await fetchWithTimeout("https://api.notion.com/v1/users/me", {
+      headers: { Authorization: `Bearer ${token}`, "Notion-Version": "2022-06-28" },
+    });
+    if (!res.ok) return { valid: false, error: `Notion API returned ${res.status}` };
+    const data = (await res.json()) as { name?: string };
+    return { valid: true, user: data.name || undefined };
+  } catch (err: unknown) {
+    return { valid: false, error: errorMessage(err) };
+  }
+}
+
+async function validateSlack(token: string): Promise<ValidationResult> {
+  try {
+    const res = await fetchWithTimeout("https://slack.com/api/auth.test", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return { valid: false, error: `Slack API returned ${res.status}` };
+    const data = (await res.json()) as { ok?: boolean; user?: string; team?: string; error?: string };
+    if (!data.ok) return { valid: false, error: data.error || "Slack auth failed" };
+    return { valid: true, user: data.user && data.team ? `${data.user}@${data.team}` : data.user || undefined };
+  } catch (err: unknown) {
+    return { valid: false, error: errorMessage(err) };
+  }
+}
+
+const validators: Record<string, (token: string) => Promise<ValidationResult>> = {
+  github: validateGitHub,
+  linear: validateLinear,
+  figma: validateFigma,
+  notion: validateNotion,
+  slack: validateSlack,
+};
+
+export async function validateToken(service: string, token: string): Promise<ValidationResult> {
+  const validator = validators[service];
+  if (!validator)
+    return {
+      valid: false,
+      error: `Unknown service: ${service}. Supported services: ${Object.keys(validators).join(", ")}`,
+    };
+  return validator(token);
+}


### PR DESCRIPTION
## Summary

- Adds `src/token-validation.ts`: validates GitHub, Linear, Figma, Notion, Slack tokens by making lightweight API calls
- Returns `ValidationResult` with validity, optional user identity, and scopes (GitHub)
- Used by the tokens route (Phase B, PR 16)
- dep: PR 5 (errorMessage from types)

## Test plan
- [x] `npm test` — 416 tests pass
- [x] `npx biome check .` — clean (formatter fix applied)