### PR TITLE
feat: add agent-mcp module

### DIFF
--- a/src/agent-mcp.test.ts
+++ b/src/agent-mcp.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_MCP_FILENAME, filterMcpServers } from "./agent-mcp";
+
+describe("filterMcpServers", () => {
+  const global = { figma: { type: "http" }, linear: { type: "http" }, slack: { type: "http" } };
+
+  it("returns only allowlisted servers", () => {
+    const { servers } = filterMcpServers(global, ["figma"]);
+    expect(Object.keys(servers)).toEqual(["figma"]);
+  });
+
+  it("reports missing servers", () => {
+    const { missing } = filterMcpServers(global, ["figma", "unknown"]);
+    expect(missing).toEqual(["unknown"]);
+  });
+
+  it("reports dropped servers", () => {
+    const { dropped } = filterMcpServers(global, ["figma"]);
+    expect(dropped).toContain("linear");
+    expect(dropped).toContain("slack");
+  });
+
+  it("empty allow returns empty servers", () => {
+    const { servers, dropped } = filterMcpServers(global, []);
+    expect(Object.keys(servers)).toHaveLength(0);
+    expect(dropped).toHaveLength(3);
+  });
+});
+
+describe("AGENT_MCP_FILENAME", () => {
+  it("is agent-mcp.json", () => {
+    expect(AGENT_MCP_FILENAME).toBe("agent-mcp.json");
+  });
+});

--- a/src/agent-mcp.ts
+++ b/src/agent-mcp.ts
@@ -1,0 +1,75 @@
+/**
+ * Per-agent MCP server scoping.
+ *
+ * MCP server tool definitions are injected into every turn's input tokens. The
+ * platform activates all credentialed servers globally (mcp-bootstrap), so an
+ * agent that never touches Figma still pays for Figma's tool schema on every
+ * message. This lets a spawn declare an allowlist (`mcpServers`) of the servers
+ * it actually needs; the CLI is then run with `--mcp-config <file>
+ * --strict-mcp-config` so only those load.
+ *
+ * Opt-in: with no allowlist, nothing here runs and the agent keeps the global
+ * server set (unchanged behaviour).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { CLAUDE_HOME } from "./utils/config-paths";
+
+/** Filename for the per-agent MCP config, written into the workspace .claude dir. */
+export const AGENT_MCP_FILENAME = "agent-mcp.json";
+
+type McpServerMap = Record<string, unknown>;
+
+/**
+ * Filter a global mcpServers map down to an allowlist of server names.
+ * Returns the kept subset plus the names that were requested but not found
+ * (typos / unconfigured servers) and the names dropped from the global set.
+ */
+export function filterMcpServers(
+  global: McpServerMap,
+  allow: string[],
+): { servers: McpServerMap; missing: string[]; dropped: string[] } {
+  const allowSet = new Set(allow);
+  const servers: McpServerMap = {};
+  for (const name of allow) {
+    if (Object.hasOwn(global, name)) servers[name] = global[name];
+  }
+  const missing = allow.filter((n) => !Object.hasOwn(global, n));
+  const dropped = Object.keys(global).filter((n) => !allowSet.has(n));
+  return { servers, missing, dropped };
+}
+
+/** Read the global activated mcpServers map from the resolved settings.json. */
+export function readGlobalMcpServers(settingsPath: string = path.join(CLAUDE_HOME, "settings.json")): McpServerMap {
+  try {
+    if (!fs.existsSync(settingsPath)) return {};
+    const parsed = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as { mcpServers?: McpServerMap };
+    return parsed.mcpServers ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/** The deterministic path of an agent's scoped MCP config within its workspace. */
+export function agentMcpConfigPath(workspaceDir: string): string {
+  return path.join(workspaceDir, ".claude", AGENT_MCP_FILENAME);
+}
+
+/**
+ * Build and write a workspace-scoped MCP config containing only the allowlisted
+ * servers. Returns the file path to pass to `--mcp-config`, or null if the
+ * allowlist is empty/undefined (caller should not add the strict flags).
+ */
+export function prepareAgentMcpConfig(
+  workspaceDir: string,
+  allow: string[] | undefined,
+  global: McpServerMap = readGlobalMcpServers(),
+): { configPath: string; servers: McpServerMap; missing: string[]; dropped: string[] } | null {
+  if (!allow || allow.length === 0) return null;
+  const { servers, missing, dropped } = filterMcpServers(global, allow);
+  const configPath = agentMcpConfigPath(workspaceDir);
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  fs.writeFileSync(configPath, JSON.stringify({ mcpServers: servers }, null, 2));
+  return { configPath, servers, missing, dropped };
+}


### PR DESCRIPTION
## Summary

Adds `src/agent-mcp.ts` — per-agent MCP server scoping to reduce input-token cost from loading unused server schemas.

- `filterMcpServers()`: filters global mcpServers map to an allowlist
- `prepareAgentMcpConfig()`: writes a workspace-scoped `agent-mcp.json` for `--mcp-config --strict-mcp-config`
- `readGlobalMcpServers()`: reads activated servers from `settings.json`
- No server.ts changes — consumed by agents.ts spawn path in Phase E PR 31

Zero fanbot/fanvue refs. ~76 lines source + ~30 lines test.

## Test plan
- [x] `npm test` passes
- [x] `npx biome check .` clean