### PR TITLE
feat: add workflow pure-logic modules (PR 19)

### DIFF
--- a/src/workflow-audit.ts
+++ b/src/workflow-audit.ts
@@ -1,0 +1,44 @@
+import { logger } from "./logger";
+
+/**
+ * Workflow credential access audit trail.
+ *
+ * Logs structured [AUDIT] entries for every credential lifecycle event so that
+ * operators can trace exactly when and how credentials were created, read,
+ * injected into agent environments, or deleted.
+ *
+ * All events are emitted through the existing logger so they appear in the
+ * same log stream as other server activity (JSON in production, coloured text
+ * in development) and can be filtered with standard tooling.
+ */
+
+export type CredentialEventType = "create" | "read" | "inject" | "delete";
+
+export interface CredentialAccessEvent {
+  /** Type of operation performed on the credential. */
+  eventType: CredentialEventType;
+  /** Service / integration the credential belongs to (e.g. "github", "linear"). */
+  service: string;
+  /** Agent that performed the operation, if applicable. */
+  agentId?: string;
+  /** Workflow context this credential access belongs to, if applicable. */
+  workflowId?: string;
+  /** Caller location for traceability (e.g. "workflow-credentials:saveWorkflowCredentials"). */
+  caller?: string;
+}
+
+/**
+ * Log a credential access event to the audit trail.
+ *
+ * Example output (production JSON):
+ *   {"level":"info","timestamp":"...","message":"[AUDIT] credential.create","service":"github","workflowId":"abc123","caller":"workflow-credentials:save"}
+ */
+export function logCredentialAccess(event: CredentialAccessEvent): void {
+  const { eventType, service, agentId, workflowId, caller } = event;
+  logger.info(`[AUDIT] credential.${eventType}`, {
+    service,
+    ...(agentId !== undefined && { agentId }),
+    ...(workflowId !== undefined && { workflowId }),
+    ...(caller !== undefined && { caller }),
+  });
+}

--- a/src/workflow-grading.ts
+++ b/src/workflow-grading.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure grading gate logic for BKL-020 Basic mode confidence grading.
+ * All functions are pure (no I/O, no side effects).
+ * Reuses GradeResult from grading.ts — do NOT redefine.
+ *
+ * Invariant: workflow grade gates PR creation. CI confidence label gates merge. Neither reads the other's store.
+ */
+
+import type { GradeResult } from "./grading";
+
+/**
+ * Gate decision based on overall risk.
+ * low/medium → CREATE_PR; high → NEEDS_HUMAN (withhold, no PR in v1).
+ * Gates on overallRisk (worst-case-axis rule from computeRisk), NOT numericScore.
+ */
+export function gradeGate(g: GradeResult): "CREATE_PR" | "NEEDS_HUMAN" {
+  if (g.overallRisk === "high") return "NEEDS_HUMAN";
+  return "CREATE_PR";
+}
+
+/**
+ * Invert numericScore to a display-safe confidence value where higher = better.
+ * grading.ts numericScore is 0-100 where higher = riskier.
+ * CRITICAL: overallRisk==='high' always yields confidence < 60 (the Medium threshold).
+ */
+export function confidenceFromGrade(g: GradeResult): number {
+  return 100 - g.numericScore;
+}
+
+/** Build the prompt for the workflow grader agent (Opus, maxTurns:12, read-only). */
+export function buildGraderPrompt(workflowId: string, ticketUrl: string): string {
+  return `You are a workflow grader (READ-ONLY). Assess completed engineering work against the original ticket.
+
+Workflow: ${workflowId} | Ticket: ${ticketUrl}
+
+READ-ONLY: use git diff/log/show + /linear MCP. Do NOT make code changes, create PRs, or run mutating commands.
+
+1. Read the Linear ticket for acceptance criteria.
+2. Review the git diff and test results.
+3. Grade along three axes:
+   - ticketClarity: how well-specified was the ticket? (high/medium/low)
+   - fixConfidence: does the implementation correctly solve it? (high/medium/low)
+   - blastRadius: how much of the system is affected? (isolated/moderate/broad)
+4. Post ONE result with metadata:
+{"workflowId":"${workflowId}","workflowGrade":{"graderAgentId":"<YOUR AGENT ID from CLAUDE.md>","ticketClarity":"...","fixConfidence":"...","blastRadius":"...","reasoning":"2-3 sentences"}}
+Be conservative — grade lower when uncertain. A false high-confidence grade is a P0. Then stop.`;
+}

--- a/src/workflow-resource-manager.ts
+++ b/src/workflow-resource-manager.ts
@@ -1,0 +1,144 @@
+/**
+ * Workflow Resource Manager
+ *
+ * Infrastructure-level protections for Linear workflow runs:
+ * - INF-1: Cost cap enforcement — halt workflow agents when actual cost exceeds 2× the estimate
+ * - INF-3: Stall detection — detect when all workflow agents have been idle for >10 minutes
+ * - INF-4: Resource budgeting — system memory threshold and per-workflow agent limits
+ *
+ * These are pure functions designed to be called from the workflow router's periodic watchdog.
+ * They do not modify state directly; callers provide callbacks for side effects.
+ */
+
+import type { AgentManager } from "./agents";
+import { CONFIG } from "./config";
+import { logger } from "./logger";
+import { getContainerMemoryLimit, getContainerMemoryUsage } from "./utils/memory";
+
+/** Max agents allowed per workflow (default 10). Override via WORKFLOW_MAX_AGENTS env var. */
+export const WORKFLOW_MAX_AGENTS = Number(process.env.WORKFLOW_MAX_AGENTS ?? "10");
+
+/** Halt workflow when actual cost reaches this multiple of the cost estimate. */
+export const WORKFLOW_COST_CAP_MULTIPLIER = 2.0;
+
+/**
+ * Duration (ms) all agents must be inactive before declaring a workflow stalled.
+ * Default: 10 minutes. Override via WORKFLOW_STALL_TIMEOUT_MS env var.
+ */
+export const WORKFLOW_STALL_TIMEOUT_MS = Number(process.env.WORKFLOW_STALL_TIMEOUT_MS ?? String(10 * 60_000));
+
+/**
+ * INF-4: Check container/system memory before starting a new workflow.
+ * Uses cgroup v2 memory stats (accurate container-level usage including child processes).
+ * Returns an error message if usage exceeds MEMORY_REJECT_THRESHOLD, null if OK.
+ */
+export function checkMemoryForNewWorkflow(): string | null {
+  const used = getContainerMemoryUsage();
+  const limit = getContainerMemoryLimit();
+  const ratio = used / limit;
+  if (ratio > CONFIG.MEMORY_REJECT_THRESHOLD) {
+    return (
+      `System memory at ${Math.round(ratio * 100)}% ` +
+      `(threshold: ${Math.round(CONFIG.MEMORY_REJECT_THRESHOLD * 100)}%). ` +
+      "Cannot start new workflow."
+    );
+  }
+  return null;
+}
+
+/**
+ * INF-4: Check per-workflow agent count before spawning another agent.
+ * Returns an error message if the limit is reached, null if OK.
+ */
+export function checkWorkflowAgentLimit(currentCount: number, max = WORKFLOW_MAX_AGENTS): string | null {
+  if (currentCount >= max) {
+    return `Workflow agent limit reached (${currentCount}/${max}).`;
+  }
+  return null;
+}
+
+/**
+ * INF-1: Compute the total actual cost for a set of agent IDs by summing
+ * each agent's usage.estimatedCost from the AgentManager registry.
+ * Agents not found in the registry (destroyed) contribute 0.
+ */
+export function computeWorkflowActualCost(agentIds: string[], agentManager: AgentManager): number {
+  let total = 0;
+  for (const agentId of agentIds) {
+    total += agentManager.get(agentId)?.usage?.estimatedCost ?? 0;
+  }
+  return total;
+}
+
+/**
+ * INF-1: Enforce workflow cost cap.
+ * Computes actual cost for all agent IDs; if it meets or exceeds
+ * WORKFLOW_COST_CAP_MULTIPLIER × costEstimate, invokes onCap.
+ * No-op when costEstimate <= 0 (no estimate available, cap disabled).
+ */
+export function enforceWorkflowCostCap(
+  workflowId: string,
+  agentIds: string[],
+  costEstimate: number,
+  agentManager: AgentManager,
+  onCap: (workflowId: string, actualCost: number, cap: number) => void,
+): void {
+  if (costEstimate <= 0) return;
+  const actual = computeWorkflowActualCost(agentIds, agentManager);
+  const cap = costEstimate * WORKFLOW_COST_CAP_MULTIPLIER;
+  if (actual >= cap) {
+    logger.warn("[workflow-guard] INF-1: Workflow cost cap exceeded", {
+      workflowId,
+      actualCost: actual.toFixed(4),
+      cap: cap.toFixed(4),
+      multiplier: WORKFLOW_COST_CAP_MULTIPLIER,
+    });
+    onCap(workflowId, actual, cap);
+  }
+}
+
+/**
+ * INF-3: Detect whether all live agents in a workflow have been idle for
+ * longer than WORKFLOW_STALL_TIMEOUT_MS.
+ *
+ * "Live" means the agent still exists in the AgentManager registry; destroyed agents
+ * are skipped. If any agent is actively running or starting, returns false.
+ * Returns true and invokes onStall if a stall is detected.
+ */
+export function detectWorkflowStall(
+  workflowId: string,
+  agentIds: string[],
+  agentManager: AgentManager,
+  onStall: (workflowId: string, idleMs: number) => void,
+): boolean {
+  if (agentIds.length === 0) return false;
+
+  const now = Date.now();
+  let oldestIdleAt = now;
+  let liveAgents = 0;
+
+  for (const agentId of agentIds) {
+    const agent = agentManager.get(agentId);
+    if (!agent) continue; // agent was destroyed — skip
+    liveAgents++;
+
+    if (agent.status === "running" || agent.status === "starting") return false;
+
+    const lastActivity = new Date(agent.lastActivity).getTime();
+    if (lastActivity < oldestIdleAt) oldestIdleAt = lastActivity;
+  }
+
+  if (liveAgents === 0) return false;
+
+  const idleMs = now - oldestIdleAt;
+  if (idleMs > WORKFLOW_STALL_TIMEOUT_MS) {
+    logger.warn("[workflow-guard] INF-3: Stalled workflow detected", {
+      workflowId,
+      idleForSec: Math.round(idleMs / 1000),
+      liveAgents,
+    });
+    onStall(workflowId, idleMs);
+    return true;
+  }
+  return false;
+}

--- a/src/workflow-triage.ts
+++ b/src/workflow-triage.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure triage logic for BKL-020 Basic mode ticket validation.
+ *
+ * All functions are pure (no I/O, no side effects) so they can be unit-tested
+ * independently of the workflow wiring in routes/workflows.ts.
+ *
+ * Rubric (§5d): agent evaluates 5 boolean checks; backend computes clarity.
+ * This keeps thresholds out of the prompt and prevents agents from self-grading.
+ */
+
+export interface TriageChecks {
+  /** Real content that differs from the title and contains a verb/outcome */
+  substance: boolean;
+  /** A discernible "what should change" (outcome/behavior, not just a symptom) */
+  goalClarity: boolean;
+  /** Acceptance criteria / checklist / "done when" / expected behavior / repro steps */
+  doneDef: boolean;
+  /** Bounds the work: which area/feature/file/flow */
+  scopeSignal: boolean;
+  /** A request to BUILD/FIX — not a question, poll, discussion, or open design debate */
+  actionability: boolean;
+}
+
+export interface ValidationResult {
+  verdict: "accept" | "accept_with_caveats" | "reject";
+  clarity: "high" | "medium" | "low";
+  missing: string[];
+  suggestions: string[];
+  readError?: "not_found" | "forbidden" | "auth_failed" | "rate_limited" | "multi_issue_empty";
+  evaluatedAt: string;
+}
+
+/**
+ * Compute ticket clarity from triage check booleans.
+ *
+ * Hard failures (→ low):
+ *   !actionability OR !substance
+ * Require at least one of {doneDef, scopeSignal} to proceed beyond reject.
+ * sat = count of {goalClarity, doneDef, scopeSignal} that are true:
+ *   sat>=2 && (doneDef||scopeSignal) → high
+ *   sat==1 && (doneDef||scopeSignal) → medium
+ *   else → low
+ */
+export function clarityFromChecks(c: TriageChecks): "high" | "medium" | "low" {
+  if (!c.actionability || !c.substance) return "low";
+  if (!c.doneDef && !c.scopeSignal) return "low";
+  const sat = [c.goalClarity, c.doneDef, c.scopeSignal].filter(Boolean).length;
+  if (sat >= 2) return "high";
+  if (sat === 1) return "medium";
+  return "low";
+}
+
+/**
+ * Map clarity level to a triage verdict.
+ * high → accept, medium → accept_with_caveats, low → reject
+ */
+export function verdictFromClarity(clarity: "high" | "medium" | "low"): "accept" | "accept_with_caveats" | "reject" {
+  if (clarity === "high") return "accept";
+  if (clarity === "medium") return "accept_with_caveats";
+  return "reject";
+}
+
+/**
+ * Build a ValidationResult, injecting generic copy if missing/suggestions are empty on reject.
+ */
+export function buildValidationResult(
+  _checks: TriageChecks,
+  verdict: "accept" | "accept_with_caveats" | "reject",
+  clarity: "high" | "medium" | "low",
+  missing: string[] = [],
+  suggestions: string[] = [],
+  readError?: ValidationResult["readError"],
+): ValidationResult {
+  let resolvedMissing = missing;
+  let resolvedSuggestions = suggestions;
+
+  if (verdict === "reject" && resolvedMissing.length === 0) {
+    resolvedMissing = ["Ticket did not meet the detail rubric"];
+  }
+  if (verdict === "reject" && resolvedSuggestions.length === 0) {
+    resolvedSuggestions = ["Add a description, acceptance criteria, and the affected area"];
+  }
+
+  return {
+    verdict,
+    clarity,
+    missing: resolvedMissing,
+    suggestions: resolvedSuggestions,
+    ...(readError ? { readError } : {}),
+    evaluatedAt: new Date().toISOString(),
+  };
+}
+
+/** Build the prompt for the triage agent (Haiku, maxTurns:15). */
+export function buildTriagePrompt(ticketUrl: string, workflowId: string): string {
+  return `You are a ticket-detail triage agent. Read the Linear ticket, evaluate 5 boolean checks, then POST a verdict message. Posting the verdict is your most important job — if you run low on turns, post your best-effort verdict immediately rather than continuing to read.
+
+Ticket: ${ticketUrl} | Workflow: ${workflowId}
+
+1. Read the ticket via the /linear MCP tools. On 403/404 set readError "not_found"/"forbidden"; auth fail → "auth_failed"; rate limit → "rate_limited". On ANY read error, set all 5 checks to false and still post (with the readError) — do NOT retry reads in a loop.
+2. Evaluate honestly (conservative — false positives waste budget):
+   - substance: description has real content differing from title with a verb/outcome
+   - goalClarity: discernible "what should change" (outcome, not just symptom)
+   - doneDef: acceptance criteria / "done when" / expected behavior / repro steps
+   - scopeSignal: bounds the work — names area, feature, file, or flow
+   - actionability: request to BUILD or FIX — not a question, poll, or discussion
+3. Post EXACTLY ONE message to the platform message bus with your verdict in the metadata field. Run this curl with Bash, substituting your real values:
+
+   curl -s --max-time 10 -X POST "http://localhost:\${PORT}/api/messages" \\
+     -H "Authorization: Bearer $(cat \${WORKSPACE}/.agent-token)" \\
+     -H "Content-Type: application/json" \\
+     -d '{"from":"<YOUR_AGENT_ID>","fromName":"workflow-triage","type":"result","content":"triage verdict","metadata":{"workflowId":"${workflowId}","triageVerdict":{"checks":{"substance":false,"goalClarity":false,"doneDef":false,"scopeSignal":false,"actionability":false},"missing":[],"suggestions":[],"readError":"omit this key entirely if there was no read error"}}}'
+
+   CRITICAL details (the backend silently drops the verdict otherwise):
+   - Use plain http:// (the local server is NOT https — https gives an SSL/EPROTO error).
+   - "from" is REQUIRED and MUST be YOUR OWN agent ID. Find it on the "**ID:**" line in your CLAUDE.md (the workspace path also contains it: /tmp/workspace-<YOUR_AGENT_ID>). A "from" that is missing or not your ID is rejected.
+   - \${PORT} and \${WORKSPACE} are set in your environment / shown in your CLAUDE.md API section. If a curl fails, check the response body and fix it — you have turns to retry the POST.
+   - Set each check to the literal true/false you decided. Replace missing/suggestions with real arrays (use them to explain a low-clarity ticket). Omit the "readError" key entirely when there was no read error.
+
+Do NOT self-assess clarity or verdict — the backend computes them from your 5 booleans. After the POST returns success, stop.`;
+}

--- a/src/workflow-validators.ts
+++ b/src/workflow-validators.ts
@@ -1,0 +1,305 @@
+/**
+ * Workflow Validators & Parsers
+ *
+ * Pure functions for validating and parsing inputs used in Linear workflow automation.
+ * VP-1: parseLinearUrl       — comprehensive URL parsing with validation
+ * VP-2: validateGitHubPatScopes — GitHub PAT scope verification (repo access)
+ * VP-3: validateLinearApiKey — Linear API key format + auth check
+ * VP-4: estimateWorkflowCost — cost estimation by issue size and model
+ */
+
+import { type AllowedModel, DEFAULT_MODEL, MODELS } from "./models";
+import { validateToken } from "./token-validation";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ParsedLinearUrl {
+  issueId: string;
+  team: string;
+  workspace: string;
+  /** Canonical safe URL, reconstructed from parsed parts (query params/fragments stripped) */
+  safeUrl: string;
+}
+
+/** Typed error codes for parseLinearUrl failures — used by the frontend to map to specific copy */
+export type LinearUrlErrorCode =
+  | "EMPTY"
+  | "INVALID_FORMAT"
+  | "NOT_HTTPS"
+  | "WRONG_DOMAIN"
+  | "INVALID_PATH"
+  | "INVALID_WORKSPACE"
+  | "INVALID_ISSUE_ID";
+
+export type LinearUrlParseResult =
+  | { ok: true; parsed: ParsedLinearUrl }
+  | { ok: false; code: LinearUrlErrorCode; error: string };
+
+export interface GitHubPatValidationResult {
+  valid: boolean;
+  login?: string;
+  scopes?: string[];
+  missingScopes?: string[];
+  error?: string;
+}
+
+export interface LinearApiKeyValidationResult {
+  valid: boolean;
+  user?: string;
+  error?: string;
+}
+
+export type IssueSize = "XS" | "S" | "M" | "L" | "XL";
+
+/** All supported models for workflow cost estimation. Alias for AllowedModel in the central MODELS registry. */
+export type SupportedModel = AllowedModel;
+
+export interface CostEstimate {
+  size: IssueSize;
+  model: SupportedModel;
+  agentCount: number;
+  minCostUsd: number;
+  maxCostUsd: number;
+  /** Human-readable signals describing the issue size characteristics */
+  signals: string[];
+}
+
+// ─── VP-1: Linear URL Parser ─────────────────────────────────────────────────
+
+/** Workspace slug: must start with alphanumeric, then alphanumeric or hyphens */
+const WORKSPACE_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/;
+
+/** Issue ID: uppercase letters then digits, e.g. ENG-123, MYTEAM-4567 */
+const ISSUE_ID_RE = /^[A-Z][A-Z0-9]*-\d+$/;
+
+/**
+ * VP-1: Parse and validate a Linear issue URL.
+ *
+ * Accepts:  https://linear.app/{workspace}/issue/{TEAM-NNN}
+ * Strips:   query parameters, URL fragments
+ * Rejects:  http://, spoofed domains, missing or malformed path segments
+ *
+ * The returned `safeUrl` is canonical and safe to embed in agent prompts.
+ */
+export function parseLinearUrl(rawUrl: string): LinearUrlParseResult {
+  if (!rawUrl || typeof rawUrl !== "string") {
+    return { ok: false, code: "EMPTY", error: "URL is required" };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(rawUrl.trim());
+  } catch {
+    return { ok: false, code: "INVALID_FORMAT", error: "Invalid URL format" };
+  }
+
+  if (url.protocol !== "https:") {
+    return { ok: false, code: "NOT_HTTPS", error: "URL must use HTTPS" };
+  }
+
+  // Strict hostname check: must be exactly linear.app
+  // This rejects linear.app.evil.com, app.linear.app, etc.
+  if (url.hostname !== "linear.app") {
+    return { ok: false, code: "WRONG_DOMAIN", error: "URL host must be linear.app" };
+  }
+
+  // Normalise path: strip trailing slash, then split into segments
+  const pathname = url.pathname.replace(/\/$/, "");
+  const segments = pathname.split("/");
+  // Expected: ["", workspace, "issue", issueId] → length 4
+  if (segments.length !== 4 || segments[2] !== "issue") {
+    return {
+      ok: false,
+      code: "INVALID_PATH",
+      error: "Invalid Linear URL path. Expected: https://linear.app/{workspace}/issue/{TEAM-NNN}",
+    };
+  }
+
+  const workspace = segments[1];
+  const rawIssueId = segments[3];
+
+  if (!workspace || !WORKSPACE_RE.test(workspace)) {
+    return { ok: false, code: "INVALID_WORKSPACE", error: "Invalid workspace slug in URL" };
+  }
+
+  // Normalise to uppercase before format validation
+  const issueId = rawIssueId.toUpperCase();
+  if (!ISSUE_ID_RE.test(issueId)) {
+    return {
+      ok: false,
+      code: "INVALID_ISSUE_ID",
+      error: "Invalid issue ID format. Expected TEAM-NNN (e.g. ENG-123)",
+    };
+  }
+
+  const team = issueId.split("-")[0];
+  // Reconstruct canonical URL — drops query params, fragments and normalises case
+  const safeUrl = `https://linear.app/${workspace}/issue/${issueId}`;
+
+  return { ok: true, parsed: { issueId, team, workspace, safeUrl } };
+}
+
+// ─── VP-2: GitHub PAT Scope Validation ───────────────────────────────────────
+
+/**
+ * Scopes that grant PR creation access.
+ * `repo` covers private repos; `public_repo` is sufficient for public repos.
+ * Fine-grained PATs expose `pull_requests:write` and `contents:write` instead.
+ */
+const ACCEPTABLE_REPO_SCOPES = ["repo", "public_repo"] as const;
+
+/**
+ * VP-2: Validate a GitHub Personal Access Token and verify it has PR-creation scopes.
+ *
+ * Makes one call to https://api.github.com/user to authenticate the token and reads
+ * the `x-oauth-scopes` response header. Verifies that at least `repo` or `public_repo`
+ * is granted (required for `gh pr create`).
+ */
+export async function validateGitHubPatScopes(token: string): Promise<GitHubPatValidationResult> {
+  if (!token || typeof token !== "string") {
+    return { valid: false, error: "Token is required" };
+  }
+
+  // Format check: classic PATs → ghp_, fine-grained → github_pat_
+  if (!/^(ghp_|github_pat_)[A-Za-z0-9_]+$/.test(token)) {
+    return {
+      valid: false,
+      error: "Token does not appear to be a GitHub PAT (expected ghp_ or github_pat_ prefix)",
+    };
+  }
+
+  const result = await validateToken("github", token);
+  if (!result.valid) {
+    return { valid: false, error: result.error ?? "GitHub authentication failed" };
+  }
+
+  const scopes = result.scopes ?? [];
+  const hasRepoAccess = ACCEPTABLE_REPO_SCOPES.some((s) => scopes.includes(s));
+
+  if (!hasRepoAccess) {
+    const missingScopes = ["repo"];
+    return {
+      valid: false,
+      login: result.user,
+      scopes,
+      missingScopes,
+      error: `Token is missing required scope: repo. Current scopes: ${scopes.join(", ") || "(none)"}. Add the 'repo' scope and regenerate the token.`,
+    };
+  }
+
+  return { valid: true, login: result.user, scopes };
+}
+
+// ─── VP-3: Linear API Key Validation ─────────────────────────────────────────
+
+/**
+ * Linear API keys follow the pattern:  lin_api_<32+ alphanumeric chars>
+ * Reference: https://linear.app/settings/api
+ */
+const LINEAR_API_KEY_RE = /^lin_api_[A-Za-z0-9]{32,}$/;
+
+/**
+ * VP-3: Validate a Linear API key.
+ *
+ * First checks the `lin_api_` prefix and minimum length, then verifies
+ * authentication via the Linear GraphQL viewer query.
+ */
+export async function validateLinearApiKey(token: string): Promise<LinearApiKeyValidationResult> {
+  if (!token || typeof token !== "string") {
+    return { valid: false, error: "Token is required" };
+  }
+
+  if (!LINEAR_API_KEY_RE.test(token)) {
+    return {
+      valid: false,
+      error: 'Linear API key must start with "lin_api_" followed by at least 32 alphanumeric characters',
+    };
+  }
+
+  const result = await validateToken("linear", token);
+  if (!result.valid) {
+    return { valid: false, error: result.error ?? "Linear API authentication failed" };
+  }
+
+  return { valid: true, user: result.user };
+}
+
+// ─── VP-4: Cost Estimation ────────────────────────────────────────────────────
+
+/**
+ * Base cost ranges in USD for Sonnet 4.6 (from empirical token estimates in cost analysis research).
+ * Source: shared-context/research/linear-workflow/cost-analysis.md §3.4 Per-Issue Sizing Guide
+ */
+const SIZE_BASE_COSTS: Record<IssueSize, { minUsd: number; maxUsd: number; agentCount: number; signals: string[] }> = {
+  XS: {
+    minUsd: 0.05,
+    maxUsd: 0.3,
+    agentCount: 1,
+    signals: ["Single function or trivial change", "Known solution path, no exploration needed"],
+  },
+  S: {
+    minUsd: 0.2,
+    maxUsd: 0.8,
+    agentCount: 2,
+    signals: ["1–3 files to change", "Clear specification with well-defined scope"],
+  },
+  M: {
+    minUsd: 0.8,
+    maxUsd: 3.0,
+    agentCount: 4,
+    signals: ["5–10 files to change", "Some codebase exploration needed"],
+  },
+  L: {
+    minUsd: 2.5,
+    maxUsd: 7.0,
+    agentCount: 6,
+    signals: ["Multi-module changes", "Architecture decision or significant refactor required"],
+  },
+  XL: {
+    minUsd: 6.0,
+    maxUsd: 20.0,
+    agentCount: 10,
+    signals: ["Cross-system feature or epic", "Requires multiple sub-issue implementations"],
+  },
+};
+
+/**
+ * Cost multiplier relative to Sonnet 4.6 baseline (= 1.0), derived from the MODELS registry.
+ * Blended-rate method: 0.8×input + 0.2×output per million tokens.
+ *   Sonnet 4.6:  0.8×$3.0 + 0.2×$15.0 = $5.40/MTok  → 1.00×
+ *   Haiku 4.5:   0.8×$1.0 + 0.2×$5.0  = $1.80/MTok  → 0.33×
+ *   Opus 4.6:    0.8×$5.0 + 0.2×$25.0 = $9.00/MTok  → 1.67×
+ */
+const MODEL_COST_MULTIPLIERS: Record<SupportedModel, number> = Object.fromEntries(
+  Object.entries(MODELS).map(([id, m]) => [id, m.costMultiplier]),
+) as Record<SupportedModel, number>;
+
+/**
+ * VP-4: Estimate the cost of a workflow run given issue size and model.
+ *
+ * Returns a min/max cost range in USD. Base ranges are calibrated for Sonnet 4.6
+ * and scaled proportionally for other models using blended token pricing.
+ *
+ * @param size   Issue size label (XS / S / M / L / XL)
+ * @param model  Claude model to use (defaults to the platform DEFAULT_MODEL)
+ */
+/** Safety buffer applied on top of model-scaled base costs to account for estimation uncertainty */
+const COST_BUFFER_MULTIPLIER = 1.2;
+
+export function estimateWorkflowCost(size: IssueSize, model: SupportedModel = DEFAULT_MODEL): CostEstimate {
+  const base = SIZE_BASE_COSTS[size];
+  const multiplier = MODEL_COST_MULTIPLIERS[model];
+
+  // Round to 2 decimal places for display; 1.2× buffer applied for estimation uncertainty
+  const minCostUsd = Math.round(base.minUsd * multiplier * COST_BUFFER_MULTIPLIER * 100) / 100;
+  const maxCostUsd = Math.round(base.maxUsd * multiplier * COST_BUFFER_MULTIPLIER * 100) / 100;
+
+  return {
+    size,
+    model,
+    agentCount: base.agentCount,
+    minCostUsd,
+    maxCostUsd,
+    signals: base.signals,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the pure-logic layer of the workflow engine (no storage, no server.ts changes):

- `workflow-triage.ts` (121L): Linear issue triage — classifies issues into workflow types
- `workflow-grading.ts` (47L): PR grading helpers for workflow scoring
- `workflow-audit.ts` (44L): Audit log entry creation for workflow lifecycle events
- `workflow-validators.ts` (305L): Input validation for workflow create/update requests — validates model names against `MODELS` registry (dep: PR #136 models.ts)
- `workflow-resource-manager.ts` (144L): Agent spawn budget and concurrency management for workflow runs

deps: PR #136 (models.ts — needed by workflow-validators.ts for model validation)

Zero fanbot/fanvue refs. ~661 lines total across 5 files.

## Test plan
- [x] `npm test` passes (414 tests)
- [x] `npx biome check .` clean