### PR TITLE
feat: add context-policy-store + context-policy routes (PR 10)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -18,6 +18,7 @@ import { createAgentsRouter } from "./src/routes/agents";
 import { createAuthRouter } from "./src/routes/auth";
 import { createConfigRouter } from "./src/routes/config";
 import { createContextRouter } from "./src/routes/context";
+import { createContextPolicyRouter } from "./src/routes/context-policy";
 import { createCostRouter } from "./src/routes/cost";
 import { createHealthRouter } from "./src/routes/health";
 import { createKillSwitchRouter } from "./src/routes/kill-switch";
@@ -206,6 +207,7 @@ app.use(createTasksRouter(taskGraph, orchestrator, gradeStore));
 app.use(createSchedulerRouter(scheduler));
 app.use(createWorkflowsRouter(agentManager, messageBus));
 app.use(createRepositoriesRouter(agentManager));
+app.use(createContextPolicyRouter());
 app.use(createStartupRouter(agentManager, messageBus));
 // Layer 1: Kill switch endpoint (no extra auth beyond authMiddleware above)
 app.use(createKillSwitchRouter(agentManager));

--- a/src/context-policy-store.test.ts
+++ b/src/context-policy-store.test.ts
@@ -1,0 +1,360 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let testRoot: string;
+let store: typeof import("./context-policy-store");
+
+describe("context-policy-store", () => {
+  beforeEach(async () => {
+    testRoot = mkdtempSync(path.join(os.tmpdir(), "context-policy-test-"));
+    const policyDir = path.join(testRoot, "context-policies");
+    mkdirSync(policyDir, { recursive: true });
+
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+
+      const patchPath = (p: unknown): string => {
+        if (typeof p !== "string") return p as string;
+        // Redirect /tmp/context-policies → testRoot/context-policies
+        if (p.includes("/tmp/context-policies")) {
+          return p.replace("/tmp/context-policies", policyDir);
+        }
+        // Redirect /persistent → always-missing sentinel (forces /tmp fallback)
+        return p;
+      };
+
+      return {
+        ...actual,
+        existsSync: (p: string) => {
+          if (p === "/persistent") return false;
+          return actual.existsSync(patchPath(p));
+        },
+        mkdirSync: (p: string, options?: object) => actual.mkdirSync(patchPath(p), options),
+        readFileSync: (p: string, enc?: BufferEncoding) => actual.readFileSync(patchPath(p), enc),
+        unlinkSync: (p: string) => actual.unlinkSync(patchPath(p)),
+      };
+    });
+
+    vi.doMock("node:fs/promises", async () => {
+      const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+      const policyDirLocal = policyDir; // capture for closure
+
+      const patchPath = (p: unknown): string => {
+        if (typeof p !== "string") return p as string;
+        if (p.includes("/tmp/context-policies")) {
+          return p.replace("/tmp/context-policies", policyDirLocal);
+        }
+        return p;
+      };
+
+      return {
+        ...actual,
+        writeFile: (p: string, data: string, enc?: BufferEncoding) =>
+          actual.writeFile(patchPath(p), data, enc),
+        rename: (from: string, to: string) =>
+          actual.rename(patchPath(from), patchPath(to)),
+      };
+    });
+
+    vi.resetModules();
+    store = await import("./context-policy-store");
+  });
+
+  afterEach(() => {
+    vi.doUnmock("node:fs");
+    vi.doUnmock("node:fs/promises");
+    vi.resetModules();
+
+    if (testRoot && existsSync(testRoot)) {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  // ── Constants ────────────────────────────────────────────────────────────────
+
+  describe("exported constants", () => {
+    it("THRESHOLD_MIN is 0.5", () => expect(store.THRESHOLD_MIN).toBe(0.5));
+    it("THRESHOLD_MAX is 0.9", () => expect(store.THRESHOLD_MAX).toBe(0.9));
+    it("THRESHOLD_DEFAULT is 0.72", () => expect(store.THRESHOLD_DEFAULT).toBe(0.72));
+    it("COOLDOWN_MIN is 1", () => expect(store.COOLDOWN_MIN).toBe(1));
+    it("COOLDOWN_MAX is 50", () => expect(store.COOLDOWN_MAX).toBe(50));
+    it("COOLDOWN_DEFAULT is 3", () => expect(store.COOLDOWN_DEFAULT).toBe(3));
+    it("GLOBAL_SCOPE is 'default'", () => expect(store.GLOBAL_SCOPE).toBe("default"));
+
+    it("BUILTIN_DEFAULT has fully resolved autoReset", () => {
+      expect(store.BUILTIN_DEFAULT.autoReset).toEqual({
+        enabled: true,
+        threshold: store.THRESHOLD_DEFAULT,
+        cooldownTurns: store.COOLDOWN_DEFAULT,
+      });
+    });
+
+    it("POLICY_BOUNDS exposes correct ranges", () => {
+      expect(store.POLICY_BOUNDS.autoReset.threshold).toEqual({
+        min: store.THRESHOLD_MIN,
+        max: store.THRESHOLD_MAX,
+      });
+      expect(store.POLICY_BOUNDS.autoReset.cooldownTurns).toEqual({
+        min: store.COOLDOWN_MIN,
+        max: store.COOLDOWN_MAX,
+      });
+    });
+  });
+
+  // ── getGlobalPolicy before any writes ────────────────────────────────────────
+
+  describe("getGlobalPolicy (no file on disk)", () => {
+    it("returns empty policy with empty updatedAt", () => {
+      const record = store.getGlobalPolicy();
+      expect(record.scope).toBe(store.GLOBAL_SCOPE);
+      expect(record.policy).toEqual({});
+      expect(record.updatedAt).toBe("");
+    });
+  });
+
+  // ── getAgentPolicy before any writes ─────────────────────────────────────────
+
+  describe("getAgentPolicy (no file on disk)", () => {
+    it("returns empty policy for unknown agentId", () => {
+      const record = store.getAgentPolicy("agent-xyz");
+      expect(record.scope).toBe("agent-xyz");
+      expect(record.policy).toEqual({});
+      expect(record.updatedAt).toBe("");
+    });
+  });
+
+  // ── setGlobalPolicy ──────────────────────────────────────────────────────────
+
+  describe("setGlobalPolicy", () => {
+    it("persists and returns the sanitized record", async () => {
+      const saved = await store.setGlobalPolicy({ autoReset: { enabled: false, threshold: 0.8, cooldownTurns: 5 } });
+      expect(saved.scope).toBe(store.GLOBAL_SCOPE);
+      expect(saved.policy.autoReset?.enabled).toBe(false);
+      expect(saved.policy.autoReset?.threshold).toBe(0.8);
+      expect(saved.policy.autoReset?.cooldownTurns).toBe(5);
+      expect(saved.updatedAt).not.toBe("");
+    });
+
+    it("round-trips: getGlobalPolicy returns what was set", async () => {
+      await store.setGlobalPolicy({ autoReset: { threshold: 0.75 } });
+      const record = store.getGlobalPolicy();
+      expect(record.policy.autoReset?.threshold).toBe(0.75);
+    });
+
+    it("overwrites a previous global policy", async () => {
+      await store.setGlobalPolicy({ autoReset: { threshold: 0.6 } });
+      await store.setGlobalPolicy({ autoReset: { threshold: 0.85 } });
+      const record = store.getGlobalPolicy();
+      expect(record.policy.autoReset?.threshold).toBe(0.85);
+    });
+
+    it("clamps threshold below THRESHOLD_MIN to THRESHOLD_MIN", async () => {
+      await store.setGlobalPolicy({ autoReset: { threshold: 0.1 } });
+      const record = store.getGlobalPolicy();
+      expect(record.policy.autoReset?.threshold).toBe(store.THRESHOLD_MIN);
+    });
+
+    it("clamps threshold above THRESHOLD_MAX to THRESHOLD_MAX", async () => {
+      await store.setGlobalPolicy({ autoReset: { threshold: 0.99 } });
+      const record = store.getGlobalPolicy();
+      expect(record.policy.autoReset?.threshold).toBe(store.THRESHOLD_MAX);
+    });
+
+    it("clamps cooldownTurns below COOLDOWN_MIN to COOLDOWN_MIN", async () => {
+      await store.setGlobalPolicy({ autoReset: { cooldownTurns: 0 } });
+      const record = store.getGlobalPolicy();
+      expect(record.policy.autoReset?.cooldownTurns).toBe(store.COOLDOWN_MIN);
+    });
+
+    it("clamps cooldownTurns above COOLDOWN_MAX to COOLDOWN_MAX", async () => {
+      await store.setGlobalPolicy({ autoReset: { cooldownTurns: 99 } });
+      const record = store.getGlobalPolicy();
+      expect(record.policy.autoReset?.cooldownTurns).toBe(store.COOLDOWN_MAX);
+    });
+
+    it("rounds fractional cooldownTurns to nearest integer", async () => {
+      await store.setGlobalPolicy({ autoReset: { cooldownTurns: 3.7 } });
+      const record = store.getGlobalPolicy();
+      expect(record.policy.autoReset?.cooldownTurns).toBe(4);
+    });
+
+    it("strips unknown top-level fields (no autoReset set → empty policy)", async () => {
+      // empty patch — nothing to sanitize
+      const saved = await store.setGlobalPolicy({});
+      expect(saved.policy).toEqual({});
+    });
+
+    it("stores updatedAt as an ISO timestamp string", async () => {
+      const before = Date.now();
+      const saved = await store.setGlobalPolicy({ autoReset: { enabled: true } });
+      const after = Date.now();
+      const ts = new Date(saved.updatedAt).getTime();
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+  });
+
+  // ── setAgentPolicy ───────────────────────────────────────────────────────────
+
+  describe("setAgentPolicy", () => {
+    it("persists a per-agent override", async () => {
+      const saved = await store.setAgentPolicy("agent-abc", { autoReset: { enabled: false } });
+      expect(saved.scope).toBe("agent-abc");
+      expect(saved.policy.autoReset?.enabled).toBe(false);
+      expect(saved.updatedAt).not.toBe("");
+    });
+
+    it("round-trips: getAgentPolicy returns what was set", async () => {
+      await store.setAgentPolicy("agent-1", { autoReset: { cooldownTurns: 10 } });
+      const record = store.getAgentPolicy("agent-1");
+      expect(record.policy.autoReset?.cooldownTurns).toBe(10);
+    });
+
+    it("different agents are stored independently", async () => {
+      await store.setAgentPolicy("agent-A", { autoReset: { threshold: 0.6 } });
+      await store.setAgentPolicy("agent-B", { autoReset: { threshold: 0.8 } });
+      expect(store.getAgentPolicy("agent-A").policy.autoReset?.threshold).toBe(0.6);
+      expect(store.getAgentPolicy("agent-B").policy.autoReset?.threshold).toBe(0.8);
+    });
+  });
+
+  // ── deleteAgentPolicy ────────────────────────────────────────────────────────
+
+  describe("deleteAgentPolicy", () => {
+    it("is a no-op for a non-existent agent (does not throw)", () => {
+      expect(() => store.deleteAgentPolicy("agent-ghost")).not.toThrow();
+    });
+
+    it("removes a previously stored per-agent override", async () => {
+      await store.setAgentPolicy("agent-del", { autoReset: { threshold: 0.65 } });
+      store.deleteAgentPolicy("agent-del");
+      // After deletion the record should be empty again
+      const record = store.getAgentPolicy("agent-del");
+      expect(record.policy).toEqual({});
+      expect(record.updatedAt).toBe("");
+    });
+  });
+
+  // ── getEffectiveContextPolicy ─────────────────────────────────────────────────
+
+  describe("getEffectiveContextPolicy", () => {
+    it("returns BUILTIN_DEFAULT when no overrides exist", () => {
+      const effective = store.getEffectiveContextPolicy();
+      expect(effective.autoReset).toEqual(store.BUILTIN_DEFAULT.autoReset);
+    });
+
+    it("returns BUILTIN_DEFAULT for an unknown agentId", () => {
+      const effective = store.getEffectiveContextPolicy("agent-new");
+      expect(effective.autoReset).toEqual(store.BUILTIN_DEFAULT.autoReset);
+    });
+
+    it("global override wins over builtin for threshold", async () => {
+      await store.setGlobalPolicy({ autoReset: { threshold: 0.8 } });
+      const effective = store.getEffectiveContextPolicy();
+      expect(effective.autoReset.threshold).toBe(0.8);
+      // Other fields inherit from builtin
+      expect(effective.autoReset.enabled).toBe(true);
+      expect(effective.autoReset.cooldownTurns).toBe(store.COOLDOWN_DEFAULT);
+    });
+
+    it("global override wins over builtin for enabled flag", async () => {
+      await store.setGlobalPolicy({ autoReset: { enabled: false } });
+      const effective = store.getEffectiveContextPolicy();
+      expect(effective.autoReset.enabled).toBe(false);
+    });
+
+    it("global override wins over builtin for cooldownTurns", async () => {
+      await store.setGlobalPolicy({ autoReset: { cooldownTurns: 10 } });
+      const effective = store.getEffectiveContextPolicy();
+      expect(effective.autoReset.cooldownTurns).toBe(10);
+    });
+
+    it("per-agent override wins over global for threshold", async () => {
+      await store.setGlobalPolicy({ autoReset: { threshold: 0.75 } });
+      await store.setAgentPolicy("agent-x", { autoReset: { threshold: 0.6 } });
+      const effective = store.getEffectiveContextPolicy("agent-x");
+      expect(effective.autoReset.threshold).toBe(0.6);
+    });
+
+    it("per-agent override wins over global for enabled", async () => {
+      await store.setGlobalPolicy({ autoReset: { enabled: false } });
+      await store.setAgentPolicy("agent-y", { autoReset: { enabled: true } });
+      const effective = store.getEffectiveContextPolicy("agent-y");
+      expect(effective.autoReset.enabled).toBe(true);
+    });
+
+    it("per-agent override is selective — unset fields inherit from global", async () => {
+      await store.setGlobalPolicy({ autoReset: { threshold: 0.8, cooldownTurns: 7 } });
+      // agent only overrides cooldownTurns
+      await store.setAgentPolicy("agent-z", { autoReset: { cooldownTurns: 2 } });
+      const effective = store.getEffectiveContextPolicy("agent-z");
+      expect(effective.autoReset.cooldownTurns).toBe(2);
+      expect(effective.autoReset.threshold).toBe(0.8); // from global
+      expect(effective.autoReset.enabled).toBe(true);  // from builtin
+    });
+
+    it("deleting per-agent override reverts to global", async () => {
+      await store.setGlobalPolicy({ autoReset: { threshold: 0.77 } });
+      await store.setAgentPolicy("agent-del2", { autoReset: { threshold: 0.55 } });
+      store.deleteAgentPolicy("agent-del2");
+      const effective = store.getEffectiveContextPolicy("agent-del2");
+      expect(effective.autoReset.threshold).toBe(0.77);
+    });
+
+    it("passing GLOBAL_SCOPE as agentId behaves as no-agent (skips per-agent layer)", async () => {
+      await store.setGlobalPolicy({ autoReset: { threshold: 0.8 } });
+      // GLOBAL_SCOPE is treated the same as undefined → no per-agent layer added
+      const effective = store.getEffectiveContextPolicy(store.GLOBAL_SCOPE);
+      expect(effective.autoReset.threshold).toBe(0.8);
+    });
+
+    it("all three layers compose in correct precedence order", async () => {
+      // builtin: enabled=true, threshold=0.72, cooldown=3
+      // global:  cooldown=10
+      // agent:   enabled=false
+      await store.setGlobalPolicy({ autoReset: { cooldownTurns: 10 } });
+      await store.setAgentPolicy("agent-full", { autoReset: { enabled: false } });
+      const effective = store.getEffectiveContextPolicy("agent-full");
+      expect(effective.autoReset.enabled).toBe(false);        // from agent
+      expect(effective.autoReset.cooldownTurns).toBe(10);     // from global
+      expect(effective.autoReset.threshold).toBe(0.72);       // from builtin
+    });
+
+    it("effective policy has no optional/undefined fields (fully resolved)", async () => {
+      const effective = store.getEffectiveContextPolicy();
+      expect(effective.autoReset.enabled).toBeDefined();
+      expect(effective.autoReset.threshold).toBeDefined();
+      expect(effective.autoReset.cooldownTurns).toBeDefined();
+    });
+  });
+
+  // ── sanitize edge cases (via the public API) ─────────────────────────────────
+
+  describe("sanitize edge cases (exercised through setGlobalPolicy)", () => {
+    it("ignores non-boolean enabled field", async () => {
+      await store.setGlobalPolicy({ autoReset: { enabled: "yes" as unknown as boolean } });
+      const record = store.getGlobalPolicy();
+      expect(record.policy.autoReset?.enabled).toBeUndefined();
+    });
+
+    it("ignores non-finite threshold", async () => {
+      await store.setGlobalPolicy({ autoReset: { threshold: NaN } });
+      const record = store.getGlobalPolicy();
+      expect(record.policy.autoReset?.threshold).toBeUndefined();
+    });
+
+    it("ignores non-numeric cooldownTurns", async () => {
+      await store.setGlobalPolicy({ autoReset: { cooldownTurns: "five" as unknown as number } });
+      const record = store.getGlobalPolicy();
+      expect(record.policy.autoReset?.cooldownTurns).toBeUndefined();
+    });
+
+    it("stores nothing when autoReset is not an object", async () => {
+      await store.setGlobalPolicy({ autoReset: "bad" as unknown as object });
+      const record = store.getGlobalPolicy();
+      expect(record.policy.autoReset).toBeUndefined();
+    });
+  });
+});

--- a/src/context-policy-store.ts
+++ b/src/context-policy-store.ts
@@ -1,0 +1,183 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
+import { rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { logger } from "./logger";
+
+// Autonomous-context-management policy store. Mirrors hook-config-store.ts
+// (JSON-per-key under /persistent), but adds a GLOBAL DEFAULT plus optional
+// PER-AGENT OVERRIDES: effective = merge(builtin, global, perAgent).
+//
+// The shape is NESTED BY CONCERN so each feature owns a sub-object. The only
+// concern wired today is `autoReset` (consumed by src/context-autoreset.ts,
+// 1e). Adding a future concern is additive: add its sub-object to the
+// interfaces + sanitize()/merge(); no structural change.
+//
+// IMPORTANT: `autoReset.threshold` is a FRACTION (0..1), NOT a percentage —
+// this matches the live consumer (context-autoreset.ts reads .autoReset and
+// multiplies by 100 for display). Do not switch units without updating 1e.
+
+/** Per-concern auto-reset tuning. All fields optional in a stored override. */
+export interface AutoResetPolicy {
+  enabled?: boolean; // master toggle (effective default: true)
+  threshold?: number; // band ceiling as a fraction 0..1 (effective default: 0.72)
+  cooldownTurns?: number; // onIdle turns to wait after a reset (effective default: 3)
+}
+
+/** Sparse override — carries only the fields it changes. */
+export interface ContextPolicy {
+  autoReset?: AutoResetPolicy;
+}
+
+/** Fully-resolved auto-reset config — no optional fields. */
+export interface EffectiveAutoReset {
+  enabled: boolean;
+  threshold: number;
+  cooldownTurns: number;
+}
+
+/** Fully-resolved policy returned by the resolver. */
+export interface EffectiveContextPolicy {
+  autoReset: EffectiveAutoReset;
+}
+
+/** Stored shape for one key: scope is "default" (global) or an agentId. */
+export interface ContextPolicyRecord {
+  scope: string;
+  policy: ContextPolicy;
+  updatedAt: string; // ISO timestamp ("" when never written)
+}
+
+// ─── Guard-rail bounds + built-in defaults ───────────────────────────────────
+
+export const THRESHOLD_MIN = 0.5;
+export const THRESHOLD_MAX = 0.9;
+export const THRESHOLD_DEFAULT = 0.72;
+export const COOLDOWN_MIN = 1;
+export const COOLDOWN_MAX = 50;
+export const COOLDOWN_DEFAULT = 3;
+
+/** Built-in default — in force before any operator customization. `enabled`
+ *  defaults true to match the context-autoreset fallback (headline behaviour). */
+export const BUILTIN_DEFAULT: EffectiveContextPolicy = {
+  autoReset: { enabled: true, threshold: THRESHOLD_DEFAULT, cooldownTurns: COOLDOWN_DEFAULT },
+};
+
+/** Machine-readable bounds for clients (UI sliders, validation). */
+export const POLICY_BOUNDS = {
+  autoReset: {
+    threshold: { min: THRESHOLD_MIN, max: THRESHOLD_MAX },
+    cooldownTurns: { min: COOLDOWN_MIN, max: COOLDOWN_MAX },
+  },
+};
+
+export const GLOBAL_SCOPE = "default"; // reserved scope key for the global record
+
+// ─── Persistence ─────────────────────────────────────────────────────────────
+
+const PERSISTENT_BASE = "/persistent";
+const PERSISTENT_AVAILABLE = existsSync(PERSISTENT_BASE);
+const CONTEXT_POLICY_DIR = PERSISTENT_AVAILABLE ? `${PERSISTENT_BASE}/context-policies` : "/tmp/context-policies";
+
+mkdirSync(CONTEXT_POLICY_DIR, { recursive: true });
+
+function policyPath(scope: string): string {
+  return path.join(CONTEXT_POLICY_DIR, `${scope}.json`);
+}
+
+function readRecord(scope: string): ContextPolicyRecord {
+  const filePath = policyPath(scope);
+  if (!existsSync(filePath)) return { scope, policy: {}, updatedAt: "" };
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf-8")) as ContextPolicyRecord;
+    return { scope, policy: sanitize(parsed.policy ?? {}), updatedAt: parsed.updatedAt ?? "" };
+  } catch (err: unknown) {
+    logger.warn(
+      `[context-policy-store] Failed to read policy for ${scope}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { scope, policy: {}, updatedAt: "" };
+  }
+}
+
+async function writeRecord(scope: string, policy: ContextPolicy): Promise<ContextPolicyRecord> {
+  const record: ContextPolicyRecord = { scope, policy: sanitize(policy), updatedAt: new Date().toISOString() };
+  const filePath = policyPath(scope);
+  const tmpPath = `${filePath}.tmp`;
+  await writeFile(tmpPath, JSON.stringify(record), "utf-8");
+  await rename(tmpPath, filePath);
+  return record;
+}
+
+// ─── Clamp / merge helpers ───────────────────────────────────────────────────
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/** Drop unknown/invalid fields and clamp numbers. Never throws — an invalid
+ *  value is omitted (so the field inherits) rather than rejected. */
+function sanitize(policy: ContextPolicy): ContextPolicy {
+  const out: ContextPolicy = {};
+  const ar = policy.autoReset;
+  if (ar && typeof ar === "object") {
+    const clean: AutoResetPolicy = {};
+    if (typeof ar.enabled === "boolean") clean.enabled = ar.enabled;
+    if (typeof ar.threshold === "number" && Number.isFinite(ar.threshold)) {
+      clean.threshold = clamp(ar.threshold, THRESHOLD_MIN, THRESHOLD_MAX);
+    }
+    if (typeof ar.cooldownTurns === "number" && Number.isFinite(ar.cooldownTurns)) {
+      clean.cooldownTurns = clamp(Math.round(ar.cooldownTurns), COOLDOWN_MIN, COOLDOWN_MAX);
+    }
+    if (Object.keys(clean).length > 0) out.autoReset = clean;
+  }
+  return out;
+}
+
+/** Layer sparse overrides over a complete base; later args win per-field. */
+function merge(base: EffectiveContextPolicy, ...layers: ContextPolicy[]): EffectiveContextPolicy {
+  const out: EffectiveContextPolicy = { autoReset: { ...base.autoReset } };
+  for (const layer of layers) {
+    const ar = sanitize(layer).autoReset;
+    if (ar?.enabled !== undefined) out.autoReset.enabled = ar.enabled;
+    if (ar?.threshold !== undefined) out.autoReset.threshold = ar.threshold;
+    if (ar?.cooldownTurns !== undefined) out.autoReset.cooldownTurns = ar.cooldownTurns;
+  }
+  return out;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+// get* return the raw sparse record ("" updatedAt if never set). set* clamp +
+// sanitize before persisting. Deleting an override reverts the agent to global.
+
+export function getGlobalPolicy(): ContextPolicyRecord {
+  return readRecord(GLOBAL_SCOPE);
+}
+
+export function getAgentPolicy(agentId: string): ContextPolicyRecord {
+  return readRecord(agentId);
+}
+
+export function setGlobalPolicy(policy: ContextPolicy): Promise<ContextPolicyRecord> {
+  return writeRecord(GLOBAL_SCOPE, policy);
+}
+
+export function setAgentPolicy(agentId: string, policy: ContextPolicy): Promise<ContextPolicyRecord> {
+  return writeRecord(agentId, policy);
+}
+
+export function deleteAgentPolicy(agentId: string): void {
+  const filePath = policyPath(agentId);
+  if (existsSync(filePath)) unlinkSync(filePath);
+}
+
+/**
+ * Resolve the effective policy: BUILTIN_DEFAULT <- global <- per-agent override.
+ * Sync + fail-safe (read errors yield builtin defaults, never throws) so the
+ * context-autoreset hot path  can call it inline. 1e calls it with
+ * no agentId, which yields the global effective policy; passing an agentId
+ * layers that agent's override on top.
+ */
+export function getEffectiveContextPolicy(agentId?: string): EffectiveContextPolicy {
+  const layers: ContextPolicy[] = [getGlobalPolicy().policy];
+  if (agentId && agentId !== GLOBAL_SCOPE) layers.push(getAgentPolicy(agentId).policy);
+  return merge(BUILTIN_DEFAULT, ...layers);
+}

--- a/src/routes/context-policy.ts
+++ b/src/routes/context-policy.ts
@@ -1,0 +1,129 @@
+// Autonomous-context-management policy routes. GET is readable behind normal
+// auth (an agent may read the policy it runs under); WRITES are operator-only
+// via requireNotAgentService — per ADR-001 the security boundary is the AUTH
+// layer: an agent must never edit the policy it is itself subject to.
+import express, { type Request, type Response } from "express";
+import { requireNotAgentService } from "../auth";
+import {
+  COOLDOWN_MAX,
+  COOLDOWN_MIN,
+  type ContextPolicy,
+  deleteAgentPolicy,
+  getAgentPolicy,
+  getEffectiveContextPolicy,
+  getGlobalPolicy,
+  POLICY_BOUNDS,
+  setAgentPolicy,
+  setGlobalPolicy,
+  THRESHOLD_MAX,
+  THRESHOLD_MIN,
+} from "../context-policy-store";
+import { logger } from "../logger";
+import { errorMessage } from "../types";
+import { param } from "../utils/express";
+
+/** Validate a sparse policy patch; throws on invalid input (caller -> 400).
+ *  Range-checks here so out-of-range gets a clear 400 rather than a silent clamp. */
+function validatePolicyPatch(body: unknown): ContextPolicy {
+  if (typeof body !== "object" || body === null) {
+    throw new Error("request body must be a JSON object");
+  }
+  const b = body as Record<string, unknown>;
+  const patch: ContextPolicy = {};
+  const ar = b.autoReset;
+  if (ar !== undefined) {
+    if (typeof ar !== "object" || ar === null) throw new Error("autoReset must be an object");
+    const a = ar as Record<string, unknown>;
+    const out: NonNullable<ContextPolicy["autoReset"]> = {};
+    if (a.enabled !== undefined) {
+      if (typeof a.enabled !== "boolean") throw new Error("autoReset.enabled must be a boolean");
+      out.enabled = a.enabled;
+    }
+    if (a.threshold !== undefined) {
+      const v = Number(a.threshold);
+      if (!Number.isFinite(v) || v < THRESHOLD_MIN || v > THRESHOLD_MAX) {
+        throw new Error(`autoReset.threshold must be between ${THRESHOLD_MIN} and ${THRESHOLD_MAX}`);
+      }
+      out.threshold = v;
+    }
+    if (a.cooldownTurns !== undefined) {
+      const v = Number(a.cooldownTurns);
+      if (!Number.isInteger(v) || v < COOLDOWN_MIN || v > COOLDOWN_MAX) {
+        throw new Error(`autoReset.cooldownTurns must be an integer between ${COOLDOWN_MIN} and ${COOLDOWN_MAX}`);
+      }
+      out.cooldownTurns = v;
+    }
+    patch.autoReset = out;
+  }
+  return patch;
+}
+
+export function createContextPolicyRouter() {
+  const router = express.Router();
+
+  // ── Global default ─────────────────────────────────────────────────────────
+
+  router.get("/api/context-policy", (_req: Request, res: Response) => {
+    res.json({ effective: getEffectiveContextPolicy(), global: getGlobalPolicy(), bounds: POLICY_BOUNDS });
+  });
+
+  router.put("/api/context-policy", requireNotAgentService, (req: Request, res: Response) => {
+    let patch: ContextPolicy;
+    try {
+      patch = validatePolicyPatch(req.body);
+    } catch (err: unknown) {
+      res.status(400).json({ error: errorMessage(err) });
+      return;
+    }
+    setGlobalPolicy(patch)
+      .then((saved) => {
+        logger.info(`[context-policy] Updated global default: ${JSON.stringify(saved.policy)}`);
+        res.json({ effective: getEffectiveContextPolicy(), global: saved, bounds: POLICY_BOUNDS });
+      })
+      .catch((err: unknown) => {
+        logger.warn(`[context-policy] Failed to persist global policy: ${errorMessage(err)}`);
+        res.status(500).json({ error: "Failed to save context policy" });
+      });
+  });
+
+  // ── Per-agent override ──────────────────────────────────────────────────────
+
+  router.get("/api/context-policy/:agentId", (req: Request, res: Response) => {
+    const agentId = param(req.params.agentId);
+    res.json({
+      effective: getEffectiveContextPolicy(agentId),
+      global: getGlobalPolicy(),
+      agent: getAgentPolicy(agentId),
+      bounds: POLICY_BOUNDS,
+    });
+  });
+
+  router.put("/api/context-policy/:agentId", requireNotAgentService, (req: Request, res: Response) => {
+    const agentId = param(req.params.agentId);
+    let patch: ContextPolicy;
+    try {
+      patch = validatePolicyPatch(req.body);
+    } catch (err: unknown) {
+      res.status(400).json({ error: errorMessage(err) });
+      return;
+    }
+    setAgentPolicy(agentId, patch)
+      .then((saved) => {
+        logger.info(`[context-policy] Updated override for ${agentId}: ${JSON.stringify(saved.policy)}`);
+        res.json({ effective: getEffectiveContextPolicy(agentId), agent: saved, bounds: POLICY_BOUNDS });
+      })
+      .catch((err: unknown) => {
+        logger.warn(`[context-policy] Failed to persist override for ${agentId}: ${errorMessage(err)}`);
+        res.status(500).json({ error: "Failed to save context policy" });
+      });
+  });
+
+  router.delete("/api/context-policy/:agentId", requireNotAgentService, (req: Request, res: Response) => {
+    const agentId = param(req.params.agentId);
+    deleteAgentPolicy(agentId);
+    logger.info(`[context-policy] Cleared override for ${agentId}`);
+    res.json({ effective: getEffectiveContextPolicy(agentId), bounds: POLICY_BOUNDS });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

- `src/context-policy-store.ts`: per-agent and global context-prune policy store. Persists to `/persistent/context-policies/` (GCS-synced). Layered merge: builtin → global → per-agent.
- `src/routes/context-policy.ts`: GET/PUT/DELETE for global and per-agent context policy. Writes gated to `requireNotAgentService`.
- `server.ts`: mount `createContextPolicyRouter()`.
- Zero fanbot/fanvue refs.

## Test plan
- [x] `npm test` — 414 tests pass
- [x] `npx biome check .` — clean