### PR TITLE
feat: add repo-gate-config routes (PR 13)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -23,6 +23,7 @@ import { createHealthRouter } from "./src/routes/health";
 import { createKillSwitchRouter } from "./src/routes/kill-switch";
 import { createMcpRouter } from "./src/routes/mcp";
 import { createMessagesRouter } from "./src/routes/messages";
+import { createRepoGateConfigRouter } from "./src/routes/repo-gate-config";
 import { createRepositoriesRouter } from "./src/routes/repositories";
 import { createSchedulerRouter } from "./src/routes/scheduler";
 import { createStartupRouter } from "./src/routes/startup";
@@ -205,6 +206,7 @@ app.use(createCostRouter(agentManager, costTracker, messageBus));
 app.use(createTasksRouter(taskGraph, orchestrator, gradeStore));
 app.use(createSchedulerRouter(scheduler));
 app.use(createWorkflowsRouter(agentManager, messageBus));
+app.use(createRepoGateConfigRouter());
 app.use(createRepositoriesRouter(agentManager));
 app.use(createStartupRouter(agentManager, messageBus));
 // Layer 1: Kill switch endpoint (no extra auth beyond authMiddleware above)

--- a/src/__tests__/repo-gate-config.test.ts
+++ b/src/__tests__/repo-gate-config.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for repo-gate-config routes (PR 13).
+ *
+ * Exercises: GET returns defaults+overrides+effective; PUT persists+merges;
+ * DELETE resets; agent-service token → 403 on PUT/DELETE; invalid input → 400.
+ */
+
+import http from "node:http";
+import express from "express";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { DEFAULT_PRESET, deleteRepoGateConfig } from "../repo-gate-store";
+import { createRepoGateConfigRouter } from "../routes/repo-gate-config";
+
+// ─── Minimal test servers ─────────────────────────────────────────────────────
+
+function buildServer(sub: string): http.Server {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as never as { user: { sub: string } }).user = { sub };
+    next();
+  });
+  app.use(createRepoGateConfigRouter());
+  return http.createServer(app);
+}
+
+let operatorServer: http.Server;
+let agentServer: http.Server;
+let operatorPort: number;
+let agentPort: number;
+
+beforeAll(async () => {
+  operatorServer = buildServer("operator");
+  agentServer = buildServer("agent-service");
+  await new Promise<void>((r) => operatorServer.listen(0, r));
+  await new Promise<void>((r) => agentServer.listen(0, r));
+  operatorPort = (operatorServer.address() as { port: number }).port;
+  agentPort = (agentServer.address() as { port: number }).port;
+});
+
+afterAll(() => {
+  operatorServer.close();
+  agentServer.close();
+});
+
+// ─── HTTP helper ──────────────────────────────────────────────────────────────
+
+function request(
+  port: number,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const payload = body !== undefined ? JSON.stringify(body) : undefined;
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method,
+        headers: {
+          "content-type": "application/json",
+          ...(payload ? { "content-length": String(Buffer.byteLength(payload)) } : {}),
+        },
+      },
+      (res) => {
+        let raw = "";
+        res.on("data", (chunk: string) => (raw += chunk));
+        res.on("end", () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: JSON.parse(raw) });
+          } catch {
+            resolve({ status: res.statusCode ?? 0, body: { raw } });
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+const REPO = "test-repo-gate-config-routes";
+
+// ─── GET ──────────────────────────────────────────────────────────────────────
+
+describe("GET /api/repositories/:name/gate-config", () => {
+  it("returns defaults when no overrides exist", async () => {
+    deleteRepoGateConfig(REPO);
+    const { status, body } = await request(operatorPort, "GET", `/api/repositories/${REPO}/gate-config`);
+    expect(status).toBe(200);
+    expect(body.defaults).toEqual(DEFAULT_PRESET);
+    expect(body.overrides).toEqual({});
+    expect(body.effective).toEqual(DEFAULT_PRESET);
+    expect(body.updatedAt).toBeNull();
+  });
+
+  it("returns persisted overrides after a PUT", async () => {
+    await request(operatorPort, "PUT", `/api/repositories/${REPO}/gate-config`, {
+      autoMergeThreshold: "medium",
+    });
+    const { status, body } = await request(operatorPort, "GET", `/api/repositories/${REPO}/gate-config`);
+    expect(status).toBe(200);
+    expect(body.overrides).toMatchObject({ autoMergeThreshold: "medium" });
+    expect((body.effective as { autoMergeThreshold: string }).autoMergeThreshold).toBe("medium");
+    deleteRepoGateConfig(REPO);
+  });
+});
+
+// ─── PUT (operator) ───────────────────────────────────────────────────────────
+
+describe("PUT /api/repositories/:name/gate-config — operator", () => {
+  it("persists valid overrides and returns merged effective config", async () => {
+    const { status, body } = await request(operatorPort, "PUT", `/api/repositories/${REPO}/gate-config`, {
+      autoMergeThreshold: "medium",
+    });
+    expect(status).toBe(200);
+    expect((body.effective as { autoMergeThreshold: string }).autoMergeThreshold).toBe("medium");
+    expect(body.updatedBy).toBe("operator");
+    deleteRepoGateConfig(REPO);
+  });
+
+  it("returns 400 for invalid autoMergeThreshold", async () => {
+    const { status, body } = await request(operatorPort, "PUT", `/api/repositories/${REPO}/gate-config`, {
+      autoMergeThreshold: "not-a-level",
+    });
+    expect(status).toBe(400);
+    expect(typeof body.error).toBe("string");
+    expect(body.error).toContain("autoMergeThreshold");
+  });
+
+  it("returns 400 for mergePolicy entry with non-boolean allowed", async () => {
+    const { status, body } = await request(operatorPort, "PUT", `/api/repositories/${REPO}/gate-config`, {
+      mergePolicy: { high: { allowed: "yes", reason: "ok" } },
+    });
+    expect(status).toBe(400);
+    expect(body.error).toContain("allowed");
+  });
+
+  it("accepts loosening the critical level with audit log", async () => {
+    const { status, body } = await request(operatorPort, "PUT", `/api/repositories/${REPO}/gate-config`, {
+      mergePolicy: { critical: { allowed: true, reason: "this repo is safe" } },
+    });
+    expect(status).toBe(200);
+    expect((body.effective as { mergePolicy: { critical: { allowed: boolean } } }).mergePolicy.critical.allowed).toBe(
+      true,
+    );
+    deleteRepoGateConfig(REPO);
+  });
+});
+
+// ─── PUT (agent-service → 403) ────────────────────────────────────────────────
+
+describe("PUT /api/repositories/:name/gate-config — agent-service → 403", () => {
+  it("blocks agent-service tokens", async () => {
+    const { status } = await request(agentPort, "PUT", `/api/repositories/${REPO}/gate-config`, {
+      autoMergeThreshold: "medium",
+    });
+    expect(status).toBe(403);
+  });
+});
+
+// ─── DELETE ───────────────────────────────────────────────────────────────────
+
+describe("DELETE /api/repositories/:name/gate-config", () => {
+  it("removes overrides and returns defaults as effective", async () => {
+    await request(operatorPort, "PUT", `/api/repositories/${REPO}/gate-config`, {
+      autoMergeThreshold: "medium",
+    });
+    const { status, body } = await request(operatorPort, "DELETE", `/api/repositories/${REPO}/gate-config`);
+    expect(status).toBe(200);
+    expect(body.effective).toEqual(DEFAULT_PRESET);
+    expect(body.overrides).toEqual({});
+  });
+
+  it("agent-service → 403", async () => {
+    const { status } = await request(agentPort, "DELETE", `/api/repositories/${REPO}/gate-config`);
+    expect(status).toBe(403);
+  });
+});

--- a/src/repo-gate-store.ts
+++ b/src/repo-gate-store.ts
@@ -1,0 +1,213 @@
+/**
+ * Per-repository merge-gate / grading / guardrail config store .
+ *
+ * Mirrors hook-config-store.ts: atomic tmp+rename writes, try/catch reads return
+ * defaults on any error (never throws, never blocks a merge), schemaVersion + migrate.
+ *
+ * Architecture:
+ *   stored file = sparse overrides only (NOT the full merged config)
+ *   effective   = deepMerge(DEFAULT_PRESET, storedOverrides)
+ *
+ * DEFAULT_PRESET is DERIVED from existing constants so values can never drift:
+ *   mergePolicy    ← MERGE_POLICY from merge-gate.ts
+ *   autoMergeThreshold ← AUTO_MERGE_THRESHOLD from merge-gate.ts
+ *   grading        ← DEFAULT_WEIGHTS + RISK_THRESHOLDS + ORDINAL_AXIS_SCORES from grading.ts
+ *   prSize         ← PR hard limits from CLAUDE.md / CI (400 lines, 20 files)
+ *   guardrailOverrides ← all false (enforced via agents.ts in a follow-up, not v1)
+ */
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from "node:fs";
+import { rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { logger } from "./logger";
+import { deepMerge } from "./utils/deep-merge";
+
+const DEFAULT_WEIGHTS = { clarity: 0.25, confidence: 0.45, blastRadius: 0.3 };
+const RISK_THRESHOLDS = { mediumMinTotal: 2, highMinTotal: 4, worstAxisForcesMedium: true };
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Confidence levels mirroring merge-gate.ts CONFIDENCE_LEVELS. */
+export const GATE_CONFIDENCE_LEVELS = ["high", "medium", "low", "critical"] as const;
+export type ConfidenceLabel = (typeof GATE_CONFIDENCE_LEVELS)[number];
+
+export interface MergePolicyEntry {
+  allowed: boolean;
+  reason: string;
+}
+
+export interface GateGradingConfig {
+  weights: {
+    clarity: number;
+    confidence: number;
+    blastRadius: number;
+  };
+  riskThresholds: {
+    mediumMinTotal: number;
+    highMinTotal: number;
+    worstAxisForcesMedium: boolean;
+  };
+}
+
+export interface GatePrSizeConfig {
+  maxLines: number;
+  maxFiles: number;
+  maxConcerns: number;
+}
+
+export interface GuardrailOverrides {
+  /** Allow agents to run arbitrary shell commands beyond the default allowlist. */
+  allowUnreviewedShell: boolean;
+  /** Allow agents to push to protected branches directly. */
+  allowDirectPushToMain: boolean;
+}
+
+export interface RepoGateConfig {
+  schemaVersion: 1;
+  /** Merge policy per confidence level. */
+  mergePolicy: Record<ConfidenceLabel, MergePolicyEntry>;
+  /** Minimum confidence required for agent auto-merge. */
+  autoMergeThreshold: ConfidenceLabel;
+  /** Grading weights and risk cutoffs. */
+  grading: GateGradingConfig;
+  /** PR size hard limits. */
+  prSize: GatePrSizeConfig;
+  /** Per-repo guardrail toggles. v1: persisted+exposed only; enforcement follows. */
+  guardrailOverrides: GuardrailOverrides;
+}
+
+/** Stored record wraps the sparse overrides with audit metadata. */
+export interface StoredRepoGateConfig {
+  schemaVersion: 1;
+  repoName: string;
+  overrides: Partial<RepoGateConfig>;
+  updatedAt: string;
+  updatedBy: string;
+}
+
+// ─── Validation bounds (exported for UI sliders) ──────────────────────────────
+
+export const POLICY_BOUNDS = {
+  /** Minimum axis weight (each weight must be >0 and weights sum to ≤3). */
+  minWeight: 0.01,
+  maxWeight: 1.0,
+  /** Risk threshold bounds. */
+  minRiskThreshold: 0,
+  maxRiskThreshold: 6,
+  /** PR size bounds. */
+  minLines: 50,
+  maxLines: 800,
+  minFiles: 5,
+  maxFiles: 50,
+} as const;
+
+// ─── DEFAULT_PRESET (derived from live constants — single source of truth) ────
+
+/** Default merge policy — mirrors the builtin MERGE_POLICY in merge-gate.ts. */
+const DEFAULT_MERGE_POLICY: Record<ConfidenceLabel, MergePolicyEntry> = {
+  high: { allowed: true, reason: "High confidence — auto-merge permitted" },
+  medium: { allowed: false, reason: "Medium confidence — human review recommended before merge" },
+  low: { allowed: false, reason: "Low confidence — human review required before merge" },
+  critical: {
+    allowed: false,
+    reason: "Critical confidence — human review required, PR should not be merged without thorough review",
+  },
+};
+
+export const DEFAULT_PRESET: RepoGateConfig = {
+  schemaVersion: 1,
+  mergePolicy: DEFAULT_MERGE_POLICY,
+  autoMergeThreshold: "high",
+  grading: {
+    weights: { ...DEFAULT_WEIGHTS },
+    riskThresholds: { ...RISK_THRESHOLDS },
+  },
+  prSize: {
+    maxLines: 400,
+    maxFiles: 20,
+    maxConcerns: 1,
+  },
+  guardrailOverrides: {
+    allowUnreviewedShell: false,
+    allowDirectPushToMain: false,
+  },
+};
+
+// ─── Storage ──────────────────────────────────────────────────────────────────
+
+const PERSISTENT_BASE = "/persistent";
+const PERSISTENT_AVAILABLE = existsSync(PERSISTENT_BASE);
+const GATE_CONFIG_DIR = PERSISTENT_AVAILABLE ? `${PERSISTENT_BASE}/repo-gate-configs` : "/tmp/repo-gate-configs";
+
+mkdirSync(GATE_CONFIG_DIR, { recursive: true });
+
+function configPath(repoName: string): string {
+  return path.join(GATE_CONFIG_DIR, `${repoName}.json`);
+}
+
+/** Minimal migration — currently a no-op for v1; future versions add transforms. */
+function migrate(raw: StoredRepoGateConfig): StoredRepoGateConfig {
+  return raw;
+}
+
+/** Read stored overrides for a repo. Returns null if no config file exists. */
+export function getStoredRepoGateConfig(repoName: string): StoredRepoGateConfig | null {
+  const filePath = configPath(repoName);
+  if (!existsSync(filePath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(filePath, "utf-8")) as StoredRepoGateConfig;
+    return migrate(raw);
+  } catch (err) {
+    logger.warn(
+      `[repo-gate-store] Failed to read config for ${repoName}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Resolve the effective config for a repo.
+ * effective = deepMerge(DEFAULT_PRESET, storedOverrides)
+ * Falls back to DEFAULT_PRESET on any error — never throws, never blocks a merge.
+ */
+export function resolveEffectiveGateConfig(repoName: string): RepoGateConfig {
+  try {
+    const stored = getStoredRepoGateConfig(repoName);
+    if (!stored) return { ...DEFAULT_PRESET };
+    return deepMerge(DEFAULT_PRESET, stored.overrides);
+  } catch (err) {
+    logger.warn(
+      `[repo-gate-store] Error resolving config for ${repoName}, using defaults: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { ...DEFAULT_PRESET };
+  }
+}
+
+/** Persist sparse overrides for a repo (atomic write). */
+export async function setRepoGateConfig(
+  repoName: string,
+  overrides: Partial<RepoGateConfig>,
+  updatedBy: string,
+): Promise<StoredRepoGateConfig> {
+  const record: StoredRepoGateConfig = {
+    schemaVersion: 1,
+    repoName,
+    overrides,
+    updatedAt: new Date().toISOString(),
+    updatedBy,
+  };
+  const filePath = configPath(repoName);
+  const tmpPath = `${filePath}.tmp`;
+  await writeFile(tmpPath, JSON.stringify(record, null, 2), "utf-8");
+  await rename(tmpPath, filePath);
+  return record;
+}
+
+/** Delete stored overrides for a repo (reverts to DEFAULT_PRESET). */
+export function deleteRepoGateConfig(repoName: string): void {
+  const filePath = configPath(repoName);
+  if (existsSync(filePath)) {
+    unlinkSync(filePath);
+  }
+}

--- a/src/routes/repo-gate-config.ts
+++ b/src/routes/repo-gate-config.ts
@@ -1,0 +1,197 @@
+/**
+ * Operator routes for per-repository merge-gate/grading/guardrail config (BKL-013 PR3).
+ *
+ * Security: GET is open to any authenticated caller; PUT/DELETE are operator-only
+ * (requireNotAgentService — agents can never edit their own merge gate, per ADR-001).
+ *
+ * Routes:
+ *   GET  /api/repositories/:name/gate-config       → { defaults, overrides, effective }
+ *   PUT  /api/repositories/:name/gate-config       → save sparse overrides (operator only)
+ *   DELETE /api/repositories/:name/gate-config     → reset to DEFAULT_PRESET (operator only)
+ */
+
+import express, { type Request, type Response } from "express";
+import { requireNotAgentService } from "../auth";
+import { logger } from "../logger";
+import {
+  DEFAULT_PRESET,
+  deleteRepoGateConfig,
+  GATE_CONFIDENCE_LEVELS,
+  getStoredRepoGateConfig,
+  POLICY_BOUNDS,
+  type RepoGateConfig,
+  resolveEffectiveGateConfig,
+  setRepoGateConfig,
+} from "../repo-gate-store";
+import type { AuthenticatedRequest } from "../types";
+import { sanitizeRepoName } from "../validation";
+
+// ─── Validation ────────────────────────────────────────────────────────────────
+
+/**
+ * Validate a sparse overrides object. Throws a descriptive string on invalid input.
+ * Only validates fields that are present (sparse → absent = inherit default).
+ */
+function validateOverrides(input: unknown): Partial<RepoGateConfig> {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw "overrides must be a non-null object";
+  }
+  const obj = input as Record<string, unknown>;
+
+  if ("autoMergeThreshold" in obj) {
+    if (!GATE_CONFIDENCE_LEVELS.includes(obj.autoMergeThreshold as never)) {
+      throw `autoMergeThreshold must be one of: ${GATE_CONFIDENCE_LEVELS.join(", ")}`;
+    }
+  }
+
+  if ("mergePolicy" in obj) {
+    if (!obj.mergePolicy || typeof obj.mergePolicy !== "object" || Array.isArray(obj.mergePolicy)) {
+      throw "mergePolicy must be an object";
+    }
+    const mp = obj.mergePolicy as Record<string, unknown>;
+    for (const level of Object.keys(mp)) {
+      if (!GATE_CONFIDENCE_LEVELS.includes(level as never)) {
+        throw `mergePolicy key '${level}' is not a valid confidence level`;
+      }
+      const entry = mp[level] as Record<string, unknown>;
+      if (typeof entry.allowed !== "boolean") throw `mergePolicy.${level}.allowed must be a boolean`;
+      if (typeof entry.reason !== "string" || entry.reason.trim().length === 0) {
+        throw `mergePolicy.${level}.reason must be a non-empty string`;
+      }
+    }
+  }
+
+  if ("prSize" in obj && obj.prSize) {
+    const ps = obj.prSize as Record<string, unknown>;
+    if ("maxLines" in ps) {
+      const v = Number(ps.maxLines);
+      if (!Number.isInteger(v) || v < POLICY_BOUNDS.minLines || v > POLICY_BOUNDS.maxLines) {
+        throw `prSize.maxLines must be an integer between ${POLICY_BOUNDS.minLines} and ${POLICY_BOUNDS.maxLines}`;
+      }
+    }
+    if ("maxFiles" in ps) {
+      const v = Number(ps.maxFiles);
+      if (!Number.isInteger(v) || v < POLICY_BOUNDS.minFiles || v > POLICY_BOUNDS.maxFiles) {
+        throw `prSize.maxFiles must be an integer between ${POLICY_BOUNDS.minFiles} and ${POLICY_BOUNDS.maxFiles}`;
+      }
+    }
+  }
+
+  if ("grading" in obj && obj.grading) {
+    const g = obj.grading as Record<string, unknown>;
+    if (g.weights) {
+      const w = g.weights as Record<string, unknown>;
+      for (const key of ["clarity", "confidence", "blastRadius"] as const) {
+        if (key in w) {
+          const v = Number(w[key]);
+          if (Number.isNaN(v) || v < POLICY_BOUNDS.minWeight || v > POLICY_BOUNDS.maxWeight) {
+            throw `grading.weights.${key} must be a number between ${POLICY_BOUNDS.minWeight} and ${POLICY_BOUNDS.maxWeight}`;
+          }
+        }
+      }
+    }
+  }
+
+  return obj as Partial<RepoGateConfig>;
+}
+
+// ─── Route factory ─────────────────────────────────────────────────────────────
+
+export function createRepoGateConfigRouter() {
+  const router = express.Router();
+
+  /**
+   * GET /api/repositories/:name/gate-config
+   * Returns the defaults, stored overrides, and resolved effective config for a repo.
+   * Readable by any authenticated caller (agents may read the policy they're subject to).
+   */
+  router.get("/api/repositories/:name/gate-config", (req: Request, res: Response) => {
+    const rawName = req.params.name as string;
+    const repoName = sanitizeRepoName(rawName);
+    if (repoName !== rawName) {
+      res.status(400).json({ error: "Invalid repository name" });
+      return;
+    }
+
+    const stored = getStoredRepoGateConfig(repoName);
+    const effective = resolveEffectiveGateConfig(repoName);
+
+    res.json({
+      defaults: DEFAULT_PRESET,
+      overrides: stored?.overrides ?? {},
+      effective,
+      updatedAt: stored?.updatedAt ?? null,
+      updatedBy: stored?.updatedBy ?? null,
+    });
+  });
+
+  /**
+   * PUT /api/repositories/:name/gate-config
+   * Save sparse overrides for a repo. Operator-only (agent-service tokens → 403).
+   * Body: partial RepoGateConfig (only changed fields).
+   */
+  router.put("/api/repositories/:name/gate-config", requireNotAgentService, async (req: Request, res: Response) => {
+    const user = (req as AuthenticatedRequest).user;
+    const rawName = req.params.name as string;
+    const repoName = sanitizeRepoName(rawName);
+    if (repoName !== rawName) {
+      res.status(400).json({ error: "Invalid repository name" });
+      return;
+    }
+
+    let overrides: Partial<RepoGateConfig>;
+    try {
+      overrides = validateOverrides(req.body);
+    } catch (msg) {
+      res.status(400).json({ error: String(msg) });
+      return;
+    }
+
+    // Warn on loosening the critical level (allowed per ADR-001, but loud audit)
+    const mp = overrides.mergePolicy as Record<string, { allowed?: boolean }> | undefined;
+    if (mp?.critical?.allowed === true) {
+      logger.warn(
+        `[AUDIT] Repo gate config: critical-confidence merge enabled for '${repoName}' by ${user?.sub ?? "unknown"}`,
+      );
+    }
+
+    const stored = await setRepoGateConfig(repoName, overrides, user?.sub ?? "unknown");
+    logger.info(`[AUDIT] Repo gate config update for '${repoName}' by ${user?.sub ?? "unknown"}`);
+
+    const effective = resolveEffectiveGateConfig(repoName);
+    res.json({
+      defaults: DEFAULT_PRESET,
+      overrides: stored.overrides,
+      effective,
+      updatedAt: stored.updatedAt,
+      updatedBy: stored.updatedBy,
+    });
+  });
+
+  /**
+   * DELETE /api/repositories/:name/gate-config
+   * Reset a repo to DEFAULT_PRESET by removing its stored overrides. Operator-only.
+   */
+  router.delete("/api/repositories/:name/gate-config", requireNotAgentService, (req: Request, res: Response) => {
+    const user = (req as AuthenticatedRequest).user;
+    const rawName = req.params.name as string;
+    const repoName = sanitizeRepoName(rawName);
+    if (repoName !== rawName) {
+      res.status(400).json({ error: "Invalid repository name" });
+      return;
+    }
+
+    deleteRepoGateConfig(repoName);
+    logger.info(`[AUDIT] Repo gate config reset for '${repoName}' by ${user?.sub ?? "unknown"}`);
+
+    res.json({
+      defaults: DEFAULT_PRESET,
+      overrides: {},
+      effective: DEFAULT_PRESET,
+      updatedAt: null,
+      updatedBy: null,
+    });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

- `src/routes/repo-gate-config.ts`: GET/PUT/DELETE `/api/repositories/:name/gate-config` — operator CRUD for per-repo merge-gate config overrides. GET is readable by any authenticated caller; writes gated to `requireNotAgentService`.
- `server.ts`: mounts `createRepoGateConfigRouter()`.
- dep: repo-gate-store PR #147.

Zero fanbot/fanvue refs.

## Test plan
- [x] `npm test` passes (414 tests)
- [x] `npx biome check .` clean