### PR TITLE
feat: add hook routes + server mount (PR 11)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -20,6 +20,8 @@ import { createConfigRouter } from "./src/routes/config";
 import { createContextRouter } from "./src/routes/context";
 import { createCostRouter } from "./src/routes/cost";
 import { createHealthRouter } from "./src/routes/health";
+import hookConfigRouter from "./src/routes/hook-config";
+import { createHooksRouter } from "./src/routes/hooks";
 import { createKillSwitchRouter } from "./src/routes/kill-switch";
 import { createMcpRouter } from "./src/routes/mcp";
 import { createMessagesRouter } from "./src/routes/messages";
@@ -207,6 +209,8 @@ app.use(createSchedulerRouter(scheduler));
 app.use(createWorkflowsRouter(agentManager, messageBus));
 app.use(createRepositoriesRouter(agentManager));
 app.use(createStartupRouter(agentManager, messageBus));
+app.use("/api/agents", hookConfigRouter);
+app.use(createHooksRouter(agentManager));
 // Layer 1: Kill switch endpoint (no extra auth beyond authMiddleware above)
 app.use(createKillSwitchRouter(agentManager));
 

--- a/src/routes/hook-config.test.ts
+++ b/src/routes/hook-config.test.ts
@@ -3,7 +3,6 @@ import express from "express";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import hookConfigRouter from "./hook-config";
 
-// Mock the store so tests don't hit the real filesystem
 vi.mock("../hook-config-store", () => ({
   getHookConfig: vi.fn().mockReturnValue({ agentId: "test-agent", rules: [], updatedAt: "" }),
   setHookConfig: vi
@@ -13,6 +12,9 @@ vi.mock("../hook-config-store", () => ({
     ),
   deleteHookConfig: vi.fn(),
 }));
+
+const HOOK_URL = "https://example.com/hook";
+const AGENT = "test-agent";
 
 function request(
   method: string,
@@ -72,9 +74,11 @@ afterAll(() => {
   server?.close();
 });
 
+const agentPath = `${AGENT}/hooks`;
+
 describe("GET /api/agents/:id/hooks", () => {
   it("returns empty rules for unknown agent", async () => {
-    const res = await request("GET", `${baseUrl}/api/agents/test-agent/hooks`);
+    const res = await request("GET", `${baseUrl}/api/agents/${agentPath}`);
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("rules");
     expect(Array.isArray(res.body.rules)).toBe(true);
@@ -83,109 +87,70 @@ describe("GET /api/agents/:id/hooks", () => {
 
 describe("PUT /api/agents/:id/hooks — valid rules", () => {
   it("accepts valid http rule", async () => {
-    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
-      rules: [
-        {
-          id: "r1",
-          event: "PreToolUse",
-          type: "http",
-          url: "https://example.com/hook",
-          matcher: "Bash",
-        },
-      ],
+    const res = await request("PUT", `${baseUrl}/api/agents/${agentPath}`, {
+      rules: [{ id: "r1", event: "PreToolUse", type: "http", url: HOOK_URL, matcher: "Bash" }],
     });
     expect(res.status).toBe(200);
     expect(Array.isArray((res.body as { rules: unknown[] }).rules)).toBe(true);
   });
 
   it("accepts valid command rule", async () => {
-    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
-      rules: [
-        {
-          id: "r2",
-          event: "PostToolUse",
-          type: "command",
-          command: "echo hello",
-        },
-      ],
+    const res = await request("PUT", `${baseUrl}/api/agents/${agentPath}`, {
+      rules: [{ id: "r2", event: "PostToolUse", type: "command", command: "echo hello" }],
     });
     expect(res.status).toBe(200);
     expect(Array.isArray((res.body as { rules: unknown[] }).rules)).toBe(true);
   });
 
   it("accepts empty rules array", async () => {
-    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, { rules: [] });
+    const res = await request("PUT", `${baseUrl}/api/agents/${agentPath}`, { rules: [] });
     expect(res.status).toBe(200);
   });
 });
 
 describe("PUT /api/agents/:id/hooks — invalid rules (400 responses)", () => {
   it("rejects invalid event name", async () => {
-    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
-      rules: [{ id: "r1", event: "BogusEvent", type: "http", url: "https://example.com" }],
+    const res = await request("PUT", `${baseUrl}/api/agents/${agentPath}`, {
+      rules: [{ id: "r1", event: "BogusEvent", type: "http", url: HOOK_URL }],
     });
     expect(res.status).toBe(400);
     expect((res.body as { error: string }).error).toMatch(/invalid event/);
   });
 
   it("rejects invalid type", async () => {
-    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
-      rules: [{ id: "r1", event: "PreToolUse", type: "webhook", url: "https://example.com" }],
+    const res = await request("PUT", `${baseUrl}/api/agents/${agentPath}`, {
+      rules: [{ id: "r1", event: "PreToolUse", type: "webhook", url: HOOK_URL }],
     });
     expect(res.status).toBe(400);
     expect((res.body as { error: string }).error).toMatch(/invalid type/);
   });
 
   it("rejects http rule with command field set", async () => {
-    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
-      rules: [
-        {
-          id: "r1",
-          event: "PreToolUse",
-          type: "http",
-          url: "https://example.com",
-          command: "echo hi",
-        },
-      ],
+    const res = await request("PUT", `${baseUrl}/api/agents/${agentPath}`, {
+      rules: [{ id: "r1", event: "PreToolUse", type: "http", url: HOOK_URL, command: "echo hi" }],
     });
     expect(res.status).toBe(400);
     expect((res.body as { error: string }).error).toMatch(/command must not be set/);
   });
 
   it("rejects command rule with url field set", async () => {
-    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
-      rules: [
-        {
-          id: "r1",
-          event: "PreToolUse",
-          type: "command",
-          command: "echo hi",
-          url: "https://example.com",
-        },
-      ],
+    const res = await request("PUT", `${baseUrl}/api/agents/${agentPath}`, {
+      rules: [{ id: "r1", event: "PreToolUse", type: "command", command: "echo hi", url: HOOK_URL }],
     });
     expect(res.status).toBe(400);
     expect((res.body as { error: string }).error).toMatch(/url must not be set/);
   });
 
   it("rejects timeout greater than 60000ms", async () => {
-    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
-      rules: [
-        {
-          id: "r1",
-          event: "PreToolUse",
-          type: "http",
-          url: "https://example.com",
-          timeout: 99999,
-        },
-      ],
+    const res = await request("PUT", `${baseUrl}/api/agents/${agentPath}`, {
+      rules: [{ id: "r1", event: "PreToolUse", type: "http", url: HOOK_URL, timeout: 99999 }],
     });
     expect(res.status).toBe(400);
     expect((res.body as { error: string }).error).toMatch(/timeout must be/);
   });
 
   it("rejects dangerous command (rm -rf /)", async () => {
-    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
+    const res = await request("PUT", `${baseUrl}/api/agents/${agentPath}`, {
       rules: [{ id: "r1", event: "PreToolUse", type: "command", command: "rm -rf /" }],
     });
     expect(res.status).toBe(400);
@@ -199,22 +164,14 @@ describe("PUT /api/agents/:id/hooks — invalid rules (400 responses)", () => {
       type: "command",
       command: "echo hi",
     }));
-    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, { rules });
+    const res = await request("PUT", `${baseUrl}/api/agents/${agentPath}`, { rules });
     expect(res.status).toBe(400);
     expect((res.body as { error: string }).error).toMatch(/max 20 rules/);
   });
 
   it("rejects invalid matcher regex", async () => {
-    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
-      rules: [
-        {
-          id: "r1",
-          event: "PreToolUse",
-          type: "http",
-          url: "https://example.com",
-          matcher: "[invalid regex(",
-        },
-      ],
+    const res = await request("PUT", `${baseUrl}/api/agents/${agentPath}`, {
+      rules: [{ id: "r1", event: "PreToolUse", type: "http", url: HOOK_URL, matcher: "[invalid regex(" }],
     });
     expect(res.status).toBe(400);
     expect((res.body as { error: string }).error).toMatch(/not a valid regex/);
@@ -227,15 +184,14 @@ describe("PUT /api/agents/:id/hooks — storage failure returns 500", () => {
     const mock = setHookConfig as ReturnType<typeof vi.fn>;
     mock.mockRejectedValueOnce(new Error("ENOSPC: no space left on device"));
 
-    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
+    const res = await request("PUT", `${baseUrl}/api/agents/${agentPath}`, {
       rules: [{ id: "r1", event: "Stop", type: "command", command: "echo hi" }],
     });
     expect(res.status).toBe(500);
     expect((res.body as { error: string }).error).toBe("Failed to save hook config");
 
-    // restore default
     mock.mockImplementation((_agentId: string, rules: unknown[]) =>
-      Promise.resolve({ agentId: "test-agent", rules, updatedAt: new Date().toISOString() }),
+      Promise.resolve({ agentId: AGENT, rules, updatedAt: new Date().toISOString() }),
     );
   });
 });

--- a/src/routes/hook-config.test.ts
+++ b/src/routes/hook-config.test.ts
@@ -1,0 +1,241 @@
+import http from "node:http";
+import express from "express";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import hookConfigRouter from "./hook-config";
+
+// Mock the store so tests don't hit the real filesystem
+vi.mock("../hook-config-store", () => ({
+  getHookConfig: vi.fn().mockReturnValue({ agentId: "test-agent", rules: [], updatedAt: "" }),
+  setHookConfig: vi
+    .fn()
+    .mockImplementation((_agentId: string, rules: unknown[]) =>
+      Promise.resolve({ agentId: "test-agent", rules, updatedAt: new Date().toISOString() }),
+    ),
+  deleteHookConfig: vi.fn(),
+}));
+
+function request(
+  method: string,
+  url: string,
+  body?: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const payload = body ? JSON.stringify(body) : undefined;
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname + parsed.search,
+        method,
+        headers: {
+          "content-type": "application/json",
+          ...(payload ? { "content-length": String(Buffer.byteLength(payload)) } : {}),
+        },
+      },
+      (res) => {
+        let raw = "";
+        res.on("data", (chunk: string) => (raw += chunk));
+        res.on("end", () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: JSON.parse(raw) });
+          } catch {
+            resolve({ status: res.statusCode ?? 0, body: { raw } });
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(
+  () =>
+    new Promise<void>((resolve) => {
+      const app = express();
+      app.use(express.json());
+      app.use("/api/agents", hookConfigRouter);
+      server = app.listen(0, "127.0.0.1", () => {
+        const addr = server.address() as { port: number };
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    }),
+);
+
+afterAll(() => {
+  server?.close();
+});
+
+describe("GET /api/agents/:id/hooks", () => {
+  it("returns empty rules for unknown agent", async () => {
+    const res = await request("GET", `${baseUrl}/api/agents/test-agent/hooks`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("rules");
+    expect(Array.isArray(res.body.rules)).toBe(true);
+  });
+});
+
+describe("PUT /api/agents/:id/hooks — valid rules", () => {
+  it("accepts valid http rule", async () => {
+    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
+      rules: [
+        {
+          id: "r1",
+          event: "PreToolUse",
+          type: "http",
+          url: "https://example.com/hook",
+          matcher: "Bash",
+        },
+      ],
+    });
+    expect(res.status).toBe(200);
+    expect(Array.isArray((res.body as { rules: unknown[] }).rules)).toBe(true);
+  });
+
+  it("accepts valid command rule", async () => {
+    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
+      rules: [
+        {
+          id: "r2",
+          event: "PostToolUse",
+          type: "command",
+          command: "echo hello",
+        },
+      ],
+    });
+    expect(res.status).toBe(200);
+    expect(Array.isArray((res.body as { rules: unknown[] }).rules)).toBe(true);
+  });
+
+  it("accepts empty rules array", async () => {
+    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, { rules: [] });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("PUT /api/agents/:id/hooks — invalid rules (400 responses)", () => {
+  it("rejects invalid event name", async () => {
+    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
+      rules: [{ id: "r1", event: "BogusEvent", type: "http", url: "https://example.com" }],
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/invalid event/);
+  });
+
+  it("rejects invalid type", async () => {
+    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
+      rules: [{ id: "r1", event: "PreToolUse", type: "webhook", url: "https://example.com" }],
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/invalid type/);
+  });
+
+  it("rejects http rule with command field set", async () => {
+    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
+      rules: [
+        {
+          id: "r1",
+          event: "PreToolUse",
+          type: "http",
+          url: "https://example.com",
+          command: "echo hi",
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/command must not be set/);
+  });
+
+  it("rejects command rule with url field set", async () => {
+    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
+      rules: [
+        {
+          id: "r1",
+          event: "PreToolUse",
+          type: "command",
+          command: "echo hi",
+          url: "https://example.com",
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/url must not be set/);
+  });
+
+  it("rejects timeout greater than 60000ms", async () => {
+    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
+      rules: [
+        {
+          id: "r1",
+          event: "PreToolUse",
+          type: "http",
+          url: "https://example.com",
+          timeout: 99999,
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/timeout must be/);
+  });
+
+  it("rejects dangerous command (rm -rf /)", async () => {
+    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
+      rules: [{ id: "r1", event: "PreToolUse", type: "command", command: "rm -rf /" }],
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/command rejected/);
+  });
+
+  it("rejects more than 20 rules", async () => {
+    const rules = Array.from({ length: 21 }, (_, i) => ({
+      id: `r${i}`,
+      event: "Stop",
+      type: "command",
+      command: "echo hi",
+    }));
+    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, { rules });
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/max 20 rules/);
+  });
+
+  it("rejects invalid matcher regex", async () => {
+    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
+      rules: [
+        {
+          id: "r1",
+          event: "PreToolUse",
+          type: "http",
+          url: "https://example.com",
+          matcher: "[invalid regex(",
+        },
+      ],
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toMatch(/not a valid regex/);
+  });
+});
+
+describe("PUT /api/agents/:id/hooks — storage failure returns 500", () => {
+  it("returns 500 when setHookConfig rejects", async () => {
+    const { setHookConfig } = await import("../hook-config-store");
+    const mock = setHookConfig as ReturnType<typeof vi.fn>;
+    mock.mockRejectedValueOnce(new Error("ENOSPC: no space left on device"));
+
+    const res = await request("PUT", `${baseUrl}/api/agents/test-agent/hooks`, {
+      rules: [{ id: "r1", event: "Stop", type: "command", command: "echo hi" }],
+    });
+    expect(res.status).toBe(500);
+    expect((res.body as { error: string }).error).toBe("Failed to save hook config");
+
+    // restore default
+    mock.mockImplementation((_agentId: string, rules: unknown[]) =>
+      Promise.resolve({ agentId: "test-agent", rules, updatedAt: new Date().toISOString() }),
+    );
+  });
+});

--- a/src/routes/hook-config.ts
+++ b/src/routes/hook-config.ts
@@ -1,0 +1,89 @@
+// Operator-only trusted configuration. These routes accept arbitrary hook rules
+// including type:'command' entries that get injected into agent settings.json and
+// executed by the CLI. Input is validated strictly; command strings are checked
+// against DANGEROUS_BASH_PATTERNS. This endpoint must remain behind auth middleware.
+import express from "express";
+import { getHookConfig, type HookEvent, type HookRule, type HookType, setHookConfig } from "../hook-config-store";
+import { logger } from "../logger";
+import { param } from "../utils/express";
+import { checkDangerousCommand } from "./hooks"; // exported in step 4a
+
+const VALID_EVENTS = new Set<HookEvent>(["PreToolUse", "PostToolUse", "Stop", "SubagentStart", "SubagentStop"]);
+const VALID_TYPES = new Set<HookType>(["http", "command"]);
+const MAX_RULES = 20;
+const MAX_TIMEOUT_MS = 60_000;
+
+function validateRules(rules: unknown[]): HookRule[] {
+  // Throws with a descriptive message if invalid
+  if (!Array.isArray(rules)) throw new Error("rules must be an array");
+  if (rules.length > MAX_RULES) throw new Error(`max ${MAX_RULES} rules per agent`);
+  return rules.map((r, i) => {
+    if (typeof r !== "object" || r === null) throw new Error(`rule[${i}]: must be an object`);
+    const rule = r as Record<string, unknown>;
+    if (!VALID_EVENTS.has(rule.event as HookEvent)) throw new Error(`rule[${i}]: invalid event "${rule.event}"`);
+    if (!VALID_TYPES.has(rule.type as HookType)) throw new Error(`rule[${i}]: invalid type "${rule.type}"`);
+    if (rule.type === "http") {
+      if (typeof rule.url !== "string" || !rule.url) throw new Error(`rule[${i}]: url required for type http`);
+      if (rule.command !== undefined) throw new Error(`rule[${i}]: command must not be set when type is http`);
+    } else {
+      if (typeof rule.command !== "string" || !rule.command)
+        throw new Error(`rule[${i}]: command required for type command`);
+      if (rule.url !== undefined) throw new Error(`rule[${i}]: url must not be set when type is command`);
+      const danger = checkDangerousCommand(rule.command);
+      if (danger) throw new Error(`rule[${i}]: command rejected — ${danger}`);
+    }
+    if (rule.timeout !== undefined) {
+      if (typeof rule.timeout !== "number" || rule.timeout < 1 || rule.timeout > MAX_TIMEOUT_MS)
+        throw new Error(`rule[${i}]: timeout must be 1–${MAX_TIMEOUT_MS}ms`);
+    }
+    if (rule.matcher !== undefined && typeof rule.matcher !== "string")
+      throw new Error(`rule[${i}]: matcher must be a string`);
+    // Validate matcher as a valid regex
+    if (typeof rule.matcher === "string") {
+      try {
+        new RegExp(rule.matcher);
+      } catch {
+        throw new Error(`rule[${i}]: matcher is not a valid regex`);
+      }
+    }
+    return {
+      id: typeof rule.id === "string" && rule.id ? rule.id : crypto.randomUUID(),
+      event: rule.event as HookEvent,
+      type: rule.type as HookType,
+      ...(rule.matcher !== undefined && { matcher: rule.matcher as string }),
+      ...(rule.url !== undefined && { url: rule.url as string }),
+      ...(rule.command !== undefined && { command: rule.command as string }),
+      ...(rule.timeout !== undefined && { timeout: rule.timeout as number }),
+      ...(rule.async !== undefined && { async: Boolean(rule.async) }),
+    };
+  });
+}
+
+const router = express.Router();
+
+router.get("/:id/hooks", (req, res) => {
+  const agentId = param(req.params.id);
+  const config = getHookConfig(agentId);
+  res.json({ rules: config.rules });
+});
+
+router.put("/:id/hooks", (req, res) => {
+  const agentId = param(req.params.id);
+  try {
+    const rules = validateRules(req.body?.rules ?? []);
+    setHookConfig(agentId, rules)
+      .then((saved) => {
+        logger.info(`[hook-config] Updated ${rules.length} rules for agent ${agentId}`);
+        res.json({ rules: saved.rules });
+      })
+      .catch((err: unknown) => {
+        logger.warn("[hook-config] Failed to persist hook rules", { agentId, error: err });
+        res.status(500).json({ error: "Failed to save hook config" });
+      });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.status(400).json({ error: msg });
+  }
+});
+
+export default router;

--- a/src/routes/hooks.ts
+++ b/src/routes/hooks.ts
@@ -1,0 +1,237 @@
+import express, { type Request, type Response } from "express";
+import type { AgentManager } from "../agents";
+import { logger } from "../logger";
+import { param } from "../utils/express";
+
+export const DANGEROUS_BASH_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
+  { pattern: /rm\s+-[a-z]*r[a-z]*f\s+\/\s*$/, reason: "rm -rf / is not allowed" },
+  { pattern: /rm\s+-[a-z]*f[a-z]*r\s+\/\s*$/, reason: "rm -rf / is not allowed" },
+  { pattern: /git\s+push\s+.*--force\b.*\bmain\b/, reason: "force push to main is not allowed" },
+  { pattern: /git\s+push\s+.*-f\b.*\bmain\b/, reason: "force push to main is not allowed" },
+  { pattern: /:\s*\(\)\s*\{.*\|.*:.*&.*\}/, reason: "fork bomb pattern is not allowed" },
+  { pattern: /\bmkfs\b/, reason: "filesystem format commands are not allowed" },
+  { pattern: /\bdd\b.*\bof=\/dev\//, reason: "writing to block device is not allowed" },
+];
+
+export function checkDangerousCommand(command: string): string | null {
+  for (const { pattern, reason } of DANGEROUS_BASH_PATTERNS) {
+    if (pattern.test(command)) {
+      return reason;
+    }
+  }
+  return null;
+}
+
+// ── Tool timeline in-memory store ─────────────────────────────────────────────
+
+export interface ToolTimelineEntry {
+  tool: string;
+  inputPreview: string;
+  timestamp: string;
+  durationMs?: number;
+  outcome: "allowed" | "blocked";
+}
+
+const MAX_TIMELINE_ENTRIES = 100;
+
+// Map from agentId -> list of timeline entries (most recent last)
+const toolTimelines = new Map<string, ToolTimelineEntry[]>();
+// Track pending PreToolUse entries awaiting PostToolUse to compute duration
+const pendingToolStarts = new Map<
+  string,
+  { tool: string; inputPreview: string; startMs: number; outcome: "allowed" | "blocked" }
+>();
+
+function getTimeline(agentId: string): ToolTimelineEntry[] {
+  let entries = toolTimelines.get(agentId);
+  if (!entries) {
+    entries = [];
+    toolTimelines.set(agentId, entries);
+  }
+  return entries;
+}
+
+function appendTimelineEntry(agentId: string, entry: ToolTimelineEntry): void {
+  const entries = getTimeline(agentId);
+  entries.push(entry);
+  if (entries.length > MAX_TIMELINE_ENTRIES) {
+    entries.splice(0, entries.length - MAX_TIMELINE_ENTRIES);
+  }
+}
+
+function buildInputPreview(tool_name: string, tool_input: Record<string, unknown> | undefined): string {
+  if (!tool_input) return "";
+  const raw = (() => {
+    switch (tool_name) {
+      case "Bash":
+        return String(tool_input.command || "");
+      case "Read":
+      case "Write":
+      case "Edit":
+        return String(tool_input.file_path || "");
+      case "Glob":
+      case "Grep":
+        return String(tool_input.pattern || "");
+      case "WebFetch":
+        return String(tool_input.url || "");
+      case "WebSearch":
+        return String(tool_input.query || "");
+      default: {
+        const keys = Object.keys(tool_input);
+        if (keys.length === 0) return "";
+        const first = tool_input[keys[0]];
+        return typeof first === "string" ? first : JSON.stringify(first);
+      }
+    }
+  })();
+  return raw.slice(0, 200);
+}
+
+export function createHooksRouter(agentManager: AgentManager) {
+  const router = express.Router();
+
+  // POST /api/hooks/:agentId/pre-tool-use
+  // Synchronous hook: validates Bash commands against a dangerous-command blocklist.
+  router.post("/api/hooks/:agentId/pre-tool-use", (req: Request, res: Response) => {
+    const agentId = param(req.params.agentId);
+    if (!agentManager.get(agentId)) {
+      res.status(404).json({ error: `Agent ${agentId} not found` });
+      return;
+    }
+
+    const { tool_name, tool_input, session_id } = req.body ?? {};
+    logger.info("[hooks] PreToolUse", { agentId: agentId.slice(0, 8), toolName: tool_name, sessionId: session_id });
+
+    let outcome: "allowed" | "blocked" = "allowed";
+    let blockReason: string | null = null;
+
+    if (tool_name === "Bash" && typeof tool_input?.command === "string") {
+      blockReason = checkDangerousCommand(tool_input.command);
+      if (blockReason) {
+        outcome = "blocked";
+        logger.warn("[hooks] PreToolUse blocked", {
+          agentId: agentId.slice(0, 8),
+          command: tool_input.command,
+          reason: blockReason,
+        });
+      }
+    }
+
+    // Record start of tool use for timeline (duration computed on PostToolUse)
+    const pendingKey = `${agentId}:${tool_name}`;
+    pendingToolStarts.set(pendingKey, {
+      tool: String(tool_name || "unknown"),
+      inputPreview: buildInputPreview(String(tool_name || ""), tool_input as Record<string, unknown> | undefined),
+      startMs: Date.now(),
+      outcome,
+    });
+
+    if (outcome === "blocked" && blockReason) {
+      // Also record blocked entry immediately (no PostToolUse will fire for blocked tools)
+      appendTimelineEntry(agentId, {
+        tool: String(tool_name || "unknown"),
+        inputPreview: buildInputPreview(String(tool_name || ""), tool_input as Record<string, unknown> | undefined),
+        timestamp: new Date().toISOString(),
+        outcome: "blocked",
+      });
+      pendingToolStarts.delete(pendingKey);
+
+      res.json({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: blockReason,
+        },
+      });
+      return;
+    }
+
+    res.json({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+      },
+    });
+  });
+
+  // POST /api/hooks/:agentId/post-tool-use
+  // Async observational hook: logs tool usage metrics and records timeline entry.
+  router.post("/api/hooks/:agentId/post-tool-use", (req: Request, res: Response) => {
+    const agentId = param(req.params.agentId);
+    if (!agentManager.get(agentId)) {
+      res.status(404).json({ error: `Agent ${agentId} not found` });
+      return;
+    }
+    const { tool_name, session_id } = req.body ?? {};
+    logger.info("[hooks] PostToolUse", { agentId: agentId.slice(0, 8), toolName: tool_name, sessionId: session_id });
+
+    // Finalise timeline entry with duration
+    const pendingKey = `${agentId}:${tool_name}`;
+    const pending = pendingToolStarts.get(pendingKey);
+    if (pending) {
+      pendingToolStarts.delete(pendingKey);
+      appendTimelineEntry(agentId, {
+        tool: pending.tool,
+        inputPreview: pending.inputPreview,
+        timestamp: new Date(pending.startMs).toISOString(),
+        durationMs: Date.now() - pending.startMs,
+        outcome: pending.outcome,
+      });
+    }
+
+    res.json({});
+  });
+
+  // GET /api/hooks/:agentId/timeline
+  // Returns the tool execution timeline for an agent (last 100 entries).
+  router.get("/api/hooks/:agentId/timeline", (req: Request, res: Response) => {
+    const agentId = param(req.params.agentId);
+    if (!agentManager.get(agentId)) {
+      res.status(404).json({ error: `Agent ${agentId} not found` });
+      return;
+    }
+    const entries = getTimeline(agentId);
+    res.json({ timeline: entries });
+  });
+
+  // POST /api/hooks/:agentId/stop
+  // Async observational hook: turn completion notification.
+  router.post("/api/hooks/:agentId/stop", (req: Request, res: Response) => {
+    const agentId = param(req.params.agentId);
+    if (!agentManager.get(agentId)) {
+      res.status(404).json({ error: `Agent ${agentId} not found` });
+      return;
+    }
+    const { session_id } = req.body ?? {};
+    logger.info("[hooks] Stop", { agentId: agentId.slice(0, 8), sessionId: session_id });
+    res.json({});
+  });
+
+  // POST /api/hooks/:agentId/subagent-start
+  // Async observational hook: sub-agent spawn tracking.
+  router.post("/api/hooks/:agentId/subagent-start", (req: Request, res: Response) => {
+    const agentId = param(req.params.agentId);
+    if (!agentManager.get(agentId)) {
+      res.status(404).json({ error: `Agent ${agentId} not found` });
+      return;
+    }
+    const { session_id } = req.body ?? {};
+    logger.info("[hooks] SubagentStart", { agentId: agentId.slice(0, 8), sessionId: session_id });
+    res.json({});
+  });
+
+  // POST /api/hooks/:agentId/subagent-stop
+  // Async observational hook: sub-agent completion tracking.
+  router.post("/api/hooks/:agentId/subagent-stop", (req: Request, res: Response) => {
+    const agentId = param(req.params.agentId);
+    if (!agentManager.get(agentId)) {
+      res.status(404).json({ error: `Agent ${agentId} not found` });
+      return;
+    }
+    const { session_id } = req.body ?? {};
+    logger.info("[hooks] SubagentStop", { agentId: agentId.slice(0, 8), sessionId: session_id });
+    res.json({});
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

Adds hook HTTP surface and mounts it in `server.ts`:

- `src/routes/hook-config.ts`: GET/PUT `/:id/hooks` — operator CRUD for per-agent `HookRule[]`. Validates against `DANGEROUS_BASH_PATTERNS` for command-type rules.
- `src/routes/hooks.ts`: POST `/api/hooks/:agentId/pre-tool-use`, `post-tool-use`, `stop`, `subagent-start`, `subagent-stop`. GET `/api/hooks/:agentId/timeline`. In-memory tool timeline (last 100 entries per agent).
- `server.ts`: mounts `hookConfigRouter` under `/api/agents` and `createHooksRouter(agentManager)`.
- dep: hook-config-store (included in worktree for compilation; store PR #145 lands first).

Zero fanbot/fanvue refs. ~270 lines across 2 new route files + 2 server.ts lines.

## Test plan
- [x] `npm test` passes (414 tests)
- [x] `npx biome check .` clean