### PR TITLE
fix(ci): pin trivy-action to v0.36.0 to fix Container Image Scan

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -27,7 +27,7 @@ jobs:
 
       # JSON report - full severity range, saved as CI artifact
       - name: Run Trivy scan (JSON report)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: agent-manager:${{ github.sha }}
           format: json
@@ -39,7 +39,7 @@ jobs:
 
       # Table report - human-readable output; exits 1 if CRITICAL or HIGH found -> fails the build
       - name: Run Trivy scan (fail on CRITICAL/HIGH)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         env:
           TRIVY_FORMAT: table
           TRIVY_OUTPUT: ""


### PR DESCRIPTION
## Summary
The `Trivy Container Scan` workflow on `main` fails at setup with:
`Unable to resolve action aquasecurity/trivy-action@0.28.0, unable to find version 0.28.0`.

This pins `aquasecurity/trivy-action` to the `v0.36.0` tag (2 occurrences) — the same fix already applied in the sibling repo. No other changes; the `agent-manager:` image tag and all scan settings are unchanged.

## Test plan
- [ ] Container Image Vulnerability Scan workflow resolves the action and runs to completion on this PR / on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)