### PR TITLE
feat: add budget-ceiling module

### DIFF
--- a/src/budget-ceiling.test.ts
+++ b/src/budget-ceiling.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { BudgetCeilingMonitor, evaluateBudgetCeiling } from "./budget-ceiling";
+
+describe("evaluateBudgetCeiling", () => {
+  it("disabled when ceiling <= 0", () => {
+    expect(evaluateBudgetCeiling(100, 0).blocked).toBe(false);
+    expect(evaluateBudgetCeiling(100, -1).blocked).toBe(false);
+    expect(evaluateBudgetCeiling(100, 0).ratio).toBe(0);
+  });
+
+  it("not blocked at 0% spend", () => {
+    expect(evaluateBudgetCeiling(0, 100).blocked).toBe(false);
+    expect(evaluateBudgetCeiling(0, 100).level).toBe(0);
+  });
+
+  it("warning at 50%", () => {
+    const r = evaluateBudgetCeiling(50, 100);
+    expect(r.level).toBe(50);
+    expect(r.blocked).toBe(false);
+  });
+
+  it("warning at 80%", () => {
+    expect(evaluateBudgetCeiling(80, 100).level).toBe(80);
+  });
+
+  it("blocked at 100%", () => {
+    const r = evaluateBudgetCeiling(100, 100);
+    expect(r.blocked).toBe(true);
+    expect(r.level).toBe(100);
+  });
+
+  it("blocked above 100%", () => {
+    expect(evaluateBudgetCeiling(150, 100).blocked).toBe(true);
+  });
+});
+
+describe("BudgetCeilingMonitor", () => {
+  it("fires crossed=50 when first crossing 50%", () => {
+    const m = new BudgetCeilingMonitor();
+    const r = m.observe(51, 100);
+    expect(r.crossed).toBe(50);
+  });
+
+  it("does not re-fire same level", () => {
+    const m = new BudgetCeilingMonitor();
+    m.observe(51, 100);
+    const r = m.observe(55, 100);
+    expect(r.crossed).toBeNull();
+  });
+
+  it("fires 80 after 50 is already latched", () => {
+    const m = new BudgetCeilingMonitor();
+    m.observe(51, 100);
+    const r = m.observe(81, 100);
+    expect(r.crossed).toBe(80);
+  });
+
+  it("reset clears latch so 50 can fire again", () => {
+    const m = new BudgetCeilingMonitor();
+    m.observe(51, 100);
+    m.reset();
+    expect(m.observe(51, 100).crossed).toBe(50);
+  });
+});

--- a/src/budget-ceiling.ts
+++ b/src/budget-ceiling.ts
@@ -1,0 +1,68 @@
+/**
+ * Global spend ceiling — the container-level backstop against runaway overnight
+ * cost (the "$800 night"). Per-agent caps bound individual agents; this bounds
+ * the whole fleet's spend over a rolling window.
+ *
+ * Pure evaluation lives in `evaluateBudgetCeiling`; `BudgetCeilingMonitor` adds
+ * edge-triggered alerting (each threshold fires once until spend drops back
+ * below it, so a new window re-alerts rather than spamming every tick).
+ */
+
+/** Alert thresholds as a percentage of the ceiling. 100 = the hard block. */
+export const BUDGET_ALERT_LEVELS = [50, 80, 100] as const;
+
+export interface BudgetCeilingEvaluation {
+  /** Spend as a fraction of the ceiling (0..1+). 0 when the ceiling is disabled. */
+  ratio: number;
+  /** True once spend has reached the ceiling — new spawns should be refused. */
+  blocked: boolean;
+  /** Highest alert level (50/80/100) currently reached, or 0 if none. */
+  level: number;
+}
+
+/**
+ * Evaluate spend against a ceiling. A ceiling <= 0 disables the feature
+ * (never blocks, never alerts).
+ */
+export function evaluateBudgetCeiling(spentUsd: number, ceilingUsd: number): BudgetCeilingEvaluation {
+  if (!Number.isFinite(ceilingUsd) || ceilingUsd <= 0) {
+    return { ratio: 0, blocked: false, level: 0 };
+  }
+  const ratio = spentUsd / ceilingUsd;
+  const pct = ratio * 100;
+  let level = 0;
+  for (const l of BUDGET_ALERT_LEVELS) {
+    if (pct >= l) level = l;
+  }
+  return { ratio, blocked: pct >= 100, level };
+}
+
+export interface BudgetCeilingObservation {
+  blocked: boolean;
+  /** A newly-crossed alert level to surface to the operator, or null. */
+  crossed: number | null;
+  ratio: number;
+}
+
+/**
+ * Stateful wrapper that remembers the highest alert level already reported, so
+ * callers polling on every spawn/cleanup tick only emit an alert when a new
+ * threshold is crossed. When spend falls back below a level (e.g. a new rolling
+ * window), the latch resets and that level can fire again.
+ */
+export class BudgetCeilingMonitor {
+  private lastAlertedLevel = 0;
+
+  observe(spentUsd: number, ceilingUsd: number): BudgetCeilingObservation {
+    const { ratio, blocked, level } = evaluateBudgetCeiling(spentUsd, ceilingUsd);
+    let crossed: number | null = null;
+    if (level > this.lastAlertedLevel) crossed = level;
+    this.lastAlertedLevel = level;
+    return { blocked, crossed, ratio };
+  }
+
+  /** Reset the alert latch (e.g. when the ceiling is reconfigured). */
+  reset(): void {
+    this.lastAlertedLevel = 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds `src/budget-ceiling.ts` — global spend ceiling with edge-triggered `BudgetCeilingMonitor`.

- `evaluateBudgetCeiling(spent, ceiling)`: pure evaluation, returns ratio/blocked/level
- `BudgetCeilingMonitor`: stateful wrapper that fires each threshold (50/80/100%) once until spend drops back below it
- No storage, no server.ts changes — consumed by agents.ts spawn path in Phase E PR 31

Zero fanbot/fanvue refs. ~70 lines source + ~55 lines test.

## Test plan
- [x] `npm test` passes
- [x] `npx biome check .` clean