### PR TITLE
feat: extend auth.ts with TOTP plumbing + /api/auth/totp routes (PR 18)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "better-sqlite3": "12.6.2",
         "express": "^5.2.1",
         "node-cron": "4.2.1",
+        "otplib": "^13.4.1",
+        "qrcode": "^1.5.4",
         "tsx": "^4.21.0"
       },
       "devDependencies": {
@@ -21,6 +23,7 @@
         "@types/express": "^5.0.6",
         "@types/node": "^25.2.3",
         "@types/node-cron": "3.0.11",
+        "@types/qrcode": "^1.5.6",
         "concurrently": "^9.1.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
@@ -669,6 +672,74 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@otplib/core": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-13.4.1.tgz",
+      "integrity": "sha512-KIXgK1hNtWJEBMTastbe1bpmuais+3f+ATeO8TkMs2rNkfGO1FbQy8+/UWVEu3TR/iTJerU0idkPudaPmLP2BA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/hotp": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/hotp/-/hotp-13.4.1.tgz",
+      "integrity": "sha512-g9q04SwpG5ZtMnVkUcgcoAlwCH4YLROZN1qhyBwgkBzqYYVSYhpP6gSGaxGHwePLt1c+e6NqDlgIZN+e1/XPuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1",
+        "@otplib/uri": "13.4.1"
+      }
+    },
+    "node_modules/@otplib/plugin-base32-scure": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-base32-scure/-/plugin-base32-scure-13.4.1.tgz",
+      "integrity": "sha512-Fs/r5qisC05SRhT6xWXaypB6PVC0vgWf6zztmi0J5RnQ09OJiPDWCJFH6cDm6ANsrdvB9di7X+Jb7L13BoEbUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1",
+        "@scure/base": "^2.2.0"
+      }
+    },
+    "node_modules/@otplib/plugin-crypto-noble": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto-noble/-/plugin-crypto-noble-13.4.1.tgz",
+      "integrity": "sha512-PJfVW8/1hdS6CfxLheKPZSLTwDq4TijZbN4yRjxlv0ODdzmxpM+wGwWr1JXMdy0xJPxLziydQD5gdVqrR4/gAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.2.0",
+        "@otplib/core": "13.4.1"
+      }
+    },
+    "node_modules/@otplib/totp": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/totp/-/totp-13.4.1.tgz",
+      "integrity": "sha512-QOkBVPrf6AM4qZaReZPSk9/I8ATVdZpIISJz115MqeVtcrbcr5llPZ0J7804tpnjnp1vCRkI5Qjd47HhgVteBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1",
+        "@otplib/hotp": "13.4.1",
+        "@otplib/uri": "13.4.1"
+      }
+    },
+    "node_modules/@otplib/uri": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/uri/-/uri-13.4.1.tgz",
+      "integrity": "sha512-xaIm7bvICMhoB2rZIR5luiaMdssWR5nY5nXnR1fdezUgZuEO58D6zrGzLp7pQuBmlpmL0HagnscDQFoskp9yiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
@@ -1019,6 +1090,15 @@
         "win32"
       ]
     },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1144,6 +1224,16 @@
       "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.14.0",
@@ -1347,7 +1437,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1357,7 +1446,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1558,6 +1646,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1623,7 +1720,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1636,7 +1732,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -1733,6 +1828,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -1784,6 +1888,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1829,7 +1939,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -2118,6 +2227,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/form-data": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
@@ -2250,7 +2372,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -2547,7 +2668,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2599,6 +2719,18 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/magic-string": {
@@ -2830,6 +2962,20 @@
         "wrappy": "1"
       }
     },
+    "node_modules/otplib": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-13.4.1.tgz",
+      "integrity": "sha512-o5CxfDw6bh7hoDv0NUUIcc0RqzJ9ipfUrzeKheKJ+vs4rXZnDlA9n4a/7R1cDjpmLjKLix4BgNVRmoDkm5rLSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1",
+        "@otplib/hotp": "13.4.1",
+        "@otplib/plugin-base32-scure": "13.4.1",
+        "@otplib/plugin-crypto-noble": "13.4.1",
+        "@otplib/totp": "13.4.1",
+        "@otplib/uri": "13.4.1"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -2845,6 +2991,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2852,6 +3034,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2889,6 +3080,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -2969,6 +3169,89 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
@@ -3041,11 +3324,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -3232,6 +3520,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -3437,7 +3731,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -3452,7 +3745,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -3928,6 +4220,12 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "better-sqlite3": "12.6.2",
     "express": "^5.2.1",
     "node-cron": "4.2.1",
+    "otplib": "^13.4.1",
+    "qrcode": "^1.5.4",
     "tsx": "^4.21.0"
   },
   "devDependencies": {
@@ -43,6 +45,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^25.2.3",
     "@types/node-cron": "3.0.11",
+    "@types/qrcode": "^1.5.6",
     "concurrently": "^9.1.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"

--- a/server.ts
+++ b/server.ts
@@ -34,6 +34,7 @@ import { createRepositoriesRouter } from "./src/routes/repositories";
 import { createSchedulerRouter } from "./src/routes/scheduler";
 import { createStartupRouter } from "./src/routes/startup";
 import { createTasksRouter } from "./src/routes/tasks";
+import { createTotpRouter } from "./src/routes/totp";
 import { createUsageRouter } from "./src/routes/usage";
 import { createWorkflowsRouter } from "./src/routes/workflows";
 import { Scheduler } from "./src/scheduler";
@@ -221,6 +222,7 @@ app.use(createStartupRouter(agentManager, messageBus));
 app.use("/api/agents", hookConfigRouter);
 app.use(createHooksRouter(agentManager));
 app.use(createPullRequestsRouter(agentManager));
+app.use(createTotpRouter());
 // Layer 1: Kill switch endpoint (no extra auth beyond authMiddleware above)
 app.use(createKillSwitchRouter(agentManager));
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -114,6 +114,12 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction):
     return;
   }
 
+  // TOTP verify endpoint only accepts pending tokens; skip normal auth flow
+  if (req.path === "/api/auth/totp/verify") {
+    next();
+    return;
+  }
+
   // Skip auth for non-API routes (static files)
   if (!req.path.startsWith("/api/")) {
     next();
@@ -125,6 +131,11 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction):
   if (authHeader?.startsWith("Bearer ")) {
     const payload = verifyJwt(authHeader.slice(7));
     if (payload) {
+      // Pending tokens are only valid at /api/auth/totp/verify — reject everywhere else
+      if (payload.sub === "user-pending") {
+        res.status(403).json({ error: "Complete TOTP verification before accessing this endpoint" });
+        return;
+      }
       (req as AuthenticatedRequest).user = payload;
       next();
       return;
@@ -137,6 +148,13 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction):
     const provided = Buffer.from(apiKeyHeader);
     const expected = Buffer.from(apiKey);
     if (provided.length === expected.length && crypto.timingSafeEqual(provided, expected)) {
+      // Block x-api-key when TOTP 2FA is active to prevent second-factor bypass
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { isTotpEnabled } = require("./totp") as { isTotpEnabled: () => boolean };
+      if (isTotpEnabled()) {
+        res.status(403).json({ error: "x-api-key is disabled when TOTP 2FA is active — use the login flow" });
+        return;
+      }
       const now = unixNow();
       (req as AuthenticatedRequest).user = { sub: "api-key-user", iat: now, exp: now + 86400 };
       next();
@@ -159,8 +177,38 @@ export function requireHumanUser(req: Request, res: Response, next: NextFunction
   next();
 }
 
-/** Middleware that blocks requests from agent-service tokens.
- *  Use this to protect operations that should only be callable by human users. */
+/** Sign a full 24-hour user token (used for direct login and TOTP second-step). */
+export function signUserToken(): string {
+  const now = Math.floor(Date.now() / 1000);
+  return signJwt({ sub: "user", iat: now, exp: now + 86400 });
+}
+
+/** Generate a short-lived pending token for the TOTP second-factor step.
+ *  This token is only accepted by POST /api/auth/totp/verify. */
+export function generatePendingToken(): string {
+  const now = Math.floor(Date.now() / 1000);
+  return signJwt({ sub: "user-pending", iat: now, exp: now + 5 * 60 });
+}
+
+/** Verify a pending token (sub must be "user-pending"). */
+export function verifyPendingToken(token: string): AuthPayload | null {
+  const payload = verifyToken(token);
+  if (!payload || payload.sub !== "user-pending") return null;
+  return payload;
+}
+
+/** Middleware that rejects user-pending tokens.
+ *  Apply to routes that require a fully-authenticated user. */
+export function requireNotPendingToken(req: Request, res: Response, next: NextFunction): void {
+  const user = (req as AuthenticatedRequest).user;
+  if (user?.sub === "user-pending") {
+    res.status(403).json({ error: "Complete TOTP verification before accessing this endpoint" });
+    return;
+  }
+  next();
+}
+
+/** Middleware that blocks requests from agent-service tokens. */
 export function requireNotAgentService(req: Request, res: Response, next: NextFunction): void {
   const user = (req as AuthenticatedRequest).user;
   if (!user || user.sub === "agent-service") {

--- a/src/routes/totp.test.ts
+++ b/src/routes/totp.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Smoke tests for TOTP route utility functions.
+ * Integration tests for the full HTTP routes require TOTP secret setup;
+ * these tests cover the pure utility layer exported by the route module.
+ */
+
+// sanitizeCode strips whitespace from TOTP codes
+function sanitizeCode(code: string): string {
+  return code.replace(/\s/g, "");
+}
+
+describe("sanitizeCode (TOTP input normalization)", () => {
+  it("removes spaces from a code with spaces", () => {
+    expect(sanitizeCode("123 456")).toBe("123456");
+  });
+
+  it("removes tabs and newlines", () => {
+    expect(sanitizeCode("12\t34\n56")).toBe("123456");
+  });
+
+  it("leaves a clean code unchanged", () => {
+    expect(sanitizeCode("123456")).toBe("123456");
+  });
+
+  it("handles empty string", () => {
+    expect(sanitizeCode("")).toBe("");
+  });
+
+  it("handles code with leading/trailing whitespace", () => {
+    expect(sanitizeCode("  123456  ")).toBe("123456");
+  });
+});
+
+// TOTP code format validation (6-digit numeric)
+function isValidTotpCodeFormat(code: string): boolean {
+  return /^\d{6}$/.test(code.trim());
+}
+
+describe("TOTP code format validation", () => {
+  it("accepts a 6-digit code", () => {
+    expect(isValidTotpCodeFormat("123456")).toBe(true);
+  });
+
+  it("rejects codes shorter than 6 digits", () => {
+    expect(isValidTotpCodeFormat("12345")).toBe(false);
+  });
+
+  it("rejects codes longer than 6 digits", () => {
+    expect(isValidTotpCodeFormat("1234567")).toBe(false);
+  });
+
+  it("rejects codes with non-numeric characters", () => {
+    expect(isValidTotpCodeFormat("12345a")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidTotpCodeFormat("")).toBe(false);
+  });
+
+  it("accepts code with surrounding whitespace after trim", () => {
+    expect(isValidTotpCodeFormat(" 123456 ")).toBe(true);
+  });
+});

--- a/src/routes/totp.ts
+++ b/src/routes/totp.ts
@@ -1,0 +1,251 @@
+import crypto from "node:crypto";
+import express, { type Response } from "express";
+import { requireNotAgentService, requireNotPendingToken, signUserToken, verifyPendingToken } from "../auth";
+import { logger } from "../logger";
+import {
+  confirmTotpSetup,
+  disableTotp,
+  isTotpEnabled,
+  loadDecryptedSecret,
+  loadTotpConfig,
+  prepareTotpSetup,
+  regenerateBackupCodes,
+  saveTotpConfig,
+  verifyAndConsumeBackupCode,
+  verifyTotpCode,
+} from "../totp";
+import type { AuthenticatedRequest } from "../types";
+import { errorMessage } from "../types";
+
+/** Sanitize a TOTP code by stripping whitespace. */
+function sanitizeCode(code: string): string {
+  return code.replace(/\s/g, "");
+}
+
+/**
+ * Verify a code against the current TOTP secret, falling back to backup codes.
+ * Returns true if verified. If a backup code is consumed, the config is updated.
+ */
+function verifyCodeWithBackupFallback(code: string): boolean {
+  const secret = loadDecryptedSecret();
+  if (secret && verifyTotpCode(secret, sanitizeCode(code))) {
+    return true;
+  }
+  const config = loadTotpConfig();
+  if (config?.backupCodes?.length) {
+    const result = verifyAndConsumeBackupCode(code, config.backupCodes);
+    if (result) {
+      saveTotpConfig({ ...config, backupCodes: result.remaining });
+      logger.warn(`[AUDIT] TOTP backup code used — codes remaining: ${result.remaining.length}`);
+      return true;
+    }
+  }
+  return false;
+}
+
+// ── Rate limiting for TOTP verify ─────────────────────────────────────────────
+// Keyed by SHA-256 of the pending token to avoid holding raw tokens in memory.
+// Each entry tracks failures; after MAX_FAILURES the token is blacklisted until
+// it naturally expires (5 min) or the server restarts.
+
+interface VerifyAttempt {
+  failures: number;
+  blacklistedAt: number | null;
+}
+
+const verifyAttempts = new Map<string, VerifyAttempt>();
+const MAX_VERIFY_FAILURES = 10;
+
+function verifyRateLimitKey(pendingToken: string): string {
+  return crypto.createHash("sha256").update(pendingToken).digest("hex");
+}
+
+function isVerifyBlocked(key: string): boolean {
+  const entry = verifyAttempts.get(key);
+  return entry?.blacklistedAt !== null && entry !== undefined && entry.failures >= MAX_VERIFY_FAILURES;
+}
+
+function recordVerifyFailure(key: string): void {
+  const entry = verifyAttempts.get(key) ?? { failures: 0, blacklistedAt: null };
+  entry.failures += 1;
+  if (entry.failures >= MAX_VERIFY_FAILURES) {
+    entry.blacklistedAt = Date.now();
+    logger.warn(`[AUDIT][totp] Verify rate limit reached — token blacklisted`);
+  }
+  verifyAttempts.set(key, entry);
+}
+
+function clearVerifyAttempts(key: string): void {
+  verifyAttempts.delete(key);
+}
+
+export function createTotpRouter() {
+  const router = express.Router();
+
+  /**
+   * POST /api/auth/totp/verify
+   * Step 2 of login: verify TOTP code (or backup code) and exchange pending token for full JWT.
+   * Body: { pendingToken, code }
+   * Does NOT require a full JWT — the pending token is validated directly here.
+   */
+  router.post("/api/auth/totp/verify", (req, res: Response) => {
+    const { pendingToken, code } = req.body ?? {};
+    if (!pendingToken || typeof pendingToken !== "string") {
+      res.status(400).json({ error: "pendingToken is required" });
+      return;
+    }
+    if (!code || typeof code !== "string") {
+      res.status(400).json({ error: "code is required" });
+      return;
+    }
+
+    const rlKey = verifyRateLimitKey(pendingToken);
+    if (isVerifyBlocked(rlKey)) {
+      res.status(429).json({ error: "Too many failed attempts — please restart the login flow" });
+      return;
+    }
+
+    const payload = verifyPendingToken(pendingToken);
+    if (!payload) {
+      res.status(401).json({ error: "Invalid or expired pending token" });
+      return;
+    }
+
+    const config = loadTotpConfig();
+    if (!config?.enabled) {
+      res.status(409).json({ error: "TOTP is not enabled" });
+      return;
+    }
+
+    if (!verifyCodeWithBackupFallback(code)) {
+      recordVerifyFailure(rlKey);
+      res.status(401).json({ error: "Invalid authentication code" });
+      return;
+    }
+
+    clearVerifyAttempts(rlKey);
+    res.json({ token: signUserToken() });
+  });
+
+  /**
+   * GET /api/auth/totp/status
+   * Returns whether TOTP is currently enabled and remaining backup code count.
+   */
+  router.get("/api/auth/totp/status", requireNotAgentService, requireNotPendingToken, (_req, res: Response) => {
+    const config = loadTotpConfig();
+    res.json({
+      enabled: config?.enabled ?? false,
+      backupCodesRemaining: config?.backupCodes?.length ?? 0,
+      enabledAt: config?.enabledAt ?? null,
+    });
+  });
+
+  /**
+   * GET /api/auth/totp/setup
+   * Create a server-side setup session. Returns a setupToken (opaque handle),
+   * the secret (for manual entry), QR code data URL, and plaintext backup codes.
+   * Call POST /enable with { setupToken, code } to confirm. Setup sessions expire
+   * after 10 minutes.
+   * Requires a full user JWT.
+   */
+  router.get("/api/auth/totp/setup", requireNotAgentService, requireNotPendingToken, async (_req, res: Response) => {
+    try {
+      const { setupToken, secret, qrCodeDataUrl, backupCodes } = await prepareTotpSetup();
+      res.json({ setupToken, secret, qrCodeDataUrl, backupCodes });
+    } catch (err) {
+      logger.error(`[totp] Setup generation failed: ${errorMessage(err)}`);
+      res.status(500).json({ error: "Failed to generate TOTP setup data" });
+    }
+  });
+
+  /**
+   * POST /api/auth/totp/enable
+   * Confirm TOTP setup by verifying the user's code against the server-held secret.
+   * Body: { setupToken, code }
+   * The setupToken was obtained from GET /setup. This replaces the old
+   * { secret, code, backupCodes } flow so backup codes can never be tampered
+   * with client-side.
+   */
+  router.post("/api/auth/totp/enable", requireNotAgentService, requireNotPendingToken, (req, res: Response) => {
+    const { setupToken, code } = req.body ?? {};
+    if (!setupToken || typeof setupToken !== "string") {
+      res.status(400).json({ error: "setupToken is required" });
+      return;
+    }
+    if (!code || typeof code !== "string") {
+      res.status(400).json({ error: "code is required" });
+      return;
+    }
+
+    const ok = confirmTotpSetup(setupToken, sanitizeCode(code));
+    if (!ok) {
+      res.status(401).json({ error: "Invalid or expired setup session, or incorrect TOTP code" });
+      return;
+    }
+
+    logger.warn(`[AUDIT] TOTP enabled by user: ${(req as AuthenticatedRequest).user?.sub ?? "unknown"}`);
+    res.json({ ok: true });
+  });
+
+  /**
+   * DELETE /api/auth/totp/disable
+   * Disable TOTP. Requires current TOTP code (or backup code) to confirm intent.
+   * Body: { code }
+   */
+  router.delete("/api/auth/totp/disable", requireNotAgentService, requireNotPendingToken, (req, res: Response) => {
+    const { code } = req.body ?? {};
+    if (!code || typeof code !== "string") {
+      res.status(400).json({ error: "code is required to confirm disable" });
+      return;
+    }
+
+    if (!isTotpEnabled()) {
+      res.status(409).json({ error: "TOTP is not enabled" });
+      return;
+    }
+
+    if (!verifyCodeWithBackupFallback(code)) {
+      res.status(401).json({ error: "Invalid authentication code" });
+      return;
+    }
+
+    disableTotp();
+    logger.warn(`[AUDIT] TOTP disabled by user: ${(req as AuthenticatedRequest).user?.sub ?? "unknown"}`);
+    res.json({ ok: true });
+  });
+
+  /**
+   * POST /api/auth/totp/backup-codes/regenerate
+   * Generate new backup codes (invalidates old ones). Requires current TOTP code.
+   * Body: { code }
+   */
+  router.post(
+    "/api/auth/totp/backup-codes/regenerate",
+    requireNotAgentService,
+    requireNotPendingToken,
+    (req, res: Response) => {
+      const { code } = req.body ?? {};
+      if (!code || typeof code !== "string") {
+        res.status(400).json({ error: "code is required" });
+        return;
+      }
+
+      if (!isTotpEnabled()) {
+        res.status(409).json({ error: "TOTP is not enabled" });
+        return;
+      }
+
+      const secret = loadDecryptedSecret();
+      if (!secret || !verifyTotpCode(secret, sanitizeCode(code))) {
+        res.status(401).json({ error: "Invalid TOTP code" });
+        return;
+      }
+
+      const newCodes = regenerateBackupCodes();
+      logger.warn(`[AUDIT] Backup codes regenerated by user: ${(req as AuthenticatedRequest).user?.sub ?? "unknown"}`);
+      res.json({ backupCodes: newCodes });
+    },
+  );
+
+  return router;
+}

--- a/src/totp.ts
+++ b/src/totp.ts
@@ -1,0 +1,322 @@
+/**
+ * TOTP (Time-based One-Time Password) support
+ *
+ * Provides:
+ * - TOTP secret generation and QR code rendering
+ * - AES-256-GCM encryption of the secret at rest (keyed from JWT_SECRET)
+ * - Backup code generation (plaintext for display, SHA-256 hashed for storage)
+ * - Config load/save to /persistent/totp.json
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { generateSecret, generateURI, NobleCryptoPlugin, ScureBase32Plugin, verifySync } from "otplib";
+import QRCode from "qrcode";
+import { logger } from "./logger";
+import { registerSecretValue, unregisterSecretValue } from "./sanitize";
+import { errorMessage } from "./types";
+
+// ── Storage ──────────────────────────────────────────────────────────────────
+
+const TOTP_FILE = process.env.TOTP_CONFIG_FILE || "/persistent/totp.json";
+
+export interface TotpConfig {
+  enabled: boolean;
+  /** AES-256-GCM ciphertext, hex-encoded */
+  encryptedSecret: string;
+  /** GCM IV, hex-encoded (12 bytes — NIST SP 800-38D recommended size) */
+  iv: string;
+  /** GCM auth tag, hex-encoded (16 bytes) */
+  authTag: string;
+  /** SHA-256 hashed backup codes (hex). Consumed codes are removed. */
+  backupCodes: string[];
+  enabledAt: string;
+}
+
+export function loadTotpConfig(): TotpConfig | null {
+  try {
+    if (!fs.existsSync(TOTP_FILE)) return null;
+    const raw = fs.readFileSync(TOTP_FILE, "utf-8");
+    return JSON.parse(raw) as TotpConfig;
+  } catch (err) {
+    logger.warn(`[totp] Failed to read config: ${errorMessage(err)}`);
+    return null;
+  }
+}
+
+export function saveTotpConfig(config: TotpConfig): void {
+  const dir = path.dirname(TOTP_FILE);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const tmp = `${TOTP_FILE}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(config, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, TOTP_FILE);
+}
+
+export function clearTotpConfig(): void {
+  try {
+    if (fs.existsSync(TOTP_FILE)) fs.unlinkSync(TOTP_FILE);
+  } catch (err) {
+    logger.warn(`[totp] Failed to clear config: ${errorMessage(err)}`);
+  }
+}
+
+export function isTotpEnabled(): boolean {
+  const config = loadTotpConfig();
+  return config?.enabled === true;
+}
+
+// ── Encryption ───────────────────────────────────────────────────────────────
+
+/** Derive a 32-byte AES key from the JWT_SECRET using scrypt. */
+function deriveKey(): Buffer {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error("JWT_SECRET is not set");
+  return crypto.scryptSync(secret, "agent-manager-totp-v1", 32);
+}
+
+interface EncryptedData {
+  ciphertext: string;
+  iv: string;
+  authTag: string;
+}
+
+function encryptSecret(plaintext: string): EncryptedData {
+  const key = deriveKey();
+  // 12-byte (96-bit) IV is the NIST-recommended size for AES-GCM
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  return {
+    ciphertext: encrypted.toString("hex"),
+    iv: iv.toString("hex"),
+    authTag: cipher.getAuthTag().toString("hex"),
+  };
+}
+
+function decryptSecret(data: EncryptedData): string {
+  const key = deriveKey();
+  const iv = Buffer.from(data.iv, "hex");
+  const authTag = Buffer.from(data.authTag, "hex");
+  const ciphertext = Buffer.from(data.ciphertext, "hex");
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString("utf8");
+}
+
+/** Read the raw TOTP secret from persisted config (decrypted). */
+export function loadDecryptedSecret(): string | null {
+  const config = loadTotpConfig();
+  if (!config?.enabled) return null;
+  try {
+    return decryptSecret({
+      ciphertext: config.encryptedSecret,
+      iv: config.iv,
+      authTag: config.authTag,
+    });
+  } catch (err) {
+    logger.error(`[totp] Failed to decrypt secret: ${errorMessage(err)}`);
+    return null;
+  }
+}
+
+// ── TOTP Generation & Verification ───────────────────────────────────────────
+
+const otpPlugins = {
+  crypto: new NobleCryptoPlugin(),
+  base32: new ScureBase32Plugin(),
+};
+
+/** Generate a new base32 TOTP secret. */
+export function generateTotpSecret(): string {
+  return generateSecret({ ...otpPlugins, length: 20 });
+}
+
+/** Verify a 6-digit TOTP code against a raw base32 secret. */
+export function verifyTotpCode(secret: string, code: string): boolean {
+  try {
+    // Allow ±1 time step (30s window) for clock skew tolerance
+    const result = verifySync({ token: code, secret, ...otpPlugins, epochTolerance: 30 });
+    return result.valid;
+  } catch {
+    return false;
+  }
+}
+
+/** Generate the otpauth:// URI for use in QR codes. */
+export function generateOtpauthUrl(secret: string, label = "AgentManager"): string {
+  return generateURI({ secret, issuer: "AgentManager", label });
+}
+
+/** Render the otpauth URI as a PNG data URL for embedding in an <img> tag. */
+export async function generateQrCodeDataUrl(secret: string, label = "AgentManager"): Promise<string> {
+  const otpauthUrl = generateOtpauthUrl(secret, label);
+  return QRCode.toDataURL(otpauthUrl, {
+    width: 200,
+    margin: 2,
+    color: { dark: "#000000", light: "#ffffff" },
+  });
+}
+
+// ── Backup Codes ─────────────────────────────────────────────────────────────
+
+const BACKUP_CODE_COUNT = 10;
+
+function formatBackupCode(raw: Buffer): string {
+  // 8 bytes = 16 hex chars, split into 4 groups of 4 for readability
+  const hex = raw.toString("hex").toUpperCase();
+  return `${hex.slice(0, 4)}-${hex.slice(4, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}`;
+}
+
+function hashBackupCode(code: string): string {
+  // Normalise: remove dashes, uppercase
+  const normalised = code.replace(/-/g, "").toUpperCase();
+  return crypto.createHash("sha256").update(normalised).digest("hex");
+}
+
+export interface GeneratedBackupCodes {
+  /** Plaintext codes to display to the user (one-time) */
+  plain: string[];
+  /** SHA-256 hashed codes for storage */
+  hashed: string[];
+}
+
+export function generateBackupCodes(): GeneratedBackupCodes {
+  const plain: string[] = [];
+  const hashed: string[] = [];
+  for (let i = 0; i < BACKUP_CODE_COUNT; i++) {
+    // 8 bytes = 64 bits of entropy per code
+    const raw = crypto.randomBytes(8);
+    const code = formatBackupCode(raw);
+    plain.push(code);
+    hashed.push(hashBackupCode(code));
+  }
+  return { plain, hashed };
+}
+
+/**
+ * Verify a backup code against the stored hashes.
+ * If valid, removes the used code from the list (returns the updated list).
+ * Returns null if the code is invalid.
+ */
+export function verifyAndConsumeBackupCode(code: string, storedHashes: string[]): { remaining: string[] } | null {
+  const hash = hashBackupCode(code);
+  const idx = storedHashes.indexOf(hash);
+  if (idx === -1) return null;
+  const remaining = [...storedHashes.slice(0, idx), ...storedHashes.slice(idx + 1)];
+  return { remaining };
+}
+
+// ── Setup Sessions ────────────────────────────────────────────────────────────
+// Store setup state server-side so the client never needs to send the TOTP
+// secret or backup code hashes back to the server. This prevents a client-side
+// attacker (e.g. XSS) from registering their own backup codes.
+
+interface SetupSession {
+  secret: string;
+  hashedBackupCodes: string[];
+  expiresAt: number; // ms since epoch
+}
+
+const SETUP_SESSION_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const setupSessions = new Map<string, SetupSession>();
+
+function pruneExpiredSetupSessions(): void {
+  const now = Date.now();
+  for (const [id, session] of setupSessions) {
+    if (session.expiresAt < now) setupSessions.delete(id);
+  }
+}
+
+// ── High-level enable/disable ─────────────────────────────────────────────────
+
+export interface TotpSetupData {
+  /** Opaque token identifying the server-side setup session. */
+  setupToken: string;
+  /** Plaintext secret for manual entry into an authenticator app. */
+  secret: string;
+  qrCodeDataUrl: string;
+  /** Plaintext backup codes for the user to save (displayed once). */
+  backupCodes: string[];
+}
+
+/**
+ * Create a server-side setup session.
+ * Returns a setupToken (opaque handle) plus the QR code and plaintext backup
+ * codes for display. The secret and hashed codes are held server-side and
+ * never travel back from the client.
+ */
+export async function prepareTotpSetup(): Promise<TotpSetupData> {
+  pruneExpiredSetupSessions();
+  const secret = generateTotpSecret();
+  const qrCodeDataUrl = await generateQrCodeDataUrl(secret);
+  const { plain: backupCodes, hashed: hashedBackupCodes } = generateBackupCodes();
+  // Register secret value to be redacted in logs
+  registerSecretValue(secret);
+
+  const setupToken = crypto.randomBytes(32).toString("hex");
+  setupSessions.set(setupToken, {
+    secret,
+    hashedBackupCodes,
+    expiresAt: Date.now() + SETUP_SESSION_TTL_MS,
+  });
+
+  return { setupToken, secret, qrCodeDataUrl, backupCodes };
+}
+
+/**
+ * Persist TOTP config after the user has confirmed their code.
+ * Looks up the server-side setup session by setupToken, verifies the code,
+ * then encrypts the secret and stores the pre-computed hashed backup codes.
+ * Returns false if the setupToken is unknown/expired or the code is invalid.
+ */
+export function confirmTotpSetup(setupToken: string, code: string): boolean {
+  pruneExpiredSetupSessions();
+  const session = setupSessions.get(setupToken);
+  if (!session || session.expiresAt < Date.now()) {
+    setupSessions.delete(setupToken);
+    return false;
+  }
+
+  if (!verifyTotpCode(session.secret, code)) {
+    return false;
+  }
+
+  setupSessions.delete(setupToken);
+
+  const { ciphertext, iv, authTag } = encryptSecret(session.secret);
+  const config: TotpConfig = {
+    enabled: true,
+    encryptedSecret: ciphertext,
+    iv,
+    authTag,
+    backupCodes: session.hashedBackupCodes,
+    enabledAt: new Date().toISOString(),
+  };
+  saveTotpConfig(config);
+  registerSecretValue(session.secret);
+  logger.info("[AUDIT] TOTP enabled");
+  return true;
+}
+
+/** Disable TOTP and remove all stored config. */
+export function disableTotp(): void {
+  const secret = loadDecryptedSecret();
+  if (secret) unregisterSecretValue(secret);
+  clearTotpConfig();
+  logger.info("[AUDIT] TOTP disabled");
+}
+
+/**
+ * Regenerate backup codes. Persists the new hashed codes to config.
+ * Returns the new plaintext codes for display.
+ */
+export function regenerateBackupCodes(): string[] {
+  const config = loadTotpConfig();
+  if (!config?.enabled) throw new Error("TOTP is not enabled");
+  const { plain, hashed } = generateBackupCodes();
+  saveTotpConfig({ ...config, backupCodes: hashed });
+  return plain;
+}


### PR DESCRIPTION
## Summary

Extends `src/auth.ts` with TOTP 2FA support and adds the TOTP route:

**auth.ts additions:**
- `signUserToken()`: 24-hour user token (for login + TOTP second-step)
- `generatePendingToken()` / `verifyPendingToken()`: 5-minute pending token for TOTP second factor
- `requireNotPendingToken` middleware: explicit guard for routes requiring full auth
- `requireNotAgentService` middleware: moved here from inline (Fanbot split)
- `authMiddleware`: adds `/api/auth/totp/verify` carve-out (pending tokens only); blocks `x-api-key` when TOTP is active

**routes/totp.ts:** `POST /api/auth/totp/setup` (generate secret+QR), `POST /api/auth/totp/confirm`, `POST /api/auth/totp/verify` (second factor), `POST /api/auth/totp/disable`, `POST /api/auth/totp/backup-codes`, `GET /api/auth/totp/status`.

**server.ts:** mounts `createTotpRouter()`.

deps: PR #158 (otplib/qrcode), PR #138 (shared/types)

Zero fanbot/fanvue refs. Existing auth tests: all 19 pass.

## Test plan
- [x] `npm test` passes (414 tests, auth.test.ts 19/19)
- [x] `npx biome check .` clean