### PR TITLE
feat: add startup bundle route (PR 15)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -25,6 +25,7 @@ import { createMcpRouter } from "./src/routes/mcp";
 import { createMessagesRouter } from "./src/routes/messages";
 import { createRepositoriesRouter } from "./src/routes/repositories";
 import { createSchedulerRouter } from "./src/routes/scheduler";
+import { createStartupRouter } from "./src/routes/startup";
 import { createTasksRouter } from "./src/routes/tasks";
 import { createUsageRouter } from "./src/routes/usage";
 import { createWorkflowsRouter } from "./src/routes/workflows";
@@ -205,6 +206,7 @@ app.use(createTasksRouter(taskGraph, orchestrator, gradeStore));
 app.use(createSchedulerRouter(scheduler));
 app.use(createWorkflowsRouter(agentManager, messageBus));
 app.use(createRepositoriesRouter(agentManager));
+app.use(createStartupRouter(agentManager, messageBus));
 // Layer 1: Kill switch endpoint (no extra auth beyond authMiddleware above)
 app.use(createKillSwitchRouter(agentManager));
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -158,3 +158,14 @@ export function requireHumanUser(req: Request, res: Response, next: NextFunction
   }
   next();
 }
+
+/** Middleware that blocks requests from agent-service tokens.
+ *  Use this to protect operations that should only be callable by human users. */
+export function requireNotAgentService(req: Request, res: Response, next: NextFunction): void {
+  const user = (req as AuthenticatedRequest).user;
+  if (!user || user.sub === "agent-service") {
+    res.status(403).json({ error: "This operation is not allowed for agent service tokens" });
+    return;
+  }
+  next();
+}

--- a/src/routes/startup.ts
+++ b/src/routes/startup.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import path from "node:path";
+import express, { type Request, type Response } from "express";
+import type { AgentManager } from "../agents";
+import type { MessageBus } from "../messages";
+import { getContextDir, validateContextPath } from "../utils/context";
+import { queryString } from "../utils/express";
+
+const STARTUP_CONTEXT_FILES = ["about-you.md", "backlog.md", "repository.md", "guides/locks.md"];
+
+function scanContextIndex(contextDir: string): Array<{ name: string; size: number; modified: string }> {
+  const result: Array<{ name: string; size: number; modified: string }> = [];
+
+  const scan = (dir: string, prefix: string) => {
+    try {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name.startsWith(".")) continue;
+          scan(fullPath, `${prefix}${entry.name}/`);
+        } else if (entry.name.endsWith(".md")) {
+          const stat = fs.statSync(fullPath);
+          result.push({
+            name: `${prefix}${entry.name}`,
+            size: stat.size,
+            modified: stat.mtime.toISOString(),
+          });
+        }
+      }
+    } catch {
+      // Directory not readable - skip
+    }
+  };
+
+  scan(contextDir, "");
+  return result;
+}
+
+export function createStartupRouter(agentManager: AgentManager, messageBus: MessageBus) {
+  const router = express.Router();
+
+  // Startup bundle - reduces agent startup to a single HTTP round-trip
+  router.get("/api/startup", (req: Request, res: Response) => {
+    const agentId = queryString(req.query.agentId);
+
+    if (!agentId) {
+      res.status(400).json({ error: "agentId query param required" });
+      return;
+    }
+
+    const contextDir = getContextDir();
+
+    // Agent registry
+    const registry = agentManager.list().map((a) => ({
+      id: a.id,
+      name: a.name,
+      status: a.status,
+      role: a.role,
+      capabilities: a.capabilities,
+      currentTask: a.currentTask,
+      parentId: a.parentId,
+      depth: a.depth,
+      model: a.model,
+      lastActivity: a.lastActivity,
+      unreadMessages: messageBus.unreadCount(a.id, a.role),
+    }));
+
+    // Unread count for the requesting agent
+    const requestingAgent = agentManager.get(agentId);
+    const unreadCount = messageBus.unreadCount(agentId, requestingAgent?.role);
+
+    // Load the standard startup context files (skip if missing)
+    const contextFiles: Record<string, string> = {};
+    try {
+      fs.mkdirSync(contextDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+    for (const name of STARTUP_CONTEXT_FILES) {
+      const filepath = validateContextPath(contextDir, name);
+      if (filepath && fs.existsSync(filepath)) {
+        try {
+          contextFiles[name] = fs.readFileSync(filepath, "utf-8");
+        } catch {
+          // skip unreadable files
+        }
+      }
+    }
+
+    // Context index (all .md files with metadata)
+    const contextIndex = scanContextIndex(contextDir);
+
+    res.json({ registry, unreadCount, contextFiles, contextIndex });
+  });
+
+  return router;
+}

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 /**
  * Return the absolute path of the shared context directory.
  *
@@ -8,4 +9,19 @@
  */
 export function getContextDir(): string {
   return process.env.SHARED_CONTEXT_DIR || "/shared-context";
+}
+
+/**
+ * Validate that a context file name is safe to read/write.
+ * Rejects path traversal attempts and names that resolve outside contextDir.
+ *
+ * @returns The resolved absolute path, or null if the name is invalid.
+ */
+export function validateContextPath(contextDir: string, name: string): string | null {
+  if (name.includes("..")) return null;
+  const filepath = path.resolve(path.join(contextDir, name));
+  if (!filepath.startsWith(path.resolve(contextDir) + path.sep) && filepath !== path.resolve(contextDir)) {
+    return null;
+  }
+  return filepath;
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -202,3 +202,8 @@ export function validatePatchAgent(req: Request, res: Response, next: NextFuncti
   req.body = sanitized;
   next();
 }
+
+/** Sanitize a repository name: alphanumeric, hyphens, underscores only. */
+export function sanitizeRepoName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, "");
+}


### PR DESCRIPTION
## Summary

Adds `src/routes/startup.ts` + server mount:

- GET `/api/startup?agentId=`: returns agent registry, unread message count, standard context files (about-you.md, backlog.md, repository.md, guides/locks.md), and context file index in a single round-trip. Reduces agent startup latency.
- Adapted from Fanbot: `AgentManager`/`agentManager` used throughout.

Zero fanbot/fanvue refs. ~97 lines.

## Test plan
- [x] `npm test` passes (414 tests)
- [x] `npx biome check .` clean