### PR TITLE
feat: add pull-requests route (PR 14)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -27,6 +27,7 @@ import { createKillSwitchRouter } from "./src/routes/kill-switch";
 import { createMcpRouter } from "./src/routes/mcp";
 import { createMergeGateRouter } from "./src/routes/merge-gate";
 import { createMessagesRouter } from "./src/routes/messages";
+import { createPullRequestsRouter } from "./src/routes/pull-requests";
 import { createRepoGateConfigRouter } from "./src/routes/repo-gate-config";
 import { createRepositoriesRouter } from "./src/routes/repositories";
 import { createSchedulerRouter } from "./src/routes/scheduler";
@@ -217,6 +218,7 @@ app.use(createContextPolicyRouter());
 app.use(createStartupRouter(agentManager, messageBus));
 app.use("/api/agents", hookConfigRouter);
 app.use(createHooksRouter(agentManager));
+app.use(createPullRequestsRouter(agentManager));
 // Layer 1: Kill switch endpoint (no extra auth beyond authMiddleware above)
 app.use(createKillSwitchRouter(agentManager));
 

--- a/src/routes/pull-requests.test.ts
+++ b/src/routes/pull-requests.test.ts
@@ -1,0 +1,529 @@
+/**
+ * Tests for src/routes/pull-requests.ts
+ *
+ * Pattern (matches existing route tests in this repo):
+ *  1. Pure-function unit tests — logic extracted inline, no I/O.
+ *  2. Integration tests — single shared express server, mocks configured via
+ *     module-level imports. All integration calls use ?refresh=true to bypass
+ *     the 30-second cache, except for explicit cache-behaviour tests.
+ *
+ * Key mock notes:
+ *  - node:child_process uses a plain factory ({ execFile: vi.fn() }) so that
+ *    promisify(execFile) uses the standard callback convention rather than
+ *    execFile[util.promisify.custom], which would bypass the mock.
+ *  - node:fs uses a plain factory for the same reason (existsSync etc. have
+ *    no custom promisify, but the factory form ensures correct auto-mock).
+ */
+
+import http from "node:http";
+import express from "express";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// Factory form for node:child_process avoids util.promisify.custom bypass.
+// Factory form for node:fs avoids async-importOriginal incompatibility.
+// ---------------------------------------------------------------------------
+
+vi.mock("node:child_process", () => ({ execFile: vi.fn() }));
+
+// Use importOriginal so the full fs module is present (path.join etc work),
+// but our four intercepted functions are vi.fn() instances shared between
+// the module's default export and named exports.
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const existsSync = vi.fn();
+  const readdirSync = vi.fn();
+  const statSync = vi.fn();
+  const readFileSync = vi.fn();
+  const patched = { ...actual, existsSync, readdirSync, statSync, readFileSync };
+  return { ...patched, default: patched };
+});
+
+vi.mock("../secrets-store", () => ({ getRepoPat: vi.fn().mockReturnValue(undefined) }));
+vi.mock("../logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Static imports (vitest hoists vi.mock calls above these)
+// ---------------------------------------------------------------------------
+
+import * as cpMod from "node:child_process";
+import * as fsMod from "node:fs";
+import * as secretsMod from "../secrets-store";
+import { createPullRequestsRouter } from "./pull-requests";
+
+// ---------------------------------------------------------------------------
+// Pure-function extractions (inline copy from route — no router needed)
+// ---------------------------------------------------------------------------
+
+function deriveChecksStatus(
+  rollup: Array<{ status?: string; conclusion?: string; state?: string }> | null,
+): "pending" | "passing" | "failing" | "none" {
+  if (!rollup || rollup.length === 0) return "none";
+  const statuses = rollup.map((r) => (r.conclusion ?? r.state ?? r.status ?? "").toUpperCase());
+  if (statuses.some((s) => s === "FAILURE" || s === "FAILED" || s === "ERROR")) return "failing";
+  if (statuses.some((s) => s === "PENDING" || s === "IN_PROGRESS" || s === "QUEUED" || s === "EXPECTED"))
+    return "pending";
+  if (statuses.every((s) => ["SUCCESS", "COMPLETED", "SKIPPED", "NEUTRAL", ""].includes(s))) return "passing";
+  return "pending";
+}
+
+function extractRepoSlug(remoteUrl: string): string | null {
+  const httpsMatch = remoteUrl.match(/github\.com[/:]([^/]+\/[^/.]+)(\.git)?$/);
+  if (httpsMatch) return httpsMatch[1];
+  const sshMatch = remoteUrl.match(/github\.com:([^/]+\/[^/.]+)(\.git)?$/);
+  if (sshMatch) return sshMatch[1];
+  return null;
+}
+
+function extractTokenFromUrl(remoteUrl: string): string | null {
+  const match = remoteUrl.match(/https?:\/\/(?:[^:]+:)?([^@]+)@github\.com/);
+  return match?.[1] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Shared test server
+// ---------------------------------------------------------------------------
+
+type AgentStub = { id: string; name: string; gitBranch?: string };
+
+function makeAgentManager(agents: AgentStub[]) {
+  return { list: () => agents } as unknown as import("../agents").AgentManager;
+}
+
+let activeAgentManager = makeAgentManager([]);
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(
+  () =>
+    new Promise<void>((resolve) => {
+      const app = express();
+      app.use(express.json());
+      app.use((req, res, next) => {
+        createPullRequestsRouter(activeAgentManager)(req, res, next);
+      });
+      server = app.listen(0, "127.0.0.1", () => {
+        const addr = server.address() as { port: number };
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    }),
+);
+
+afterAll(() => {
+  server?.close();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  activeAgentManager = makeAgentManager([]);
+});
+
+// HTTP GET helper — always uses ?refresh=true to bypass the 30s cache
+function get(extraQs = ""): Promise<{ status: number; body: Record<string, unknown> }> {
+  const url = `${baseUrl}/api/pull-requests?refresh=true${extraQs}`;
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const req = http.request(
+      { hostname: parsed.hostname, port: parsed.port, path: parsed.pathname + parsed.search, method: "GET" },
+      (res) => {
+        let raw = "";
+        res.on("data", (c: string) => (raw += c));
+        res.on("end", () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: JSON.parse(raw) });
+          } catch {
+            resolve({ status: res.statusCode ?? 0, body: { raw } });
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+// HTTP GET with explicit URL (for cache tests that need to control ?refresh)
+function rawGet(path: string): Promise<{ status: number; body: Record<string, unknown> }> {
+  const url = `${baseUrl}${path}`;
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const req = http.request(
+      { hostname: parsed.hostname, port: parsed.port, path: parsed.pathname + parsed.search, method: "GET" },
+      (res) => {
+        let raw = "";
+        res.on("data", (c: string) => (raw += c));
+        res.on("end", () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: JSON.parse(raw) });
+          } catch {
+            resolve({ status: res.statusCode ?? 0, body: { raw } });
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+// Sample GhPR fixture
+const sampleGhPR = {
+  number: 42,
+  title: "feat: add something",
+  url: "https://github.com/org/repo/pull/42",
+  headRefName: "feature-branch",
+  baseRefName: "main",
+  isDraft: false,
+  state: "OPEN",
+  author: { login: "dev", name: "Dev User" },
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-01-02T00:00:00Z",
+  reviewDecision: null,
+  additions: 10,
+  deletions: 3,
+  statusCheckRollup: [{ conclusion: "SUCCESS" }],
+  labels: [{ name: "bug" }],
+};
+
+// Configure mocks for a single-repo scenario
+function setupMocks(ghPRs: object[] = [sampleGhPR]) {
+  vi.mocked(fsMod.existsSync).mockReturnValue(true);
+  vi.mocked(fsMod.readdirSync).mockReturnValue(["fanbot.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
+  vi.mocked(fsMod.statSync).mockReturnValue({ isDirectory: () => true } as ReturnType<typeof fsMod.statSync>);
+  vi.mocked(fsMod.readFileSync).mockImplementation(() => {
+    throw new Error("no file");
+  });
+  vi.mocked(secretsMod.getRepoPat).mockReturnValue(undefined);
+
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  (vi.mocked(cpMod.execFile) as any).mockImplementation(
+    (_c: unknown, args: unknown, _o: unknown, cb: (e: Error | null, r?: { stdout: string }) => void) => {
+      const a = args as string[];
+      if (a.includes("remote")) {
+        cb(null, { stdout: "https://github.com/org/fanbot.git\n" });
+      } else if (a.includes("pr")) {
+        cb(null, { stdout: JSON.stringify(ghPRs) });
+      } else {
+        cb(new Error("unexpected command"));
+      }
+      return {} as ReturnType<typeof cpMod.execFile>;
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: deriveChecksStatus
+// ---------------------------------------------------------------------------
+
+describe("deriveChecksStatus", () => {
+  it("returns none for null", () => expect(deriveChecksStatus(null)).toBe("none"));
+  it("returns none for []", () => expect(deriveChecksStatus([])).toBe("none"));
+  it("failing on FAILURE conclusion", () =>
+    expect(deriveChecksStatus([{ conclusion: "FAILURE" }, { conclusion: "SUCCESS" }])).toBe("failing"));
+  it("failing on FAILED state", () => expect(deriveChecksStatus([{ state: "FAILED" }])).toBe("failing"));
+  it("failing on ERROR conclusion", () => expect(deriveChecksStatus([{ conclusion: "ERROR" }])).toBe("failing"));
+  it("pending on PENDING status", () =>
+    expect(deriveChecksStatus([{ status: "PENDING" }, { conclusion: "SUCCESS" }])).toBe("pending"));
+  it("pending on IN_PROGRESS state", () => expect(deriveChecksStatus([{ state: "IN_PROGRESS" }])).toBe("pending"));
+  it("passing when all SUCCESS", () =>
+    expect(deriveChecksStatus([{ conclusion: "SUCCESS" }, { conclusion: "SUCCESS" }])).toBe("passing"));
+  it("passing for SUCCESS/SKIPPED/NEUTRAL mix", () =>
+    expect(deriveChecksStatus([{ conclusion: "SUCCESS" }, { conclusion: "SKIPPED" }, { conclusion: "NEUTRAL" }])).toBe(
+      "passing",
+    ));
+  it("passing for COMPLETED", () => expect(deriveChecksStatus([{ conclusion: "COMPLETED" }])).toBe("passing"));
+  it("failing beats pending", () =>
+    expect(deriveChecksStatus([{ conclusion: "FAILURE" }, { status: "PENDING" }])).toBe("failing"));
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: extractRepoSlug
+// ---------------------------------------------------------------------------
+
+describe("extractRepoSlug", () => {
+  it("HTTPS without token", () => expect(extractRepoSlug("https://github.com/org/repo.git")).toBe("org/repo"));
+  it("HTTPS with embedded token", () =>
+    expect(extractRepoSlug("https://x-access-token:ghp_abc@github.com/org/repo.git")).toBe("org/repo"));
+  it("SSH", () => expect(extractRepoSlug("git@github.com:org/repo.git")).toBe("org/repo"));
+  it("HTTPS without .git suffix", () => expect(extractRepoSlug("https://github.com/org/repo")).toBe("org/repo"));
+  it("null for non-GitHub URL", () => expect(extractRepoSlug("https://gitlab.com/org/repo.git")).toBeNull());
+  it("null for empty string", () => expect(extractRepoSlug("")).toBeNull());
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: extractTokenFromUrl
+// ---------------------------------------------------------------------------
+
+describe("extractTokenFromUrl", () => {
+  it("x-access-token style", () =>
+    expect(extractTokenFromUrl("https://x-access-token:ghp_SECRET@github.com/org/repo")).toBe("ghp_SECRET"));
+  it("bare token", () => expect(extractTokenFromUrl("https://ghp_TOKEN@github.com/org/repo")).toBe("ghp_TOKEN"));
+  it("null when no token", () => expect(extractTokenFromUrl("https://github.com/org/repo")).toBeNull());
+});
+
+// ---------------------------------------------------------------------------
+// Integration: empty / no repos
+// ---------------------------------------------------------------------------
+
+describe("GET /api/pull-requests — empty / no repos", () => {
+  it("returns empty array when PERSISTENT_REPOS does not exist", async () => {
+    vi.mocked(fsMod.existsSync).mockReturnValue(false);
+
+    const res = await get();
+    expect(res.status).toBe(200);
+    const body = res.body as { pullRequests: unknown[]; fromCache: boolean };
+    expect(body.pullRequests).toHaveLength(0);
+    expect(body.fromCache).toBe(false);
+  });
+
+  it("returns empty array when git remote fails for all repos", async () => {
+    vi.mocked(fsMod.existsSync).mockReturnValue(true);
+    vi.mocked(fsMod.readdirSync).mockReturnValue(["myrepo.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
+    vi.mocked(fsMod.statSync).mockReturnValue({ isDirectory: () => true } as ReturnType<typeof fsMod.statSync>);
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    (vi.mocked(cpMod.execFile) as any).mockImplementation(
+      (_c: unknown, _a: unknown, _o: unknown, cb: (e: Error | null) => void) => {
+        cb(new Error("not a git repo"));
+        return {} as ReturnType<typeof cpMod.execFile>;
+      },
+    );
+
+    const res = await get();
+    expect(res.status).toBe(200);
+    expect((res.body as { pullRequests: unknown[] }).pullRequests).toHaveLength(0);
+  });
+
+  it("returns empty array when readdirSync throws", async () => {
+    vi.mocked(fsMod.existsSync).mockReturnValue(true);
+    vi.mocked(fsMod.readdirSync).mockImplementation(() => {
+      throw new Error("EPERM");
+    });
+
+    const res = await get();
+    expect(res.status).toBe(200);
+    expect((res.body as { pullRequests: unknown[] }).pullRequests).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: PR shape
+// ---------------------------------------------------------------------------
+
+describe("GET /api/pull-requests — PR response shape", () => {
+  beforeEach(() => setupMocks());
+
+  it("returns a PR with all required fields", async () => {
+    const res = await get();
+    expect(res.status).toBe(200);
+    const prs = (res.body as { pullRequests: Record<string, unknown>[] }).pullRequests;
+    expect(prs).toHaveLength(1);
+    expect(prs[0]).toMatchObject({
+      number: 42,
+      title: "feat: add something",
+      url: "https://github.com/org/repo/pull/42",
+      state: "open",
+      branch: "feature-branch",
+      baseBranch: "main",
+      author: "Dev User",
+      repo: "fanbot",
+      isDraft: false,
+      additions: 10,
+      deletions: 3,
+      checksStatus: "passing",
+      reviewDecision: "",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-02T00:00:00Z",
+      agent: null,
+      labels: ["bug"],
+    });
+  });
+
+  it("state is draft when isDraft=true", async () => {
+    setupMocks([{ ...sampleGhPR, isDraft: true }]);
+    const res = await get();
+    const prs = (res.body as { pullRequests: Record<string, unknown>[] }).pullRequests;
+    expect(prs[0].state).toBe("draft");
+    expect(prs[0].isDraft).toBe(true);
+  });
+
+  it("state is merged when gh state is MERGED", async () => {
+    setupMocks([{ ...sampleGhPR, state: "MERGED", isDraft: false }]);
+    const res = await get();
+    expect((res.body as { pullRequests: Record<string, unknown>[] }).pullRequests[0].state).toBe("merged");
+  });
+
+  it("state is closed when gh state is CLOSED", async () => {
+    setupMocks([{ ...sampleGhPR, state: "CLOSED", isDraft: false }]);
+    const res = await get();
+    expect((res.body as { pullRequests: Record<string, unknown>[] }).pullRequests[0].state).toBe("closed");
+  });
+
+  it("falls back to author login when author name is null", async () => {
+    setupMocks([{ ...sampleGhPR, author: { login: "dev-login", name: null } }]);
+    const res = await get();
+    expect((res.body as { pullRequests: Record<string, unknown>[] }).pullRequests[0].author).toBe("dev-login");
+  });
+
+  it("returns empty labels array when labels is null", async () => {
+    setupMocks([{ ...sampleGhPR, labels: null }]);
+    const res = await get();
+    expect((res.body as { pullRequests: Record<string, unknown>[] }).pullRequests[0].labels).toEqual([]);
+  });
+
+  it("returns 0 additions/deletions when fields are missing", async () => {
+    const pr = { ...sampleGhPR } as Partial<typeof sampleGhPR>;
+    delete pr.additions;
+    delete pr.deletions;
+    setupMocks([pr]);
+    const res = await get();
+    const p = (res.body as { pullRequests: Record<string, unknown>[] }).pullRequests[0];
+    expect(p.additions).toBe(0);
+    expect(p.deletions).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: agent cross-referencing
+// ---------------------------------------------------------------------------
+
+describe("GET /api/pull-requests — agent cross-referencing", () => {
+  beforeEach(() => setupMocks());
+
+  it("attaches agent when gitBranch matches PR headRefName", async () => {
+    activeAgentManager = makeAgentManager([{ id: "agent-1", name: "My Worker", gitBranch: "feature-branch" }]);
+    const res = await get();
+    const prs = (res.body as { pullRequests: Record<string, unknown>[] }).pullRequests;
+    expect(prs[0].agent).toEqual({ id: "agent-1", name: "My Worker" });
+  });
+
+  it("sets agent to null when no branch matches", async () => {
+    activeAgentManager = makeAgentManager([{ id: "agent-2", name: "Other Worker", gitBranch: "different-branch" }]);
+    const res = await get();
+    const prs = (res.body as { pullRequests: Record<string, unknown>[] }).pullRequests;
+    expect(prs[0].agent).toBeNull();
+  });
+
+  it("sets agent to null when agent has no gitBranch property", async () => {
+    activeAgentManager = makeAgentManager([{ id: "agent-3", name: "No Branch Agent" }]);
+    const res = await get();
+    const prs = (res.body as { pullRequests: Record<string, unknown>[] }).pullRequests;
+    expect(prs[0].agent).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: error handling
+// ---------------------------------------------------------------------------
+
+describe("GET /api/pull-requests — error handling", () => {
+  it("returns empty array (not 500) when gh pr list exits with error", async () => {
+    vi.mocked(fsMod.existsSync).mockReturnValue(true);
+    vi.mocked(fsMod.readdirSync).mockReturnValue(["fanbot.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
+    vi.mocked(fsMod.statSync).mockReturnValue({ isDirectory: () => true } as ReturnType<typeof fsMod.statSync>);
+    vi.mocked(fsMod.readFileSync).mockImplementation(() => {
+      throw new Error("no file");
+    });
+    vi.mocked(secretsMod.getRepoPat).mockReturnValue(undefined);
+
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    (vi.mocked(cpMod.execFile) as any).mockImplementation(
+      (_c: unknown, args: unknown, _o: unknown, cb: (e: Error | null, r?: { stdout: string }) => void) => {
+        const a = args as string[];
+        if (a.includes("remote")) {
+          cb(null, { stdout: "https://github.com/org/fanbot.git\n" });
+        } else {
+          cb(new Error("gh: command not found"));
+        }
+        return {} as ReturnType<typeof cpMod.execFile>;
+      },
+    );
+
+    const res = await get();
+    expect(res.status).toBe(200);
+    expect((res.body as { pullRequests: unknown[] }).pullRequests).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: 30-second cache
+// ---------------------------------------------------------------------------
+
+describe("GET /api/pull-requests — 30-second cache", () => {
+  it("returns fromCache:false on first call, fromCache:true on second (no refresh)", async () => {
+    let ghCallCount = 0;
+    vi.mocked(fsMod.existsSync).mockReturnValue(true);
+    vi.mocked(fsMod.readdirSync).mockReturnValue(["fanbot.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
+    vi.mocked(fsMod.statSync).mockReturnValue({ isDirectory: () => true } as ReturnType<typeof fsMod.statSync>);
+    vi.mocked(fsMod.readFileSync).mockImplementation(() => {
+      throw new Error("no file");
+    });
+    vi.mocked(secretsMod.getRepoPat).mockReturnValue(undefined);
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    (vi.mocked(cpMod.execFile) as any).mockImplementation(
+      (_c: unknown, args: unknown, _o: unknown, cb: (e: Error | null, r?: { stdout: string }) => void) => {
+        const a = args as string[];
+        if (a.includes("remote")) {
+          cb(null, { stdout: "https://github.com/org/fanbot.git\n" });
+        } else if (a.includes("pr")) {
+          ghCallCount++;
+          cb(null, { stdout: JSON.stringify([sampleGhPR]) });
+        } else {
+          cb(new Error("unexpected"));
+        }
+        return {} as ReturnType<typeof cpMod.execFile>;
+      },
+    );
+
+    // First: force-refresh to populate fresh cache
+    const res1 = await rawGet("/api/pull-requests?refresh=true");
+    expect(res1.status).toBe(200);
+    expect(res1.body).toHaveProperty("fromCache", false);
+    const ghAfterFirst = ghCallCount;
+
+    // Second: no ?refresh — should hit cache
+    const res2 = await rawGet("/api/pull-requests");
+    expect(res2.status).toBe(200);
+    expect(res2.body).toHaveProperty("fromCache", true);
+    expect((res2.body as { pullRequests: unknown[] }).pullRequests).toHaveLength(1);
+    expect(ghCallCount).toBe(ghAfterFirst);
+  });
+
+  it("bypasses cache when refresh=true is passed", async () => {
+    let ghCallCount = 0;
+    vi.mocked(fsMod.existsSync).mockReturnValue(true);
+    vi.mocked(fsMod.readdirSync).mockReturnValue(["fanbot.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
+    vi.mocked(fsMod.statSync).mockReturnValue({ isDirectory: () => true } as ReturnType<typeof fsMod.statSync>);
+    vi.mocked(fsMod.readFileSync).mockImplementation(() => {
+      throw new Error("no file");
+    });
+    vi.mocked(secretsMod.getRepoPat).mockReturnValue(undefined);
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    (vi.mocked(cpMod.execFile) as any).mockImplementation(
+      (_c: unknown, args: unknown, _o: unknown, cb: (e: Error | null, r?: { stdout: string }) => void) => {
+        const a = args as string[];
+        if (a.includes("remote")) {
+          cb(null, { stdout: "https://github.com/org/fanbot.git\n" });
+        } else if (a.includes("pr")) {
+          ghCallCount++;
+          cb(null, { stdout: JSON.stringify([sampleGhPR]) });
+        } else {
+          cb(new Error("unexpected"));
+        }
+        return {} as ReturnType<typeof cpMod.execFile>;
+      },
+    );
+
+    await rawGet("/api/pull-requests?refresh=true");
+    const afterFirst = ghCallCount;
+
+    const res2 = await rawGet("/api/pull-requests?refresh=true");
+    expect(res2.status).toBe(200);
+    expect(res2.body).toHaveProperty("fromCache", false);
+    expect(ghCallCount).toBeGreaterThan(afterFirst);
+  });
+});

--- a/src/routes/pull-requests.test.ts
+++ b/src/routes/pull-requests.test.ts
@@ -193,7 +193,7 @@ const sampleGhPR = {
 // Configure mocks for a single-repo scenario
 function setupMocks(ghPRs: object[] = [sampleGhPR]) {
   vi.mocked(fsMod.existsSync).mockReturnValue(true);
-  vi.mocked(fsMod.readdirSync).mockReturnValue(["fanbot.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
+  vi.mocked(fsMod.readdirSync).mockReturnValue(["myrepo.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
   vi.mocked(fsMod.statSync).mockReturnValue({ isDirectory: () => true } as ReturnType<typeof fsMod.statSync>);
   vi.mocked(fsMod.readFileSync).mockImplementation(() => {
     throw new Error("no file");
@@ -205,7 +205,7 @@ function setupMocks(ghPRs: object[] = [sampleGhPR]) {
     (_c: unknown, args: unknown, _o: unknown, cb: (e: Error | null, r?: { stdout: string }) => void) => {
       const a = args as string[];
       if (a.includes("remote")) {
-        cb(null, { stdout: "https://github.com/org/fanbot.git\n" });
+        cb(null, { stdout: "https://github.com/org/myrepo.git\n" });
       } else if (a.includes("pr")) {
         cb(null, { stdout: JSON.stringify(ghPRs) });
       } else {
@@ -330,7 +330,7 @@ describe("GET /api/pull-requests — PR response shape", () => {
       branch: "feature-branch",
       baseBranch: "main",
       author: "Dev User",
-      repo: "fanbot",
+      repo: "myrepo",
       isDraft: false,
       additions: 10,
       deletions: 3,
@@ -423,7 +423,7 @@ describe("GET /api/pull-requests — agent cross-referencing", () => {
 describe("GET /api/pull-requests — error handling", () => {
   it("returns empty array (not 500) when gh pr list exits with error", async () => {
     vi.mocked(fsMod.existsSync).mockReturnValue(true);
-    vi.mocked(fsMod.readdirSync).mockReturnValue(["fanbot.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
+    vi.mocked(fsMod.readdirSync).mockReturnValue(["myrepo.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
     vi.mocked(fsMod.statSync).mockReturnValue({ isDirectory: () => true } as ReturnType<typeof fsMod.statSync>);
     vi.mocked(fsMod.readFileSync).mockImplementation(() => {
       throw new Error("no file");
@@ -435,7 +435,7 @@ describe("GET /api/pull-requests — error handling", () => {
       (_c: unknown, args: unknown, _o: unknown, cb: (e: Error | null, r?: { stdout: string }) => void) => {
         const a = args as string[];
         if (a.includes("remote")) {
-          cb(null, { stdout: "https://github.com/org/fanbot.git\n" });
+          cb(null, { stdout: "https://github.com/org/myrepo.git\n" });
         } else {
           cb(new Error("gh: command not found"));
         }
@@ -457,7 +457,7 @@ describe("GET /api/pull-requests — 30-second cache", () => {
   it("returns fromCache:false on first call, fromCache:true on second (no refresh)", async () => {
     let ghCallCount = 0;
     vi.mocked(fsMod.existsSync).mockReturnValue(true);
-    vi.mocked(fsMod.readdirSync).mockReturnValue(["fanbot.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
+    vi.mocked(fsMod.readdirSync).mockReturnValue(["myrepo.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
     vi.mocked(fsMod.statSync).mockReturnValue({ isDirectory: () => true } as ReturnType<typeof fsMod.statSync>);
     vi.mocked(fsMod.readFileSync).mockImplementation(() => {
       throw new Error("no file");
@@ -468,7 +468,7 @@ describe("GET /api/pull-requests — 30-second cache", () => {
       (_c: unknown, args: unknown, _o: unknown, cb: (e: Error | null, r?: { stdout: string }) => void) => {
         const a = args as string[];
         if (a.includes("remote")) {
-          cb(null, { stdout: "https://github.com/org/fanbot.git\n" });
+          cb(null, { stdout: "https://github.com/org/myrepo.git\n" });
         } else if (a.includes("pr")) {
           ghCallCount++;
           cb(null, { stdout: JSON.stringify([sampleGhPR]) });
@@ -496,7 +496,7 @@ describe("GET /api/pull-requests — 30-second cache", () => {
   it("bypasses cache when refresh=true is passed", async () => {
     let ghCallCount = 0;
     vi.mocked(fsMod.existsSync).mockReturnValue(true);
-    vi.mocked(fsMod.readdirSync).mockReturnValue(["fanbot.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
+    vi.mocked(fsMod.readdirSync).mockReturnValue(["myrepo.git"] as unknown as ReturnType<typeof fsMod.readdirSync>);
     vi.mocked(fsMod.statSync).mockReturnValue({ isDirectory: () => true } as ReturnType<typeof fsMod.statSync>);
     vi.mocked(fsMod.readFileSync).mockImplementation(() => {
       throw new Error("no file");
@@ -507,7 +507,7 @@ describe("GET /api/pull-requests — 30-second cache", () => {
       (_c: unknown, args: unknown, _o: unknown, cb: (e: Error | null, r?: { stdout: string }) => void) => {
         const a = args as string[];
         if (a.includes("remote")) {
-          cb(null, { stdout: "https://github.com/org/fanbot.git\n" });
+          cb(null, { stdout: "https://github.com/org/myrepo.git\n" });
         } else if (a.includes("pr")) {
           ghCallCount++;
           cb(null, { stdout: JSON.stringify([sampleGhPR]) });

--- a/src/routes/pull-requests.ts
+++ b/src/routes/pull-requests.ts
@@ -1,0 +1,345 @@
+/**
+ * Pull Requests route — lists open PRs across all repos.
+ *
+ * Uses `gh pr list` to query GitHub for open PRs across all repos in
+ * /persistent/repos. Cross-references with active agents to show which
+ * agent created/is working on each PR. Results are cached for 30 seconds
+ * to avoid hammering the GitHub API.
+ */
+
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import express, { type Request, type Response } from "express";
+import type { AgentManager } from "../agents";
+import { logger } from "../logger";
+import { getRepoPat } from "../secrets-store";
+
+const execFileAsync = promisify(execFile);
+const PERSISTENT_REPOS = "/persistent/repos";
+
+/**
+ * Wire-format for a PR item returned by this endpoint.
+ * Matches the PullRequestItem interface defined in ui/src/api.ts.
+ */
+interface PullRequestItem {
+  number: number;
+  title: string;
+  url: string;
+  state: "open" | "closed" | "merged" | "draft";
+  branch: string;
+  baseBranch: string;
+  author: string;
+  repo: string;
+  isDraft: boolean;
+  additions: number;
+  deletions: number;
+  checksStatus: "pending" | "passing" | "failing" | "none";
+  reviewDecision: string;
+  createdAt: string;
+  updatedAt: string;
+  agent: { id: string; name: string } | null;
+  labels: string[];
+}
+
+interface PRCache {
+  prs: PullRequestItem[];
+  fetchedAt: number;
+}
+let cache: PRCache | null = null;
+const CACHE_TTL_MS = 30_000;
+
+/**
+ * GitHub CLI JSON shape for a single PR in `gh pr list` output.
+ */
+interface GhPR {
+  number: number;
+  title: string;
+  url: string;
+  headRefName: string;
+  baseRefName: string;
+  isDraft: boolean;
+  state: string;
+  author: { login: string; name?: string | null };
+  createdAt: string;
+  updatedAt: string;
+  reviewDecision: string | null;
+  additions: number;
+  deletions: number;
+  statusCheckRollup: Array<{
+    status?: string;
+    conclusion?: string;
+    state?: string;
+  }> | null;
+  labels: Array<{ name: string }> | null;
+}
+
+/**
+ * Derive CI checks status from statusCheckRollup array.
+ */
+function deriveChecksStatus(rollup: GhPR["statusCheckRollup"]): "pending" | "passing" | "failing" | "none" {
+  if (!rollup || rollup.length === 0) return "none";
+
+  const statuses = rollup.map((r) => (r.conclusion ?? r.state ?? r.status ?? "").toUpperCase());
+
+  if (statuses.some((s) => s === "FAILURE" || s === "FAILED" || s === "ERROR")) return "failing";
+  if (statuses.some((s) => s === "PENDING" || s === "IN_PROGRESS" || s === "QUEUED" || s === "EXPECTED")) {
+    return "pending";
+  }
+  if (statuses.every((s) => ["SUCCESS", "COMPLETED", "SKIPPED", "NEUTRAL", ""].includes(s))) {
+    return "passing";
+  }
+  return "pending";
+}
+
+/**
+ * Extract the full GitHub repo slug (e.g. "org/reponame") from a remote URL.
+ */
+function extractRepoSlug(remoteUrl: string): string | null {
+  // HTTPS: https://token@github.com/org/repo.git or https://github.com/org/repo
+  const httpsMatch = remoteUrl.match(/github\.com[/:]([^/]+\/[^/.]+)(\.git)?$/);
+  if (httpsMatch) return httpsMatch[1];
+  // SSH: git@github.com:org/repo.git
+  const sshMatch = remoteUrl.match(/github\.com:([^/]+\/[^/.]+)(\.git)?$/);
+  if (sshMatch) return sshMatch[1];
+  return null;
+}
+
+/**
+ * Extract an embedded token from a remote URL.
+ * Handles formats like https://x-access-token:TOKEN@github.com/...
+ * and https://TOKEN@github.com/...
+ */
+function extractTokenFromUrl(remoteUrl: string): string | null {
+  const match = remoteUrl.match(/https?:\/\/(?:[^:]+:)?([^@]+)@github\.com/);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Resolve the best available GitHub token for a repo.
+ * Priority: repo PAT > URL-embedded token > .repo-token file > env var.
+ */
+function resolveGhToken(repoName: string, remoteUrl: string): string | null {
+  // 1. Repo-specific PAT (set via UI)
+  const pat = getRepoPat(repoName) ?? null;
+  if (pat) return pat;
+
+  // 2. Token embedded in the remote URL
+  const urlToken = extractTokenFromUrl(remoteUrl);
+  if (urlToken) return urlToken;
+
+  // 3. Shared .repo-token file
+  try {
+    const repoToken = fs.readFileSync(path.join(PERSISTENT_REPOS, ".repo-token"), "utf8").trim();
+    if (repoToken) return repoToken;
+  } catch {
+    // not available
+  }
+
+  // 4. Environment variable
+  return process.env.GH_TOKEN || process.env.GITHUB_TOKEN || null;
+}
+
+/**
+ * Get the remote URL for a repo directory.
+ */
+async function getRemoteUrl(repoPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", ["-C", repoPath, "remote", "get-url", "origin"], {
+      encoding: "utf-8",
+      timeout: 5_000,
+    });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch open PRs for a single repo slug using the gh CLI.
+ */
+async function fetchPRsForRepo(repoSlug: string, _repoName: string, ghToken?: string | null): Promise<GhPR[]> {
+  try {
+    const env = ghToken ? { ...process.env, GH_TOKEN: ghToken } : undefined;
+    const { stdout } = await execFileAsync(
+      "gh",
+      [
+        "pr",
+        "list",
+        "--repo",
+        repoSlug,
+        "--state",
+        "open",
+        "--limit",
+        "100",
+        "--json",
+        [
+          "number",
+          "title",
+          "url",
+          "headRefName",
+          "baseRefName",
+          "isDraft",
+          "state",
+          "author",
+          "createdAt",
+          "updatedAt",
+          "reviewDecision",
+          "additions",
+          "deletions",
+          "statusCheckRollup",
+          "labels",
+        ].join(","),
+      ],
+      { encoding: "utf-8", timeout: 30_000, env },
+    );
+
+    return JSON.parse(stdout || "[]") as GhPR[];
+  } catch (err) {
+    logger.warn(`[pull-requests] Failed to fetch PRs for ${repoSlug}:`, {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+/**
+ * Build a map of branch name → agent for fast cross-referencing.
+ */
+function buildBranchAgentMap(agentManager: AgentManager): Map<string, { id: string; name: string }> {
+  const map = new Map<string, { id: string; name: string }>();
+  try {
+    const agents = agentManager.list();
+    for (const agent of agents) {
+      if (agent.gitBranch) {
+        map.set(agent.gitBranch, { id: agent.id, name: agent.name });
+      }
+    }
+  } catch {
+    // safe to ignore if list fails
+  }
+  return map;
+}
+
+/**
+ * Fetch all open PRs across all repos with agent cross-referencing.
+ */
+async function fetchAllPRs(agentManager: AgentManager): Promise<PullRequestItem[]> {
+  if (!fs.existsSync(PERSISTENT_REPOS)) {
+    return [];
+  }
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(PERSISTENT_REPOS).filter((f) => {
+      try {
+        const stat = fs.statSync(path.join(PERSISTENT_REPOS, f));
+        return stat.isDirectory() && f !== "hooks";
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return [];
+  }
+
+  const repoInfos = await Promise.all(
+    entries.map(async (entry) => {
+      const repoPath = path.join(PERSISTENT_REPOS, entry);
+      const remoteUrl = await getRemoteUrl(repoPath);
+      if (!remoteUrl) return null;
+      const slug = extractRepoSlug(remoteUrl);
+      if (!slug) return null;
+      const name = entry.replace(/\.git$/, "");
+      const token = resolveGhToken(name, remoteUrl);
+      return { name, slug, token };
+    }),
+  );
+
+  const validRepos = repoInfos.filter((r): r is { name: string; slug: string; token: string | null } => r !== null);
+  if (validRepos.length === 0) return [];
+
+  const branchMap = buildBranchAgentMap(agentManager);
+
+  const prArrays = await Promise.all(
+    validRepos.map(async ({ name, slug, token }) => {
+      const ghPRs = await fetchPRsForRepo(slug, name, token);
+      return ghPRs.map((gh): PullRequestItem => {
+        const isDraft = gh.isDraft;
+        const state: PullRequestItem["state"] = isDraft
+          ? "draft"
+          : gh.state === "MERGED"
+            ? "merged"
+            : gh.state === "CLOSED"
+              ? "closed"
+              : "open";
+
+        const agent = branchMap.get(gh.headRefName) ?? null;
+
+        return {
+          number: gh.number,
+          title: gh.title,
+          url: gh.url,
+          state,
+          branch: gh.headRefName,
+          baseBranch: gh.baseRefName,
+          author: gh.author?.name ?? gh.author?.login ?? "unknown",
+          repo: name,
+          isDraft,
+          additions: gh.additions ?? 0,
+          deletions: gh.deletions ?? 0,
+          checksStatus: deriveChecksStatus(gh.statusCheckRollup),
+          reviewDecision: gh.reviewDecision ?? "",
+          createdAt: gh.createdAt,
+          updatedAt: gh.updatedAt,
+          agent,
+          labels: (gh.labels ?? []).map((l) => l.name),
+        };
+      });
+    }),
+  );
+
+  return prArrays.flat();
+}
+
+export function createPullRequestsRouter(agentManager: AgentManager) {
+  const router = express.Router();
+
+  /**
+   * GET /api/pull-requests
+   *
+   * Returns all open PRs across all repos with agent cross-references.
+   * Results are cached for 30 seconds.
+   *
+   * Query params:
+   *   - refresh=true  force-invalidate the cache
+   */
+  router.get("/api/pull-requests", async (req: Request, res: Response) => {
+    try {
+      const forceRefresh = req.query.refresh === "true";
+      const now = Date.now();
+
+      if (!forceRefresh && cache && now - cache.fetchedAt < CACHE_TTL_MS) {
+        res.json({
+          pullRequests: cache.prs,
+          cachedAt: cache.fetchedAt,
+          fromCache: true,
+        });
+        return;
+      }
+
+      const prs = await fetchAllPRs(agentManager);
+      cache = { prs, fetchedAt: now };
+
+      res.json({ pullRequests: prs, cachedAt: now, fromCache: false });
+    } catch (err) {
+      logger.error("[pull-requests] Failed to list pull requests:", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      res.status(500).json({ error: "Failed to list pull requests" });
+    }
+  });
+
+  return router;
+}

--- a/src/utils/memory.ts
+++ b/src/utils/memory.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
+import os from "node:os";
 
 const CGROUP_MEMORY_PATH = "/sys/fs/cgroup/memory.current";
+const CGROUP_MEMORY_MAX_PATH = "/sys/fs/cgroup/memory.max";
 
 /**
  * Read container-level memory usage from cgroup v2. This captures the server
@@ -8,6 +10,23 @@ const CGROUP_MEMORY_PATH = "/sys/fs/cgroup/memory.current";
  * which only measures the Node.js server itself.
  * Falls back to process RSS when cgroup files aren't available (local dev).
  */
+/**
+ * Read the container memory limit from cgroup v2. Returns the value of
+ * /sys/fs/cgroup/memory.max when set (not "max"), otherwise falls back to
+ * os.totalmem() for local dev or unconstrained environments.
+ */
+export function getContainerMemoryLimit(): number {
+  try {
+    const raw = fs.readFileSync(CGROUP_MEMORY_MAX_PATH, "utf-8").trim();
+    if (raw === "max") return os.totalmem();
+    const bytes = Number(raw);
+    if (Number.isNaN(bytes) || bytes <= 0) return os.totalmem();
+    return bytes;
+  } catch {
+    return os.totalmem();
+  }
+}
+
 export function getContainerMemoryUsage(): number {
   try {
     const raw = fs.readFileSync(CGROUP_MEMORY_PATH, "utf-8").trim();


### PR DESCRIPTION
## Summary

Adds `src/routes/pull-requests.ts` + server mount:

- GET `/api/pull-requests`: lists open PRs across all repos in `/persistent/repos`, cross-referenced with active agents. 30-second cache.
- Adapted from Fanbot: `loadRepoPat` replaced with AM's `getRepoPat` from `secrets-store`.
- `AgentManager` type used throughout (was `Fanbot`).

Zero fanbot/fanvue refs.

## Test plan
- [x] `npm test` passes (414 tests)
- [x] `npx biome check .` clean