### PR TITLE
feat: add missing exports needed by Phases B/C (hotfix)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -158,3 +158,14 @@ export function requireHumanUser(req: Request, res: Response, next: NextFunction
   }
   next();
 }
+
+/** Middleware that blocks requests from agent-service tokens.
+ *  Use this to protect operations that should only be callable by human users. */
+export function requireNotAgentService(req: Request, res: Response, next: NextFunction): void {
+  const user = (req as AuthenticatedRequest).user;
+  if (!user || user.sub === "agent-service") {
+    res.status(403).json({ error: "This operation is not allowed for agent service tokens" });
+    return;
+  }
+  next();
+}

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 /**
  * Return the absolute path of the shared context directory.
  *
@@ -8,4 +9,19 @@
  */
 export function getContextDir(): string {
   return process.env.SHARED_CONTEXT_DIR || "/shared-context";
+}
+
+/**
+ * Validate that a context file name is safe to read/write.
+ * Rejects path traversal attempts and names that resolve outside contextDir.
+ *
+ * @returns The resolved absolute path, or null if the name is invalid.
+ */
+export function validateContextPath(contextDir: string, name: string): string | null {
+  if (name.includes("..")) return null;
+  const filepath = path.resolve(path.join(contextDir, name));
+  if (!filepath.startsWith(path.resolve(contextDir) + path.sep) && filepath !== path.resolve(contextDir)) {
+    return null;
+  }
+  return filepath;
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -202,3 +202,8 @@ export function validatePatchAgent(req: Request, res: Response, next: NextFuncti
   req.body = sanitized;
   next();
 }
+
+/** Sanitize a repository name: alphanumeric, hyphens, underscores only. */
+export function sanitizeRepoName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_-]/g, "");
+}


### PR DESCRIPTION
## Summary

Adds three small exports that several Phase B/C PRs depend on but were missing from AM main:

- `src/auth.ts`: `requireNotAgentService` middleware (blocks agent-service tokens from operator-only routes). Used by #141, #148, #150, #159.
- `src/validation.ts`: `sanitizeRepoName(name)` — strips non-alphanumeric/hyphen/underscore chars. Used by #148, #150.
- `src/utils/context.ts`: `validateContextPath(contextDir, name)` — rejects path traversal, returns resolved path or null. Used by #153.

These are all tiny additions (~5-15 lines each). Prerequisite for:
- #141 (context-policy route) — needs `requireNotAgentService`
- #148 (repo-gate-config route) — needs both `requireNotAgentService` and `sanitizeRepoName`
- #150 (merge-gate route) — needs `requireNotAgentService` and `sanitizeRepoName`
- #153 (startup route) — needs `validateContextPath`

Zero fanbot/fanvue refs.

## Test plan
- [x] `npm test` passes (414 tests)
- [x] `npx biome check .` clean