### PR TITLE
feat: add workflow-credentials (PR 21)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -35,6 +35,7 @@ import { createSchedulerRouter } from "./src/routes/scheduler";
 import { createStartupRouter } from "./src/routes/startup";
 import { createTasksRouter } from "./src/routes/tasks";
 import { createUsageRouter } from "./src/routes/usage";
+import { createWorkflowCredentialsRouter } from "./src/routes/workflow-credentials";
 import { createWorkflowsRouter } from "./src/routes/workflows";
 import { Scheduler } from "./src/scheduler";
 import { loadSecretsIntoEnv } from "./src/secrets-store";
@@ -221,6 +222,7 @@ app.use(createStartupRouter(agentManager, messageBus));
 app.use("/api/agents", hookConfigRouter);
 app.use(createHooksRouter(agentManager));
 app.use(createPullRequestsRouter(agentManager));
+app.use(createWorkflowCredentialsRouter());
 // Layer 1: Kill switch endpoint (no extra auth beyond authMiddleware above)
 app.use(createKillSwitchRouter(agentManager));
 

--- a/src/routes/workflow-credentials.test.ts
+++ b/src/routes/workflow-credentials.test.ts
@@ -1,0 +1,130 @@
+import http from "node:http";
+import express from "express";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createWorkflowCredentialsRouter } from "./workflow-credentials";
+
+vi.mock("../auth", () => ({
+  requireNotAgentService: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock("../sanitize", () => ({
+  registerSecretValue: vi.fn(),
+}));
+
+vi.mock("../token-validation", () => ({
+  validateToken: vi.fn().mockResolvedValue({ valid: true, user: "test-user" }),
+}));
+
+function request(
+  method: string,
+  url: string,
+  body?: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const payload = body ? JSON.stringify(body) : undefined;
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname,
+        method,
+        headers: {
+          "content-type": "application/json",
+          ...(payload ? { "content-length": String(Buffer.byteLength(payload)) } : {}),
+        },
+      },
+      (res) => {
+        let raw = "";
+        res.on("data", (chunk: string) => (raw += chunk));
+        res.on("end", () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: JSON.parse(raw) });
+          } catch {
+            resolve({ status: res.statusCode ?? 0, body: { raw } });
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(
+  () =>
+    new Promise<void>((resolve) => {
+      const app = express();
+      app.use(express.json());
+      app.use(createWorkflowCredentialsRouter());
+      server = app.listen(0, "127.0.0.1", () => {
+        const addr = server.address() as { port: number };
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    }),
+);
+
+afterAll(() => {
+  server?.close();
+});
+
+const PATH = "/api/workflows/validate-credentials";
+
+describe("POST /api/workflows/validate-credentials — input validation", () => {
+  it("returns 400 when body is empty", async () => {
+    const { status, body } = await request("POST", `${baseUrl}${PATH}`, {});
+    expect(status).toBe(400);
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 400 for linearApiKey shorter than 8 chars", async () => {
+    const { status, body } = await request("POST", `${baseUrl}${PATH}`, { linearApiKey: "short" });
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/linearApiKey/);
+  });
+
+  it("returns 400 for linearApiKey that is not a string", async () => {
+    const { status, body } = await request("POST", `${baseUrl}${PATH}`, { linearApiKey: 12345 });
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/linearApiKey/);
+  });
+
+  it("returns 400 for githubPat shorter than 8 chars", async () => {
+    const { status, body } = await request("POST", `${baseUrl}${PATH}`, { githubPat: "tooshrt" });
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/githubPat/);
+  });
+});
+
+describe("POST /api/workflows/validate-credentials — valid credentials", () => {
+  it("returns 200 with valid:true for a valid linearApiKey", async () => {
+    const { status, body } = await request("POST", `${baseUrl}${PATH}`, {
+      linearApiKey: "lin_api_validkey_12345",
+    });
+    expect(status).toBe(200);
+    expect(body).toHaveProperty("results");
+  });
+
+  it("returns 200 with valid:true for a valid githubPat", async () => {
+    const { status, body } = await request("POST", `${baseUrl}${PATH}`, {
+      githubPat: "ghp_validpat_12345678",
+    });
+    expect(status).toBe(200);
+    expect(body).toHaveProperty("results");
+  });
+
+  it("validates both keys when both are provided", async () => {
+    const { status, body } = await request("POST", `${baseUrl}${PATH}`, {
+      linearApiKey: "lin_api_validkey_12345",
+      githubPat: "ghp_validpat_12345678",
+    });
+    expect(status).toBe(200);
+    expect(body.results).toHaveProperty("linear");
+    expect(body.results).toHaveProperty("github");
+  });
+});

--- a/src/routes/workflow-credentials.ts
+++ b/src/routes/workflow-credentials.ts
@@ -1,0 +1,92 @@
+import express, { type Request, type Response } from "express";
+import { requireNotAgentService } from "../auth";
+import { registerSecretValue } from "../sanitize";
+import { validateToken } from "../token-validation";
+import { errorMessage } from "../types";
+
+/**
+ * Routes for validating workflow credentials (Linear API key + GitHub PAT)
+ * before a workflow is started.
+ *
+ * CM-4: Token validation endpoints
+ */
+export function createWorkflowCredentialsRouter() {
+  const router = express.Router();
+
+  /**
+   * POST /api/workflows/validate-credentials
+   * Validate a Linear API key and/or GitHub PAT.
+   *
+   * Body: { linearApiKey?: string, githubPat?: string }
+   * Response: { valid: boolean, results: { linear?: ValidationResult, github?: ValidationResult } }
+   */
+  router.post("/api/workflows/validate-credentials", requireNotAgentService, async (req: Request, res: Response) => {
+    try {
+      const { linearApiKey, githubPat } = (req.body ?? {}) as {
+        linearApiKey?: unknown;
+        githubPat?: unknown;
+      };
+
+      if (!linearApiKey && !githubPat) {
+        res.status(400).json({
+          error: "At least one of linearApiKey or githubPat is required",
+        });
+        return;
+      }
+
+      const results: {
+        linear?: { valid: boolean; user?: string; error?: string };
+        github?: {
+          valid: boolean;
+          user?: string;
+          scopes?: string[];
+          warning?: string;
+          error?: string;
+        };
+      } = {};
+
+      if (linearApiKey !== undefined) {
+        if (typeof linearApiKey !== "string" || linearApiKey.length > 1000 || linearApiKey.length < 8) {
+          res.status(400).json({
+            error: "linearApiKey must be a string between 8 and 1000 characters",
+          });
+          return;
+        }
+        // Register for redaction before any outbound network call
+        registerSecretValue(linearApiKey);
+        results.linear = await validateToken("linear", linearApiKey);
+      }
+
+      if (githubPat !== undefined) {
+        if (typeof githubPat !== "string" || githubPat.length > 1000 || githubPat.length < 8) {
+          res.status(400).json({
+            error: "githubPat must be a string between 8 and 1000 characters",
+          });
+          return;
+        }
+        // Register for redaction before any outbound network call
+        registerSecretValue(githubPat);
+        const githubResult = await validateToken("github", githubPat);
+        // Warn if using a classic PAT with the broad 'repo' scope — fine-grained PATs are preferred
+        const hasRepoScope = githubResult.scopes?.includes("repo") ?? false;
+        results.github = {
+          ...githubResult,
+          ...(hasRepoScope
+            ? {
+                warning:
+                  "Classic PAT with 'repo' scope grants access to all your repositories. " +
+                  "Consider using a fine-grained PAT scoped to specific repositories.",
+              }
+            : {}),
+        };
+      }
+
+      const allValid = Object.values(results).every((r) => r.valid);
+      res.status(allValid ? 200 : 422).json({ valid: allValid, results });
+    } catch (err: unknown) {
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  return router;
+}

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -61,7 +61,7 @@ function sanitizeString(input: string, patterns: string[]): string {
   for (const secret of patterns) {
     result = result.replaceAll(secret, REDACTED);
   }
-  for (const secret of runtimeSecrets) {
+  for (const secret of dynamicSecrets) {
     result = result.replaceAll(secret, REDACTED);
   }
   return result;

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -61,6 +61,9 @@ function sanitizeString(input: string, patterns: string[]): string {
   for (const secret of patterns) {
     result = result.replaceAll(secret, REDACTED);
   }
+  for (const secret of runtimeSecrets) {
+    result = result.replaceAll(secret, REDACTED);
+  }
   return result;
 }
 

--- a/src/workflow-credentials.test.ts
+++ b/src/workflow-credentials.test.ts
@@ -1,0 +1,331 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  deleteWorkflowCredentials,
+  invalidateKeyCache,
+  loadWorkflowCredentials,
+  storeWorkflowCredentials,
+  writeMcpOverride,
+} from "./workflow-credentials";
+
+/**
+ * The module binds CREDS_DIR at import time from WORKFLOW_CREDS_DIR env var
+ * (falling back to /persistent/workflow-creds).  Tests work against whatever
+ * directory the module resolved at startup and clean up their own files.
+ */
+
+// Stable key for all tests
+const TEST_KEY = "workflow-creds-test-encryption-key-12345678";
+// Track UUIDs created in each test so afterEach can clean them up
+const createdIds: string[] = [];
+
+beforeEach(() => {
+  process.env.ENCRYPTION_KEY = TEST_KEY;
+  delete process.env.JWT_SECRET;
+  invalidateKeyCache();
+  createdIds.length = 0;
+});
+
+afterEach(() => {
+  // Delete any credential files created by this test
+  for (const id of createdIds) {
+    try {
+      deleteWorkflowCredentials(id);
+    } catch {
+      // ignore
+    }
+  }
+  process.env.ENCRYPTION_KEY = TEST_KEY;
+  invalidateKeyCache();
+});
+
+/** Helper: store creds and register id for cleanup */
+function store(id: string, creds: { linearApiKey?: string; githubPat?: string }) {
+  createdIds.push(id);
+  return storeWorkflowCredentials(id, creds);
+}
+
+// ── AES-256-GCM encrypt/decrypt round-trip ───────────────────────────────────
+
+describe("AES-256-GCM encrypt/decrypt round-trip", () => {
+  it("store then load returns identical credentials", () => {
+    const id = crypto.randomUUID();
+    const input = {
+      linearApiKey: "lin_api_test_key_12345678",
+      githubPat: "ghp_testPAT1234567890abcdef",
+    };
+
+    store(id, input);
+
+    const loaded = loadWorkflowCredentials(id);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.linearApiKey).toBe(input.linearApiKey);
+    expect(loaded!.githubPat).toBe(input.githubPat);
+    expect(loaded!.workflowId).toBe(id);
+  });
+
+  it("ciphertext differs on each store (random IV ensures semantic security)", () => {
+    const id1 = crypto.randomUUID();
+    const id2 = crypto.randomUUID();
+    createdIds.push(id1, id2);
+
+    storeWorkflowCredentials(id1, { linearApiKey: "lin_api_same_key_12345678" });
+    storeWorkflowCredentials(id2, { linearApiKey: "lin_api_same_key_12345678" });
+
+    // Load raw ciphertext from the two files to compare
+    const { getCredsFilePath } = (() => {
+      // We can't import the private helper, so resolve the path ourselves
+      const dir = process.env.WORKFLOW_CREDS_DIR || "/persistent/workflow-creds";
+      return {
+        getCredsFilePath: (wid: string) => path.join(dir, `${wid}.json`),
+      };
+    })();
+
+    const enc1 = (JSON.parse(fs.readFileSync(getCredsFilePath(id1), "utf8")) as { encrypted: string }).encrypted;
+    const enc2 = (JSON.parse(fs.readFileSync(getCredsFilePath(id2), "utf8")) as { encrypted: string }).encrypted;
+    expect(enc1).not.toBe(enc2);
+  });
+
+  it("decryption fails gracefully for tampered ciphertext", () => {
+    const id = crypto.randomUUID();
+    createdIds.push(id);
+    storeWorkflowCredentials(id, { linearApiKey: "lin_api_tamper_test_12345" });
+
+    const dir = process.env.WORKFLOW_CREDS_DIR || "/persistent/workflow-creds";
+    const filePath = path.join(dir, `${id}.json`);
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as {
+      encrypted: string;
+      [k: string]: unknown;
+    };
+    // Corrupt the last two base64 chars of the ciphertext (auth-tag or data)
+    const enc = parsed.encrypted;
+    parsed.encrypted = `${enc.slice(0, -2)}${enc.endsWith("AA") ? "BB" : "AA"}`;
+    fs.writeFileSync(filePath, JSON.stringify(parsed));
+
+    expect(loadWorkflowCredentials(id)).toBeNull();
+  });
+});
+
+// ── storeWorkflowCredentials ─────────────────────────────────────────────────
+
+describe("storeWorkflowCredentials", () => {
+  it("returns the credentials with expiresAt ~4h in the future", () => {
+    const id = crypto.randomUUID();
+    const before = Date.now();
+    const result = store(id, { githubPat: "ghp_expire_test_12345678" });
+    const after = Date.now();
+
+    const expiresAtMs = new Date(result.expiresAt).getTime();
+    const fourHoursMs = 4 * 60 * 60 * 1000;
+    expect(expiresAtMs).toBeGreaterThanOrEqual(before + fourHoursMs);
+    expect(expiresAtMs).toBeLessThanOrEqual(after + fourHoursMs + 1000);
+  });
+
+  it("stores only the provided fields (partial creds)", () => {
+    const id = crypto.randomUUID();
+    store(id, { linearApiKey: "lin_api_partial_12345678" });
+
+    const loaded = loadWorkflowCredentials(id);
+    expect(loaded!.linearApiKey).toBe("lin_api_partial_12345678");
+    expect(loaded!.githubPat).toBeUndefined();
+  });
+
+  it("sanitizes path-traversal characters from workflowId (strips ../ to safe chars)", () => {
+    // "../evil" strips to "evil" — traversal chars removed, no throw, no path escape
+    const dir = process.env.WORKFLOW_CREDS_DIR || "/persistent/workflow-creds";
+    storeWorkflowCredentials("../evil", { linearApiKey: "lin_api_test_12345678" });
+    createdIds.push("../evil");
+    // File must be inside creds dir (safe path), NOT outside it
+    expect(fs.existsSync(path.join(dir, "evil.json"))).toBe(true);
+    // Clean up evil.json directly since afterEach uses deleteWorkflowCredentials("../evil")
+    // which also maps to evil.json — so that's fine
+  });
+
+  it("throws for workflowId that strips to empty string", () => {
+    // "..." strips all chars to "" — module should throw Invalid workflowId
+    expect(() => storeWorkflowCredentials("...", { linearApiKey: "lin_api_test_12345678" })).toThrow(
+      /Invalid workflowId/,
+    );
+  });
+
+  it("overwrites a previous credential file for the same workflowId", () => {
+    const id = crypto.randomUUID();
+    store(id, { linearApiKey: "lin_api_first_value_12345" });
+    store(id, { linearApiKey: "lin_api_second_value_12345" });
+
+    expect(loadWorkflowCredentials(id)!.linearApiKey).toBe("lin_api_second_value_12345");
+  });
+});
+
+// ── loadWorkflowCredentials ───────────────────────────────────────────────────
+
+describe("loadWorkflowCredentials", () => {
+  it("returns null for an unknown workflowId", () => {
+    expect(loadWorkflowCredentials(crypto.randomUUID())).toBeNull();
+  });
+
+  it("returns the workflowId field in the result", () => {
+    const id = crypto.randomUUID();
+    store(id, { linearApiKey: "lin_api_id_check_12345678" });
+    expect(loadWorkflowCredentials(id)!.workflowId).toBe(id);
+  });
+
+  it("returns null and deletes the file for expired credentials", () => {
+    const id = crypto.randomUUID();
+    store(id, { linearApiKey: "lin_api_ttl_test_12345678" });
+
+    const dir = process.env.WORKFLOW_CREDS_DIR || "/persistent/workflow-creds";
+    const filePath = path.join(dir, `${id}.json`);
+    const raw = JSON.parse(fs.readFileSync(filePath, "utf8")) as { expiresAt: string; [k: string]: unknown };
+    raw.expiresAt = new Date(Date.now() - 1000).toISOString();
+    fs.writeFileSync(filePath, JSON.stringify(raw));
+
+    expect(loadWorkflowCredentials(id)).toBeNull();
+    expect(fs.existsSync(filePath)).toBe(false);
+    // Already deleted — remove from cleanup list to avoid double-delete noise
+    const idx = createdIds.indexOf(id);
+    if (idx !== -1) createdIds.splice(idx, 1);
+  });
+});
+
+// ── 4h TTL expiry logic ───────────────────────────────────────────────────────
+
+describe("4h TTL expiry", () => {
+  it("expiresAt is exactly ~4h after createdAt", () => {
+    const id = crypto.randomUUID();
+    const result = store(id, { linearApiKey: "lin_api_time_check_1234" });
+
+    const created = new Date(result.createdAt).getTime();
+    const expires = new Date(result.expiresAt).getTime();
+    const fourHoursMs = 4 * 60 * 60 * 1000;
+
+    expect(expires - created).toBeGreaterThanOrEqual(fourHoursMs - 100);
+    expect(expires - created).toBeLessThanOrEqual(fourHoursMs + 1000);
+  });
+
+  it("credentials within TTL are loaded successfully", () => {
+    const id = crypto.randomUUID();
+    store(id, { linearApiKey: "lin_api_valid_ttl_12345678" });
+    expect(loadWorkflowCredentials(id)).not.toBeNull();
+  });
+});
+
+// ── deleteWorkflowCredentials ─────────────────────────────────────────────────
+
+describe("deleteWorkflowCredentials", () => {
+  it("removes the credentials so subsequent load returns null", () => {
+    const id = crypto.randomUUID();
+    store(id, { linearApiKey: "lin_api_delete_test_12345" });
+    deleteWorkflowCredentials(id);
+    const idx = createdIds.indexOf(id);
+    if (idx !== -1) createdIds.splice(idx, 1);
+
+    expect(loadWorkflowCredentials(id)).toBeNull();
+  });
+
+  it("is a no-op for a non-existent workflowId", () => {
+    expect(() => deleteWorkflowCredentials(crypto.randomUUID())).not.toThrow();
+  });
+});
+
+// ── writeMcpOverride ──────────────────────────────────────────────────────────
+
+describe("writeMcpOverride", () => {
+  it("creates .claude/settings.json with the Linear MCP entry", () => {
+    const workspaceDir = path.join(os.tmpdir(), `wt-mcp-test-${Date.now()}`);
+    fs.mkdirSync(workspaceDir, { recursive: true });
+
+    try {
+      writeMcpOverride(workspaceDir, "lin_api_mcp_test_key_12345");
+
+      const settingsPath = path.join(workspaceDir, ".claude", "settings.json");
+      expect(fs.existsSync(settingsPath)).toBe(true);
+
+      const settings = JSON.parse(fs.readFileSync(settingsPath, "utf8")) as {
+        mcpServers: { linear: { headers: { Authorization: string } } };
+      };
+      expect(settings.mcpServers.linear.headers.Authorization).toBe("Bearer lin_api_mcp_test_key_12345");
+    } finally {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves existing mcpServers entries from global settings", () => {
+    const workspaceDir = path.join(os.tmpdir(), `wt-mcp-preserve-${Date.now()}`);
+    const claudeHome = path.join(os.tmpdir(), `.claude-global-test-${Date.now()}`);
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.mkdirSync(claudeHome, { recursive: true });
+
+    const origClaudeHome = process.env.CLAUDE_HOME;
+    process.env.CLAUDE_HOME = claudeHome;
+
+    fs.writeFileSync(
+      path.join(claudeHome, "settings.json"),
+      JSON.stringify({
+        mcpServers: { github: { type: "http", url: "https://api.github.com" } },
+      }),
+    );
+
+    try {
+      writeMcpOverride(workspaceDir, "lin_api_preserve_key_12345");
+
+      const settings = JSON.parse(fs.readFileSync(path.join(workspaceDir, ".claude", "settings.json"), "utf8")) as {
+        mcpServers: { github?: unknown; linear?: unknown };
+      };
+
+      expect(settings.mcpServers.github).toBeDefined();
+      expect(settings.mcpServers.linear).toBeDefined();
+    } finally {
+      process.env.CLAUDE_HOME = origClaudeHome;
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+      fs.rmSync(claudeHome, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── key derivation ────────────────────────────────────────────────────────────
+
+describe("key derivation", () => {
+  it("falls back to JWT_SECRET when ENCRYPTION_KEY is not set", () => {
+    delete process.env.ENCRYPTION_KEY;
+    process.env.JWT_SECRET = "fallback-jwt-secret-for-tests-12345678";
+    invalidateKeyCache();
+
+    const id = crypto.randomUUID();
+    createdIds.push(id);
+    const result = storeWorkflowCredentials(id, { linearApiKey: "lin_api_jwt_fallback_12345" });
+    expect(result.linearApiKey).toBe("lin_api_jwt_fallback_12345");
+
+    const loaded = loadWorkflowCredentials(id);
+    expect(loaded!.linearApiKey).toBe("lin_api_jwt_fallback_12345");
+  });
+
+  it("throws when neither ENCRYPTION_KEY nor JWT_SECRET is set", () => {
+    delete process.env.ENCRYPTION_KEY;
+    delete process.env.JWT_SECRET;
+    invalidateKeyCache();
+
+    expect(() => storeWorkflowCredentials(crypto.randomUUID(), { linearApiKey: "lin_api_no_key_12345678" })).toThrow(
+      /No encryption key available/,
+    );
+  });
+
+  it("credentials encrypted with one key cannot be decrypted with a different key", () => {
+    const id = crypto.randomUUID();
+    createdIds.push(id);
+    store(id, { linearApiKey: "lin_api_cross_key_12345678" });
+
+    // Rotate to a different key
+    process.env.ENCRYPTION_KEY = "different-test-encryption-key-for-workflow-12345";
+    invalidateKeyCache();
+
+    expect(loadWorkflowCredentials(id)).toBeNull();
+
+    // Restore key so afterEach cleanup can delete the file
+    process.env.ENCRYPTION_KEY = TEST_KEY;
+    invalidateKeyCache();
+  });
+});

--- a/src/workflow-credentials.ts
+++ b/src/workflow-credentials.ts
@@ -1,0 +1,282 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { logger } from "./logger";
+import { registerSecretValue, unregisterSecretValue } from "./sanitize";
+import { errorMessage } from "./types";
+
+/**
+ * Per-workflow credential storage for Linear API keys and GitHub PATs.
+ *
+ * Credentials are:
+ * - Encrypted at rest with AES-256-GCM (key derived via PBKDF2 from ENCRYPTION_KEY or JWT_SECRET)
+ * - Stored at /persistent/workflow-creds/{workflowId}.json with mode 0600
+ * - Auto-expired after 4h TTL
+ * - Registered with sanitize.ts for log redaction
+ * - Deleted on workflow terminal state (completed/failed/cancelled)
+ */
+
+export interface WorkflowCredentials {
+  workflowId: string;
+  linearApiKey?: string;
+  githubPat?: string;
+  expiresAt: string;
+  createdAt: string;
+}
+
+const CREDS_DIR = process.env.WORKFLOW_CREDS_DIR || "/persistent/workflow-creds";
+const MAX_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+const KEY_LEN = 32; // 256-bit key for AES-256-GCM
+const IV_LEN = 12; // 96-bit IV (recommended for GCM)
+const PBKDF2_ITERATIONS = 100_000;
+const PBKDF2_DIGEST = "sha256";
+// Fixed subsystem salt — prevents cross-subsystem key reuse if the secret is shared
+const KDF_SALT = "agentManager-workflow-credentials-v1";
+
+// Lazy-derived key — computed once per process on first use
+let _derivedKey: Buffer | null = null;
+
+/**
+ * Derive a 32-byte AES-256 encryption key via PBKDF2.
+ * Uses ENCRYPTION_KEY env var (preferred) or JWT_SECRET as the input secret.
+ */
+function deriveKey(): Buffer {
+  if (_derivedKey) return _derivedKey;
+  const secret = process.env.ENCRYPTION_KEY || process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error("[workflow-credentials] No encryption key available. Set ENCRYPTION_KEY or JWT_SECRET.");
+  }
+  _derivedKey = crypto.pbkdf2Sync(secret, KDF_SALT, PBKDF2_ITERATIONS, KEY_LEN, PBKDF2_DIGEST);
+  return _derivedKey;
+}
+
+/** Invalidate the cached derived key (e.g. after key rotation in tests). */
+export function invalidateKeyCache(): void {
+  _derivedKey = null;
+}
+
+/** Encrypt plaintext with AES-256-GCM. Returns "iv:authTag:ciphertext" (base64). */
+function encrypt(plaintext: string): string {
+  const key = deriveKey();
+  const iv = crypto.randomBytes(IV_LEN);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return [iv.toString("base64"), authTag.toString("base64"), encrypted.toString("base64")].join(":");
+}
+
+/** Decrypt ciphertext from "iv:authTag:ciphertext" format. Throws on tamper. */
+function decrypt(ciphertext: string): string {
+  const parts = ciphertext.split(":");
+  if (parts.length !== 3) throw new Error("Invalid ciphertext format");
+  const [ivB64, authTagB64, dataB64] = parts;
+  const key = deriveKey();
+  const iv = Buffer.from(ivB64, "base64");
+  const authTag = Buffer.from(authTagB64, "base64");
+  const data = Buffer.from(dataB64, "base64");
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(data), decipher.final()]).toString("utf8");
+}
+
+function ensureCredsDir(): void {
+  if (!fs.existsSync(CREDS_DIR)) {
+    fs.mkdirSync(CREDS_DIR, { recursive: true, mode: 0o700 });
+  }
+}
+
+function getCredsFilePath(workflowId: string): string {
+  // Sanitize to prevent path traversal
+  const safe = workflowId.replace(/[^a-zA-Z0-9_-]/g, "");
+  if (!safe) throw new Error("Invalid workflowId");
+  return path.join(CREDS_DIR, `${safe}.json`);
+}
+
+interface StoredCredFile {
+  workflowId: string;
+  encrypted: string;
+  expiresAt: string;
+  createdAt: string;
+}
+
+/**
+ * Store encrypted workflow credentials.
+ * Registers secret values for log redaction.
+ * Returns the stored credential record (with plaintext values for immediate use).
+ */
+export function storeWorkflowCredentials(
+  workflowId: string,
+  creds: { linearApiKey?: string; githubPat?: string },
+): WorkflowCredentials {
+  ensureCredsDir();
+
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + MAX_TTL_MS).toISOString();
+  const plaintext = JSON.stringify({
+    linearApiKey: creds.linearApiKey,
+    githubPat: creds.githubPat,
+  });
+
+  const encrypted = encrypt(plaintext);
+  const stored: StoredCredFile = {
+    workflowId,
+    encrypted,
+    expiresAt,
+    createdAt: now.toISOString(),
+  };
+
+  const filePath = getCredsFilePath(workflowId);
+  const nonce = crypto.randomBytes(4).toString("hex");
+  const tmpPath = `${filePath}.tmp.${process.pid}.${nonce}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(stored, null, 2), { mode: 0o600 });
+  fs.renameSync(tmpPath, filePath);
+
+  // Register secrets for log redaction
+  if (creds.linearApiKey) registerSecretValue(creds.linearApiKey);
+  if (creds.githubPat) registerSecretValue(creds.githubPat);
+
+  logger.info(`[workflow-credentials] Stored credentials for workflow ${workflowId.slice(0, 8)}`);
+  return {
+    workflowId,
+    linearApiKey: creds.linearApiKey,
+    githubPat: creds.githubPat,
+    expiresAt,
+    createdAt: now.toISOString(),
+  };
+}
+
+/**
+ * Load and decrypt workflow credentials.
+ * Returns null if not found or expired.
+ */
+export function loadWorkflowCredentials(workflowId: string): WorkflowCredentials | null {
+  let filePath: string;
+  try {
+    filePath = getCredsFilePath(workflowId);
+  } catch {
+    return null;
+  }
+
+  if (!fs.existsSync(filePath)) return null;
+
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const stored = JSON.parse(raw) as StoredCredFile;
+
+    // Check TTL
+    if (new Date() >= new Date(stored.expiresAt)) {
+      logger.warn(`[workflow-credentials] Credentials expired for workflow ${workflowId.slice(0, 8)}`);
+      deleteWorkflowCredentials(workflowId);
+      return null;
+    }
+
+    const plaintext = decrypt(stored.encrypted);
+    const creds = JSON.parse(plaintext) as {
+      linearApiKey?: string;
+      githubPat?: string;
+    };
+
+    // Re-register for redaction (e.g. after process restart with warm cache)
+    if (creds.linearApiKey) registerSecretValue(creds.linearApiKey);
+    if (creds.githubPat) registerSecretValue(creds.githubPat);
+
+    return {
+      workflowId,
+      linearApiKey: creds.linearApiKey,
+      githubPat: creds.githubPat,
+      expiresAt: stored.expiresAt,
+      createdAt: stored.createdAt,
+    };
+  } catch (err: unknown) {
+    logger.error(
+      `[workflow-credentials] Failed to load credentials for workflow ${workflowId.slice(0, 8)}: ${errorMessage(err)}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Securely delete workflow credentials.
+ * Called on workflow terminal state (completed/failed/cancelled).
+ */
+export function deleteWorkflowCredentials(workflowId: string): void {
+  let filePath: string;
+  try {
+    filePath = getCredsFilePath(workflowId);
+  } catch {
+    return;
+  }
+
+  if (!fs.existsSync(filePath)) return;
+
+  try {
+    // Best-effort: unregister from redaction before deletion
+    try {
+      const raw = fs.readFileSync(filePath, "utf8");
+      const stored = JSON.parse(raw) as StoredCredFile;
+      const plaintext = decrypt(stored.encrypted);
+      const creds = JSON.parse(plaintext) as {
+        linearApiKey?: string;
+        githubPat?: string;
+      };
+      if (creds.linearApiKey) unregisterSecretValue(creds.linearApiKey);
+      if (creds.githubPat) unregisterSecretValue(creds.githubPat);
+    } catch {
+      // Non-fatal — file may be corrupt or already unregistered
+    }
+
+    fs.unlinkSync(filePath);
+    logger.info(`[workflow-credentials] Deleted credentials for workflow ${workflowId.slice(0, 8)}`);
+  } catch (err: unknown) {
+    logger.error(
+      `[workflow-credentials] Failed to delete credentials for workflow ${workflowId.slice(0, 8)}: ${errorMessage(err)}`,
+    );
+  }
+}
+
+/**
+ * Write a per-workflow MCP settings override into the agent workspace's .claude/ directory.
+ * Overrides the platform's global LINEAR_API_KEY with the user-supplied key so the
+ * Linear MCP server uses the workflow user's credentials, not the platform operator's.
+ */
+export function writeMcpOverride(workspaceDir: string, linearApiKey: string): void {
+  const claudeDir = path.join(workspaceDir, ".claude");
+  fs.mkdirSync(claudeDir, { recursive: true });
+
+  // Read the global settings.json from the platform's CLAUDE_HOME
+  const globalClaudeHome = process.env.CLAUDE_HOME || path.join(os.homedir(), ".claude");
+  const globalSettingsPath = path.join(globalClaudeHome, "settings.json");
+
+  let baseSettings: Record<string, unknown> = {};
+  try {
+    const raw = fs.readFileSync(globalSettingsPath, "utf8");
+    baseSettings = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    // Use empty settings if global not found — agent will use defaults
+  }
+
+  // Override the Linear MCP entry with workflow-scoped credentials
+  const overrideSettings = {
+    ...baseSettings,
+    mcpServers: {
+      ...(baseSettings.mcpServers as Record<string, unknown> | undefined),
+      linear: {
+        type: "http",
+        url: "https://mcp.linear.app/mcp",
+        headers: { Authorization: `Bearer ${linearApiKey}` },
+      },
+    },
+  };
+
+  const settingsPath = path.join(claudeDir, "settings.json");
+  const nonce = crypto.randomBytes(4).toString("hex");
+  const tmpPath = `${settingsPath}.tmp.${process.pid}.${nonce}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(overrideSettings, null, 2), {
+    mode: 0o600,
+  });
+  fs.renameSync(tmpPath, settingsPath);
+
+  logger.info("[workflow-credentials] Wrote MCP override for workflow (Linear key set)");
+}


### PR DESCRIPTION
## Summary

Adds encrypted per-workflow credential storage:

- `src/workflow-credentials.ts`: AES-256-GCM encrypted credential store, 4-hour TTL, persists to `/persistent/workflow-creds/` (GCS-synced).
- `src/routes/workflow-credentials.ts`: GET/POST/DELETE `/api/workflow-credentials/:workflowId` — operator-only writes.
- `server.ts`: mounts `createWorkflowCredentialsRouter()`.

deps: PR #20 (workflow-engine)

Zero fanbot/fanvue refs. ~374 lines.

## Test plan
- [x] `npm test` passes (414 tests)
- [x] `npx biome check .` clean