### PR TITLE
feat: workflow engine routes + namespace split (PR 22)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -21,6 +21,7 @@ import { createContextRouter } from "./src/routes/context";
 import { createCostRouter } from "./src/routes/cost";
 import { createHealthRouter } from "./src/routes/health";
 import { createKillSwitchRouter } from "./src/routes/kill-switch";
+import { createLinearWorkflowsRouter } from "./src/routes/linear-workflows";
 import { createMcpRouter } from "./src/routes/mcp";
 import { createMessagesRouter } from "./src/routes/messages";
 import { createRepositoriesRouter } from "./src/routes/repositories";
@@ -204,6 +205,7 @@ app.use(createCostRouter(agentManager, costTracker, messageBus));
 app.use(createTasksRouter(taskGraph, orchestrator, gradeStore));
 app.use(createSchedulerRouter(scheduler));
 app.use(createWorkflowsRouter(agentManager, messageBus));
+app.use(createLinearWorkflowsRouter(agentManager, messageBus));
 app.use(createRepositoriesRouter(agentManager));
 // Layer 1: Kill switch endpoint (no extra auth beyond authMiddleware above)
 app.use(createKillSwitchRouter(agentManager));

--- a/src/routes/linear-workflows.ts
+++ b/src/routes/linear-workflows.ts
@@ -1,0 +1,246 @@
+import crypto from "node:crypto";
+import express, { type Request, type Response } from "express";
+import type { AgentManager } from "../agents";
+import { requireHumanUser } from "../auth";
+import { logger } from "../logger";
+import type { MessageBus } from "../messages";
+import { buildManagerPrompt } from "../templates/linear-workflow-manager-prompt";
+import { errorMessage } from "../types";
+
+interface LinearWorkflow {
+  id: string;
+  linearUrl: string;
+  repository: string;
+  status: "starting" | "running" | "completed" | "failed" | "cancelled";
+  agents: Array<{ id: string; name: string; role: string }>;
+  prUrl?: string;
+  error?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Max concurrent workflows */
+const MAX_WORKFLOWS = 5;
+
+/** Max total stored workflows (evict oldest terminal workflows beyond this) */
+const MAX_STORED_WORKFLOWS = 50;
+
+/** Valid repository name pattern: alphanumeric, hyphens, underscores, dots, and optional owner/ prefix */
+const REPO_NAME_RE = /^[\w.-]+(\/[\w.-]+)?$/;
+
+function parseLinearUrl(url: string): { issueId: string; team: string; workspace: string } | null {
+  // Anchored to https://linear.app to prevent matching spoofed domains
+  const match = url.match(/^https:\/\/linear\.app\/([\w-]+)\/issue\/([\w]+-\d+)/);
+  if (match) {
+    const workspace = match[1];
+    const issueId = match[2];
+    const team = issueId.split("-")[0];
+    return { issueId, team, workspace };
+  }
+  return null;
+}
+
+/** Reconstruct a clean Linear URL from parsed components (prevents prompt injection via URL) */
+function buildSafeLinearUrl(parsed: { issueId: string; workspace: string }): string {
+  return `https://linear.app/${parsed.workspace}/issue/${parsed.issueId}`;
+}
+
+/** Evict oldest terminal workflows when the store exceeds MAX_STORED_WORKFLOWS */
+function evictStaleWorkflows(workflows: Map<string, LinearWorkflow>): void {
+  if (workflows.size <= MAX_STORED_WORKFLOWS) return;
+  const terminal = Array.from(workflows.entries())
+    .filter(([, w]) => w.status === "completed" || w.status === "failed" || w.status === "cancelled")
+    .sort((a, b) => new Date(a[1].createdAt).getTime() - new Date(b[1].createdAt).getTime());
+  while (workflows.size > MAX_STORED_WORKFLOWS && terminal.length > 0) {
+    const oldest = terminal.shift();
+    if (oldest) workflows.delete(oldest[0]);
+  }
+}
+
+export function createLinearWorkflowsRouter(agentManager: AgentManager, messageBus: MessageBus) {
+  const router = express.Router();
+  const workflows = new Map<string, LinearWorkflow>();
+
+  /**
+   * POST /api/linear-workflows/linear
+   * Start a new Linear-to-PR workflow
+   */
+  router.post("/api/linear-workflows/linear", requireHumanUser, (req: Request, res: Response) => {
+    try {
+      const { linearUrl, repository } = req.body ?? {};
+
+      if (!linearUrl || typeof linearUrl !== "string") {
+        res.status(400).json({ error: "linearUrl is required" });
+        return;
+      }
+
+      if (!repository || typeof repository !== "string") {
+        res.status(400).json({ error: "repository is required" });
+        return;
+      }
+
+      // Validate repository name format (prevents prompt injection)
+      if (!REPO_NAME_RE.test(repository) || repository.length > 100) {
+        res.status(400).json({
+          error: "Invalid repository name. Use alphanumeric characters, hyphens, underscores, and dots only.",
+        });
+        return;
+      }
+
+      // Validate Linear URL (anchored to https://linear.app)
+      const parsed = parseLinearUrl(linearUrl);
+      if (!parsed) {
+        res.status(400).json({
+          error: "Invalid Linear URL. Expected format: https://linear.app/team/issue/TEAM-123",
+        });
+        return;
+      }
+
+      // Reconstruct a safe URL from parsed components to prevent prompt injection
+      const safeLinearUrl = buildSafeLinearUrl(parsed);
+
+      // Check concurrent workflow limit
+      const active = Array.from(workflows.values()).filter((w) => w.status === "starting" || w.status === "running");
+      if (active.length >= MAX_WORKFLOWS) {
+        res.status(429).json({
+          error: `Maximum ${MAX_WORKFLOWS} concurrent workflows allowed. Wait for an existing workflow to complete.`,
+        });
+        return;
+      }
+
+      const workflowId = crypto.randomUUID();
+      const now = new Date().toISOString();
+
+      const workflow: LinearWorkflow = {
+        id: workflowId,
+        linearUrl: safeLinearUrl,
+        repository,
+        status: "starting",
+        agents: [],
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      workflows.set(workflowId, workflow);
+      evictStaleWorkflows(workflows);
+
+      // Spawn the manager agent, then respond with the result
+      const managerPrompt = buildManagerPrompt(safeLinearUrl, repository, workflowId);
+
+      try {
+        const managerName = `workflow-${parsed.issueId.toLowerCase()}`;
+        const { agent } = agentManager.create({
+          prompt: managerPrompt,
+          name: managerName,
+          model: "claude-sonnet-4-6",
+          maxTurns: 100,
+          role: "workflow-manager",
+        });
+
+        workflow.agents.push({ id: agent.id, name: managerName, role: "manager" });
+        workflow.status = "running";
+        workflow.updatedAt = new Date().toISOString();
+
+        res.status(201).json({ workflow });
+      } catch (err: unknown) {
+        logger.error(`[Workflows] Failed to spawn manager for ${workflowId}`, { error: errorMessage(err) });
+        workflow.status = "failed";
+        workflow.error = errorMessage(err);
+        workflow.updatedAt = new Date().toISOString();
+
+        res.status(500).json({ error: `Failed to start workflow: ${errorMessage(err)}`, workflow });
+      }
+    } catch (err: unknown) {
+      logger.error("[Workflows] Error starting workflow", { error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  /**
+   * GET /api/linear-workflows
+   * List all workflows
+   */
+  router.get("/api/linear-workflows", (_req: Request, res: Response) => {
+    const all = Array.from(workflows.values()).sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+    res.json(all);
+  });
+
+  /**
+   * GET /api/linear-workflows/:id
+   * Get workflow status
+   */
+  router.get("/api/linear-workflows/:id", (req: Request<{ id: string }>, res: Response) => {
+    const workflow = workflows.get(req.params.id);
+    if (!workflow) {
+      res.status(404).json({ error: "Workflow not found" });
+      return;
+    }
+
+    // Enrich with live agent status
+    const enriched = {
+      ...workflow,
+      agents: workflow.agents.map((a) => {
+        const agent = agentManager.get(a.id);
+        return {
+          ...a,
+          status: agent?.status ?? "unknown",
+          currentTask: agent?.currentTask,
+        };
+      }),
+    };
+
+    res.json(enriched);
+  });
+
+  /**
+   * DELETE /api/linear-workflows/:id
+   * Cancel a workflow and destroy its agents
+   */
+  router.delete("/api/linear-workflows/:id", requireHumanUser, async (req: Request<{ id: string }>, res: Response) => {
+    const workflow = workflows.get(req.params.id);
+    if (!workflow) {
+      res.status(404).json({ error: "Workflow not found" });
+      return;
+    }
+
+    // Destroy all associated agents
+    for (const agent of workflow.agents) {
+      try {
+        const destroyed = await agentManager.destroy(agent.id);
+        if (!destroyed) {
+          logger.warn("[Workflows] Agent already gone on cancel", { agentId: agent.id });
+        }
+      } catch (err: unknown) {
+        logger.warn(`[Workflows] Failed to destroy agent ${agent.id}`, { error: errorMessage(err) });
+      }
+    }
+
+    workflow.status = "cancelled";
+    workflow.updatedAt = new Date().toISOString();
+
+    res.json({ ok: true, workflow });
+  });
+
+  // Listen for workflow completion messages
+  messageBus.subscribe((msg) => {
+    if (msg.type !== "result" || !msg.metadata?.workflowId) return;
+
+    const wfId = msg.metadata.workflowId;
+    if (typeof wfId !== "string") return;
+
+    const workflow = workflows.get(wfId);
+    if (!workflow) return;
+
+    // Check if message contains a PR URL
+    const prMatch = msg.content.match(/https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/pull\/\d+/);
+    if (prMatch) {
+      workflow.prUrl = prMatch[0];
+      workflow.status = "completed";
+      workflow.updatedAt = new Date().toISOString();
+    }
+  });
+
+  return router;
+}

--- a/src/routes/workflows.ts
+++ b/src/routes/workflows.ts
@@ -1,23 +1,106 @@
+import { execFile } from "node:child_process";
 import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
 import express, { type Request, type Response } from "express";
 import type { AgentManager } from "../agents";
-import { requireHumanUser } from "../auth";
+import { requireNotAgentService } from "../auth";
+import { createGrade, type GradeResult } from "../grading";
+import { ALLOWED_MODELS, type AllowedModel, DEFAULT_MODEL } from "../guardrails";
 import { logger } from "../logger";
 import type { MessageBus } from "../messages";
-import { buildManagerPrompt } from "../templates/linear-workflow-manager-prompt";
+import { registerSecretValue } from "../sanitize";
 import { errorMessage } from "../types";
+import { REPO_NAME_RE } from "../validation";
+import { confidenceFromGrade, gradeGate } from "../workflow-grading";
+import {
+  checkMemoryForNewWorkflow,
+  checkWorkflowAgentLimit,
+  detectWorkflowStall,
+  enforceWorkflowCostCap,
+  WORKFLOW_MAX_AGENTS,
+} from "../workflow-resource-manager";
+import {
+  buildTriagePrompt,
+  buildValidationResult,
+  clarityFromChecks,
+  type TriageChecks,
+  verdictFromClarity,
+} from "../workflow-triage";
+import {
+  applyPatToGitConfig,
+  canStartClone,
+  cloningInProgress,
+  extractRepoName,
+  isValidGitUrl,
+  PERSISTENT_REPOS,
+  saveRepoPat,
+} from "./repositories";
 
-interface LinearWorkflow {
+const execFileAsync = promisify(execFile);
+
+export interface LinearWorkflow {
   id: string;
   linearUrl: string;
   repository: string;
-  status: "starting" | "running" | "completed" | "failed" | "cancelled";
+  status:
+    | "validating"
+    | "rejected"
+    | "starting"
+    | "running"
+    | "awaiting_confirm"
+    | "grading"
+    | "needs_human"
+    | "completed"
+    | "failed"
+    | "cancelled";
   agents: Array<{ id: string; name: string; role: string }>;
+  /** True if user-supplied credentials were provided for this workflow run */
+  hasCredentials?: boolean;
+  /** Arbitrary metadata written by the manager agent (e.g. issueDetails, costEstimate) */
+  metadata?: Record<string, unknown>;
   prUrl?: string;
   error?: string;
+  /** INF-1: Pre-run cost estimate in USD. When set, workflow is halted at 2× this value. */
+  costEstimate?: number;
+  /** Agent ID of the triage agent spawned for basicMode validation */
+  triageAgentId?: string;
+  /** Agent ID of the grader agent (recorded for identity-bound grade ingestion) */
+  graderAgentId?: string;
+  /** Ticket validation result from the triage agent (basicMode only) */
+  validation?: {
+    verdict: "accept" | "accept_with_caveats" | "reject";
+    clarity: "high" | "medium" | "low";
+    missing: string[];
+    suggestions: string[];
+    readError?: "not_found" | "forbidden" | "auth_failed" | "rate_limited" | "multi_issue_empty";
+    evaluatedAt: string;
+  };
+  /** Confidence grade from the workflow grader (basicMode only) */
+  grade?: GradeResult;
+  /** Inverted confidence score 0-100 (higher = better = 100 - grade.numericScore) */
+  confidence?: number;
   createdAt: string;
   updatedAt: string;
 }
+
+/** AllowedModel imported from central guardrails — see guardrails.ts for authoritative type. */
+
+/** Validate a Linear API key format (lin_api_ prefix, min 32 chars after prefix) */
+function isValidLinearApiKey(key: string): boolean {
+  return /^lin_api_[A-Za-z0-9_]{32,}$/.test(key);
+}
+
+/** Validate a GitHub PAT format (classic ghp_, fine-grained github_pat_, or legacy 40-char hex) */
+function isValidGithubPat(pat: string): boolean {
+  return /^(ghp_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9]{36,}|gho_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{40,}|[a-f0-9]{40})$/.test(
+    pat,
+  );
+}
+
+/** In-memory workflow store */
+const workflows = new Map<string, LinearWorkflow>();
 
 /** Max concurrent workflows */
 const MAX_WORKFLOWS = 5;
@@ -25,28 +108,60 @@ const MAX_WORKFLOWS = 5;
 /** Max total stored workflows (evict oldest terminal workflows beyond this) */
 const MAX_STORED_WORKFLOWS = 50;
 
-/** Valid repository name pattern: alphanumeric, hyphens, underscores, dots, and optional owner/ prefix */
-const REPO_NAME_RE = /^[\w.-]+(\/[\w.-]+)?$/;
+/** Wall-clock terminal timeout for running workflows — a hung manager pins a slot forever without this. */
+export const RUNNING_WALL_CLOCK_TIMEOUT_MS = 60 * 60_000;
 
-function parseLinearUrl(url: string): { issueId: string; team: string; workspace: string } | null {
-  // Anchored to https://linear.app to prevent matching spoofed domains
-  const match = url.match(/^https:\/\/linear\.app\/([\w-]+)\/issue\/([\w]+-\d+)/);
-  if (match) {
-    const workspace = match[1];
-    const issueId = match[2];
-    const team = issueId.split("-")[0];
-    return { issueId, team, workspace };
+/** Supported Linear entity types */
+type LinearEntityType = "issue" | "project" | "cycle" | "view";
+
+interface ParsedLinearUrl {
+  workspace: string;
+  entityType: LinearEntityType;
+  /** Issue ID like "TEAM-123", project slug, cycle ID, or view ID */
+  entityId: string;
+  /** Team prefix extracted from issue IDs (e.g. "TEAM" from "TEAM-123"), or undefined */
+  team?: string;
+}
+
+/** Parse a broad set of Linear URLs — issues, projects, cycles, views.
+ *  Anchored to https://linear.app to prevent spoofed domains. */
+function parseLinearUrl(url: string): ParsedLinearUrl | null {
+  // Issue: https://linear.app/{workspace}/issue/{TEAM-123}
+  const issueMatch = url.match(/^https:\/\/linear\.app\/([\w-]+)\/issue\/([\w]+-\d+)/);
+  if (issueMatch) {
+    const workspace = issueMatch[1];
+    const entityId = issueMatch[2];
+    return { workspace, entityType: "issue", entityId, team: entityId.split("-")[0] };
   }
+
+  // Project: https://linear.app/{workspace}/project/{slug-uuid}
+  const projectMatch = url.match(/^https:\/\/linear\.app\/([\w-]+)\/project\/([\w-]+)/);
+  if (projectMatch) {
+    return { workspace: projectMatch[1], entityType: "project", entityId: projectMatch[2] };
+  }
+
+  // Cycle: https://linear.app/{workspace}/cycle/{id}
+  const cycleMatch = url.match(/^https:\/\/linear\.app\/([\w-]+)\/cycle\/([\w-]+)/);
+  if (cycleMatch) {
+    return { workspace: cycleMatch[1], entityType: "cycle", entityId: cycleMatch[2] };
+  }
+
+  // View (saved filters / custom views): https://linear.app/{workspace}/view/{id}
+  const viewMatch = url.match(/^https:\/\/linear\.app\/([\w-]+)\/view\/([\w-]+)/);
+  if (viewMatch) {
+    return { workspace: viewMatch[1], entityType: "view", entityId: viewMatch[2] };
+  }
+
   return null;
 }
 
 /** Reconstruct a clean Linear URL from parsed components (prevents prompt injection via URL) */
-function buildSafeLinearUrl(parsed: { issueId: string; workspace: string }): string {
-  return `https://linear.app/${parsed.workspace}/issue/${parsed.issueId}`;
+function buildSafeLinearUrl(parsed: ParsedLinearUrl): string {
+  return `https://linear.app/${parsed.workspace}/${parsed.entityType}/${parsed.entityId}`;
 }
 
 /** Evict oldest terminal workflows when the store exceeds MAX_STORED_WORKFLOWS */
-function evictStaleWorkflows(workflows: Map<string, LinearWorkflow>): void {
+function evictStaleWorkflows(): void {
   if (workflows.size <= MAX_STORED_WORKFLOWS) return;
   const terminal = Array.from(workflows.entries())
     .filter(([, w]) => w.status === "completed" || w.status === "failed" || w.status === "cancelled")
@@ -57,54 +172,393 @@ function evictStaleWorkflows(workflows: Map<string, LinearWorkflow>): void {
   }
 }
 
+export function buildManagerPrompt(
+  safeLinearUrl: string,
+  repository: string,
+  workflowId: string,
+  entityType: LinearEntityType = "issue",
+): string {
+  const entityLabel =
+    entityType === "issue" ? "Linear Issue" : `Linear ${entityType.charAt(0).toUpperCase() + entityType.slice(1)}`;
+
+  const entityIntro: Record<LinearEntityType, string> = {
+    issue: "Read the Linear issue",
+    project: "Read the Linear project and list all its issues",
+    cycle: "Read the Linear cycle and list all its issues",
+    view: "Read the Linear view and list all matching issues",
+  };
+
+  const contextInstructions = `1. **${entityIntro[entityType]}** using the \`/linear\` slash command or MCP tools. Extract **full context**:
+   - Title, description (full markdown body), and acceptance criteria
+   - **Sub-issues**: Read every sub-issue / child issue — each is part of the scope
+   - **Linked issues**: Read related/blocked/blocking issues for context
+   - **Attachments**: Download and review all — Slack messages, images, design files, screenshots contain critical requirements
+   - **Comments**: Read full comment threads for clarifications, decisions, and scope changes
+   - Labels, priority, and estimate metadata${entityType !== "issue" ? "\n   - Prioritize issues by Linear priority and implement in dependency order" : ""}`;
+
+  return `You are the lead engineer for a workflow. Take a ${entityLabel}, understand it fully, implement it, and produce a PR.
+
+## ${entityLabel}: ${safeLinearUrl}
+**Repository:** ${repository} | **Workflow ID:** ${workflowId}
+
+## Instructions
+${contextInstructions}
+2. **Plan** — Read the codebase, create a plan, write it to shared-context as \`workflow-${workflowId.slice(0, 8)}-plan.md\`.
+3. **Spawn team** via \`POST /api/agents/batch\`: Engineer (claude-sonnet-4-6, maxTurns: 200) and Reviewer (claude-sonnet-4-6, maxTurns: 30). Sonnet handles routine implementation and review well — only request \`claude-opus-4-8-20260601\` for a sub-task that is genuinely architecturally hard.
+4. **Coordinate** — Send engineer the plan, monitor via message bus, get reviewer to review, iterate on feedback.
+5. **Grade** — Spawn a grader agent (model: claude-opus-4-8-20260601, maxTurns: 12, role: workflow-grader, read-only). The grader must post ONE result message with metadata:
+   \`{"workflowId":"${workflowId}","workflowGrade":{"graderAgentId":"<GRADER AGENT ID>","ticketClarity":"high|medium|low","fixConfidence":"high|medium|low","blastRadius":"isolated|moderate|broad","reasoning":"<2-3 sentences>"}}\`
+   The grader must include its own agent ID in the payload. Wait for the backend to post a \`gradeDecision\` message back to you:
+   - \`CREATE_PR\` → proceed to step 6.
+   - \`NEEDS_HUMAN\` → do NOT create a PR; broadcast a status message with workflowId; stop.
+6. **Create PR** via \`gh pr create\` referencing the Linear ${entityType}. Branch: \`feat/TEAM-123-description\`.
+7. **Report** — Broadcast a "result" message with PR URL and metadata \`{"workflowId": "${workflowId}"}\`.
+
+## Rules
+- Always read attachments (Slack threads, images, docs) — they contain context you cannot skip
+- Keep the team small. Reference the Linear URL in the PR. Report blockers as "status" messages.`;
+}
+
+/** Resolve a repository from either a bare name or a git URL.
+ *  If the URL points to a repo not yet cloned, performs an async bare clone.
+ *  Returns the bare repo name or an error string. */
+async function resolveRepository(
+  repoNameOrUrl: string,
+  githubPat?: string,
+): Promise<{ ok: true; name: string } | { ok: false; error: string }> {
+  if (isValidGitUrl(repoNameOrUrl)) {
+    const name = extractRepoName(repoNameOrUrl);
+    if (!name) return { ok: false, error: "Could not extract repository name from URL" };
+
+    const targetDir = path.join(PERSISTENT_REPOS, name);
+    const barePath = fs.existsSync(`${targetDir}.git`) ? `${targetDir}.git` : null;
+    const plainPath = fs.existsSync(targetDir) ? targetDir : null;
+    const existingPath = barePath || plainPath;
+
+    if (!existingPath) {
+      const bareTarget = `${targetDir}.git`;
+      if (cloningInProgress.has(bareTarget)) {
+        return { ok: false, error: "Repository is currently being cloned. Please try again shortly." };
+      }
+      if (!canStartClone().allowed) {
+        return { ok: false, error: "Too many concurrent clone operations. Please try again shortly." };
+      }
+      fs.mkdirSync(PERSISTENT_REPOS, { recursive: true });
+      cloningInProgress.add(bareTarget);
+      try {
+        // Pass PAT via credential header instead of embedding in URL to avoid persisting secrets
+        const cloneUrl = repoNameOrUrl.trim();
+        const args = ["clone", "--bare"];
+        if (githubPat && cloneUrl.startsWith("https://")) {
+          const encoded = Buffer.from(`oauth2:${githubPat}`).toString("base64");
+          args.push("-c", `http.extraHeader=Authorization: Basic ${encoded}`);
+        }
+        args.push(cloneUrl, bareTarget);
+        await execFileAsync("git", args, { encoding: "utf-8", timeout: 120_000 });
+        logger.info(`[Workflows] Auto-cloned ${name} from URL`);
+      } catch (err) {
+        try {
+          fs.rmSync(bareTarget, { recursive: true, force: true });
+        } catch {}
+        return { ok: false, error: `Failed to clone repository: ${err instanceof Error ? err.message : String(err)}` };
+      } finally {
+        cloningInProgress.delete(bareTarget);
+      }
+    }
+
+    if (githubPat) {
+      saveRepoPat(name, githubPat);
+      const repoPath = existingPath ?? `${targetDir}.git`;
+      applyPatToGitConfig(repoPath, githubPat).catch((err) => {
+        logger.warn(`[Workflows] Failed to apply PAT to git config for ${name}: ${err}`);
+      });
+    }
+    return { ok: true, name };
+  }
+
+  if (!REPO_NAME_RE.test(repoNameOrUrl) || repoNameOrUrl.length > 100) {
+    return {
+      ok: false,
+      error: "Invalid repository name. Use alphanumeric characters, hyphens, underscores, and dots only.",
+    };
+  }
+  return { ok: true, name: repoNameOrUrl };
+}
+
 export function createWorkflowsRouter(agentManager: AgentManager, messageBus: MessageBus) {
   const router = express.Router();
-  const workflows = new Map<string, LinearWorkflow>();
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // INF-2: Workflow agent membership tracking for TTL extension.
+  // Builds a set of all agent IDs belonging to active workflows (including
+  // descendants spawned by the manager via parentId traversal). Cached for
+  // 60s to match the cleanupExpired() interval and avoid repeated BFS.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  let workflowAgentCache: { ids: Set<string>; expiresAt: number } | null = null;
+
+  /** Return all agent IDs for a specific workflow (manager + all descendants via BFS). */
+  function getWorkflowAgentIds(workflow: LinearWorkflow): string[] {
+    const ids = new Set<string>(workflow.agents.map((a) => a.id));
+    const allAgents = agentManager.list();
+    // BFS: include agents spawned by workflow agents (up to MAX_AGENT_DEPTH levels)
+    let added = true;
+    while (added) {
+      added = false;
+      for (const agent of allAgents) {
+        if (!ids.has(agent.id) && agent.parentId !== undefined && ids.has(agent.parentId)) {
+          ids.add(agent.id);
+          added = true;
+        }
+      }
+    }
+    return [...ids];
+  }
+
+  /** Return the union of all active workflow agent IDs (cached). */
+  function getActiveWorkflowAgentIds(): Set<string> {
+    const now = Date.now();
+    if (workflowAgentCache && now < workflowAgentCache.expiresAt) {
+      return workflowAgentCache.ids;
+    }
+    const ids = new Set<string>();
+    for (const wf of workflows.values()) {
+      // Protect agents in all active states so INF-2 cleanup doesn't evict
+      // triage/grader agents while their workflow is still in flight.
+      if (wf.status !== "starting" && wf.status !== "running" && wf.status !== "validating" && wf.status !== "grading")
+        continue;
+      for (const agentId of getWorkflowAgentIds(wf)) ids.add(agentId);
+    }
+    workflowAgentCache = { ids, expiresAt: now + 60_000 };
+    return ids;
+  }
+
+  // Register INF-2 membership checker — AgentManager.cleanupExpired() will skip these agents
+  agentManager.setWorkflowMembershipChecker((agentId) => getActiveWorkflowAgentIds().has(agentId));
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // INF-1 + INF-3: Periodic watchdog — runs every 60s alongside cleanupExpired.
+  // Checks all active workflows for cost cap violations and stall conditions.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  const watchdogInterval = setInterval(() => {
+    // Invalidate cache so watchdog sees fresh agent state
+    workflowAgentCache = null;
+
+    // Terminal timeout for validating state (triage agent crash/hang → fail after 5min)
+    const VALIDATING_TIMEOUT_MS = 5 * 60_000;
+    // Terminal timeout for grading state (grader crash/hang → fail after 10min)
+    const GRADING_TIMEOUT_MS = 10 * 60_000;
+    for (const [wfId, workflow] of workflows) {
+      if (workflow.status === "validating") {
+        const age = Date.now() - new Date(workflow.updatedAt).getTime();
+        if (age > VALIDATING_TIMEOUT_MS) {
+          workflow.status = "failed";
+          workflow.error = "Triage timed out — ticket validation did not complete in time.";
+          workflow.updatedAt = new Date().toISOString();
+          logger.warn(`[workflow-watchdog] Triage timeout for workflow ${wfId}`);
+          if (workflow.triageAgentId) {
+            agentManager.destroy(workflow.triageAgentId);
+          }
+        }
+        continue;
+      }
+      if (workflow.status === "grading") {
+        const age = Date.now() - new Date(workflow.updatedAt).getTime();
+        if (age > GRADING_TIMEOUT_MS) {
+          workflow.status = "failed";
+          workflow.error = "Grading timed out — confidence grading did not complete in time.";
+          workflow.updatedAt = new Date().toISOString();
+          logger.warn(`[workflow-watchdog] Grading timeout for workflow ${wfId}`);
+          if (workflow.graderAgentId) {
+            agentManager.destroy(workflow.graderAgentId);
+          }
+        }
+        continue;
+      }
+      if (workflow.status !== "running") continue;
+
+      const agentIds = getWorkflowAgentIds(workflow);
+
+      // INF-1: Cost cap enforcement — halt workflow at 2× cost estimate
+      if (workflow.costEstimate && workflow.costEstimate > 0) {
+        enforceWorkflowCostCap(wfId, agentIds, workflow.costEstimate, agentManager, (workflowId, actualCost, cap) => {
+          // Pause all running agents to halt spending
+          for (const agentId of agentIds) {
+            agentManager.pause(agentId);
+          }
+          workflow.status = "failed";
+          workflow.error =
+            `Cost cap exceeded: $${actualCost.toFixed(4)} >= $${cap.toFixed(4)} ` +
+            `(${workflow.costEstimate != null ? `estimate $${workflow.costEstimate.toFixed(4)}` : "no estimate"})`;
+          workflow.updatedAt = new Date().toISOString();
+          logger.warn(`[workflow-watchdog] INF-1: Halted workflow ${workflowId} — cost cap reached`);
+        });
+      }
+
+      // Skip stall check if workflow was just halted by cost cap
+      if (workflow.status !== "running") continue;
+
+      // INF-3: Stall detection — notify orchestrator when all agents idle >10min
+      detectWorkflowStall(wfId, agentIds, agentManager, (workflowId, idleMs) => {
+        const managerId = workflow.agents[0]?.id;
+        if (managerId) {
+          messageBus.post({
+            from: "workflow-guard",
+            fromName: "workflow-guard",
+            to: managerId,
+            type: "status",
+            content:
+              `Workflow stall detected: all agents have been idle for ` +
+              `${Math.round(idleMs / 60_000)} minute(s). ` +
+              "Are you blocked? Please report status or continue working.",
+            metadata: { workflowId, idleMs, event: "stall_detected" },
+          });
+        }
+      });
+
+      // Wall-clock terminal timeout for running workflows (closes the gap
+      // where stall detection only notifies and never terminates a hung manager).
+      const runningAge = Date.now() - new Date(workflow.createdAt).getTime();
+      if (runningAge > RUNNING_WALL_CLOCK_TIMEOUT_MS) {
+        for (const agentId of agentIds) {
+          agentManager.pause(agentId);
+        }
+        workflow.status = "failed";
+        workflow.error = "Workflow exceeded the 60-minute wall-clock limit and was terminated.";
+        workflow.updatedAt = new Date().toISOString();
+        logger.warn(`[workflow-watchdog] Wall-clock timeout for workflow ${wfId}`);
+      }
+    }
+  }, 60_000);
+
+  // Don't hold the event loop open if the server shuts down
+  watchdogInterval.unref();
 
   /**
    * POST /api/workflows/linear
    * Start a new Linear-to-PR workflow
    */
-  router.post("/api/workflows/linear", requireHumanUser, (req: Request, res: Response) => {
+  router.post("/api/workflows/linear", requireNotAgentService, async (req: Request, res: Response) => {
     try {
-      const { linearUrl, repository } = req.body ?? {};
+      const {
+        linearUrl,
+        repository,
+        repositoryUrl,
+        linearApiKey,
+        githubPat,
+        model,
+        maxTurns,
+        costEstimate,
+        basicMode,
+      } = req.body ?? {};
 
       if (!linearUrl || typeof linearUrl !== "string") {
         res.status(400).json({ error: "linearUrl is required" });
         return;
       }
 
-      if (!repository || typeof repository !== "string") {
-        res.status(400).json({ error: "repository is required" });
+      // API-1: Validate optional credential fields early (format only — never log values)
+      if (linearApiKey !== undefined) {
+        if (typeof linearApiKey !== "string" || !isValidLinearApiKey(linearApiKey)) {
+          res.status(400).json({ error: "Invalid linearApiKey format. Expected lin_api_... prefix." });
+          return;
+        }
+        registerSecretValue(linearApiKey);
+      }
+
+      if (githubPat !== undefined) {
+        if (typeof githubPat !== "string" || !isValidGithubPat(githubPat)) {
+          res.status(400).json({
+            error: "Invalid githubPat format. Expected ghp_..., github_pat_..., or 40-char hex token.",
+          });
+          return;
+        }
+        registerSecretValue(githubPat);
+      }
+
+      // Accept either repositoryUrl (git URL) or repository (bare name)
+      const repoInput = repositoryUrl || repository;
+      if (!repoInput || typeof repoInput !== "string") {
+        res.status(400).json({ error: "repository or repositoryUrl is required" });
         return;
       }
 
-      // Validate repository name format (prevents prompt injection)
-      if (!REPO_NAME_RE.test(repository) || repository.length > 100) {
-        res.status(400).json({
-          error: "Invalid repository name. Use alphanumeric characters, hyphens, underscores, and dots only.",
-        });
+      // Resolve repository: validates name or auto-clones from URL
+      const repoResult = await resolveRepository(
+        repoInput.trim(),
+        typeof githubPat === "string" ? githubPat : undefined,
+      );
+      if (!repoResult.ok) {
+        res.status(400).json({ error: repoResult.error });
         return;
       }
+      const resolvedRepoName = repoResult.name;
 
-      // Validate Linear URL (anchored to https://linear.app)
+      // Validate Linear URL — supports issues, projects, cycles, views
       const parsed = parseLinearUrl(linearUrl);
       if (!parsed) {
         res.status(400).json({
-          error: "Invalid Linear URL. Expected format: https://linear.app/team/issue/TEAM-123",
+          error:
+            "Invalid Linear URL. Supported formats: " +
+            "https://linear.app/{workspace}/issue/TEAM-123, " +
+            "https://linear.app/{workspace}/project/{slug}, " +
+            "https://linear.app/{workspace}/cycle/{id}",
         });
+        return;
+      }
+
+      // API-1: Validate optional model
+      let resolvedModel: AllowedModel = DEFAULT_MODEL;
+      if (model !== undefined) {
+        if (!ALLOWED_MODELS.includes(model as AllowedModel)) {
+          res.status(400).json({ error: `Invalid model. Allowed values: ${ALLOWED_MODELS.join(", ")}` });
+          return;
+        }
+        resolvedModel = model as AllowedModel;
+      }
+
+      // API-1: Validate optional maxTurns
+      let resolvedMaxTurns = 100;
+      if (maxTurns !== undefined) {
+        const turns = Number(maxTurns);
+        if (!Number.isInteger(turns) || turns < 1 || turns > 500) {
+          res.status(400).json({ error: "maxTurns must be an integer between 1 and 500." });
+          return;
+        }
+        resolvedMaxTurns = turns;
+      }
+
+      // INF-4: Reject new workflows when system memory is above the threshold
+      const memErr = checkMemoryForNewWorkflow();
+      if (memErr) {
+        res.status(503).json({ error: memErr });
         return;
       }
 
       // Reconstruct a safe URL from parsed components to prevent prompt injection
       const safeLinearUrl = buildSafeLinearUrl(parsed);
 
-      // Check concurrent workflow limit
-      const active = Array.from(workflows.values()).filter((w) => w.status === "starting" || w.status === "running");
+      // Check concurrent workflow limit (include validating/grading so the cap is honest — PR-5/PR-7)
+      const active = Array.from(workflows.values()).filter(
+        (w) =>
+          w.status === "validating" ||
+          w.status === "starting" ||
+          w.status === "running" ||
+          w.status === "grading" ||
+          w.status === "awaiting_confirm",
+      );
       if (active.length >= MAX_WORKFLOWS) {
         res.status(429).json({
           error: `Maximum ${MAX_WORKFLOWS} concurrent workflows allowed. Wait for an existing workflow to complete.`,
         });
+        return;
+      }
+
+      // INF-4: Check per-workflow agent limit (1 manager spawned here; sub-agents added later)
+      const agentLimitErr = checkWorkflowAgentLimit(1, WORKFLOW_MAX_AGENTS);
+      if (agentLimitErr) {
+        res.status(503).json({ error: agentLimitErr });
         return;
       }
 
@@ -114,44 +568,86 @@ export function createWorkflowsRouter(agentManager: AgentManager, messageBus: Me
       const workflow: LinearWorkflow = {
         id: workflowId,
         linearUrl: safeLinearUrl,
-        repository,
+        repository: resolvedRepoName,
         status: "starting",
         agents: [],
+        hasCredentials: !!(linearApiKey || githubPat),
+        metadata: {},
+        // INF-1: Store cost estimate for cap enforcement (0 = no cap)
+        costEstimate: typeof costEstimate === "number" && costEstimate > 0 ? costEstimate : undefined,
         createdAt: now,
         updatedAt: now,
       };
 
       workflows.set(workflowId, workflow);
-      evictStaleWorkflows(workflows);
+      evictStaleWorkflows();
 
-      // Spawn the manager agent, then respond with the result
-      const managerPrompt = buildManagerPrompt(safeLinearUrl, repository, workflowId);
+      if (basicMode === true) {
+        // Basic mode: spawn a triage agent to validate ticket detail before building.
+        // The manager is NOT spawned here — the subscribe seam spawns it after a successful verdict.
+        try {
+          const triagePrompt = buildTriagePrompt(safeLinearUrl, workflowId);
+          const { agent: triageAgent } = agentManager.create({
+            prompt: triagePrompt,
+            name: `workflow-triage-${workflowId.slice(0, 8)}`,
+            model: "claude-haiku-4-5-20251001",
+            // 6 turns was too tight: reading the Linear ticket via MCP + posting the
+            // verdict message routinely exhausted the budget before the verdict was sent,
+            // tripping the 5-min VALIDATING_TIMEOUT_MS watchdog. 15 gives headroom while
+            // staying well under the manager budget (Haiku keeps the extra turns cheap).
+            maxTurns: 15,
+            role: "workflow-triage",
+            // Never allow Basic-lane agents to self-merge (security invariant)
+          });
 
-      try {
-        const managerName = `workflow-${parsed.issueId.toLowerCase()}`;
-        const { agent } = agentManager.create({
-          prompt: managerPrompt,
-          name: managerName,
-          model: "claude-sonnet-4-6",
-          maxTurns: 100,
-          role: "workflow-manager",
-        });
+          workflow.triageAgentId = triageAgent.id;
+          workflow.agents.push({ id: triageAgent.id, name: triageAgent.name, role: "triage" });
+          workflow.status = "validating";
+          workflow.updatedAt = new Date().toISOString();
+          workflowAgentCache = null;
 
-        workflow.agents.push({ id: agent.id, name: managerName, role: "manager" });
-        workflow.status = "running";
-        workflow.updatedAt = new Date().toISOString();
+          res.status(201).json({ workflow });
+        } catch (err) {
+          logger.error(`[Workflows] Failed to spawn triage agent for ${workflowId}: ${errorMessage(err)}`);
+          workflow.status = "failed";
+          workflow.error = errorMessage(err);
+          workflow.updatedAt = new Date().toISOString();
+          res.status(500).json({ error: `Failed to start workflow: ${errorMessage(err)}`, workflow });
+        }
+      } else {
+        // Advanced path (default): spawn manager immediately, byte-identical to prior behaviour.
+        const managerPrompt = buildManagerPrompt(safeLinearUrl, resolvedRepoName, workflowId, parsed.entityType);
 
-        res.status(201).json({ workflow });
-      } catch (err: unknown) {
-        logger.error(`[Workflows] Failed to spawn manager for ${workflowId}`, { error: errorMessage(err) });
-        workflow.status = "failed";
-        workflow.error = errorMessage(err);
-        workflow.updatedAt = new Date().toISOString();
+        try {
+          const entityLabel = parsed.team
+            ? parsed.entityId.toLowerCase()
+            : `${parsed.entityType}-${parsed.entityId.slice(0, 8).toLowerCase()}`;
+          const managerName = `workflow-${entityLabel}`;
+          const { agent } = agentManager.create({
+            prompt: managerPrompt,
+            name: managerName,
+            model: resolvedModel,
+            maxTurns: resolvedMaxTurns,
+            role: "workflow-manager",
+          });
 
-        res.status(500).json({ error: `Failed to start workflow: ${errorMessage(err)}`, workflow });
+          workflow.agents.push({ id: agent.id, name: managerName, role: "manager" });
+          workflow.status = "running";
+          workflow.updatedAt = new Date().toISOString();
+          // Invalidate INF-2 cache so the new manager is immediately protected from TTL cleanup
+          workflowAgentCache = null;
+
+          res.status(201).json({ workflow });
+        } catch (err) {
+          logger.error(`[Workflows] Failed to spawn manager for ${workflowId}: ${errorMessage(err)}`);
+          workflow.status = "failed";
+          workflow.error = errorMessage(err);
+          workflow.updatedAt = new Date().toISOString();
+          res.status(500).json({ error: `Failed to start workflow: ${errorMessage(err)}`, workflow });
+        }
       }
-    } catch (err: unknown) {
-      logger.error("[Workflows] Error starting workflow", { error: errorMessage(err) });
+    } catch (err) {
+      logger.error(`[Workflows] Error starting workflow: ${String(err)}`);
       res.status(500).json({ error: errorMessage(err) });
     }
   });
@@ -169,7 +665,7 @@ export function createWorkflowsRouter(agentManager: AgentManager, messageBus: Me
 
   /**
    * GET /api/workflows/:id
-   * Get workflow status
+   * Get workflow status with live agent state and aggregated cost
    */
   router.get("/api/workflows/:id", (req: Request<{ id: string }>, res: Response) => {
     const workflow = workflows.get(req.params.id);
@@ -179,26 +675,123 @@ export function createWorkflowsRouter(agentManager: AgentManager, messageBus: Me
     }
 
     // Enrich with live agent status
-    const enriched = {
-      ...workflow,
-      agents: workflow.agents.map((a) => {
-        const agent = agentManager.get(a.id);
-        return {
-          ...a,
-          status: agent?.status ?? "unknown",
-          currentTask: agent?.currentTask,
-        };
-      }),
-    };
+    const enrichedAgents = workflow.agents.map((a) => {
+      const agent = agentManager.get(a.id);
+      return {
+        ...a,
+        status: agent?.status ?? "unknown",
+        currentTask: agent?.currentTask,
+      };
+    });
 
-    res.json(enriched);
+    // API-3: Aggregate token usage and estimated cost across all workflow agents
+    let totalTokensIn = 0;
+    let totalTokensOut = 0;
+    let totalTokens = 0;
+    let estimatedCost = 0;
+    for (const a of workflow.agents) {
+      const usage = agentManager.getUsage(a.id);
+      if (usage) {
+        totalTokensIn += usage.tokensIn;
+        totalTokensOut += usage.tokensOut;
+        totalTokens += usage.tokensTotal;
+        estimatedCost += usage.estimatedCost;
+      }
+    }
+
+    res.json({
+      ...workflow,
+      agents: enrichedAgents,
+      cost: {
+        totalTokensIn,
+        totalTokensOut,
+        totalTokens,
+        estimatedCost: Math.round(estimatedCost * 1e6) / 1e6,
+      },
+    });
+  });
+
+  /**
+   * GET /api/workflows/:id/logs
+   * Aggregate logs from all agents in a workflow
+   */
+  router.get("/api/workflows/:id/logs", async (req: Request<{ id: string }>, res: Response) => {
+    const workflow = workflows.get(req.params.id);
+    if (!workflow) {
+      res.status(404).json({ error: "Workflow not found" });
+      return;
+    }
+
+    const tailParam = req.query.tail ? Number.parseInt(req.query.tail as string, 10) : undefined;
+    const tail = tailParam && Number.isFinite(tailParam) && tailParam > 0 ? Math.min(tailParam, 1000) : undefined;
+
+    // Filter to a specific agent if requested
+    const agentFilter = typeof req.query.agent === "string" ? req.query.agent : undefined;
+    const agentsToQuery = agentFilter ? workflow.agents.filter((a) => a.id === agentFilter) : workflow.agents;
+
+    if (agentFilter && agentsToQuery.length === 0) {
+      res.status(404).json({ error: "Agent not found in this workflow" });
+      return;
+    }
+
+    const agentLogs = await Promise.all(
+      agentsToQuery.map(async (a) => {
+        try {
+          const { lines, total } = await agentManager.getLogs(a.id, { tail });
+          return { agentId: a.id, agentName: a.name, role: a.role, lines, total };
+        } catch (err) {
+          logger.warn(`[Workflows] Failed to get logs for agent ${a.id}: ${errorMessage(err)}`);
+          return { agentId: a.id, agentName: a.name, role: a.role, lines: [], total: 0 };
+        }
+      }),
+    );
+
+    res.json({ workflowId: req.params.id, agents: agentLogs });
+  });
+
+  /**
+   * POST /api/workflows/:id/confirm
+   * API-4: User confirmation gate — transitions workflow from awaiting_confirm to running.
+   * The workflow manager agent is notified via the message bus so it can proceed.
+   */
+  router.post("/api/workflows/:id/confirm", requireNotAgentService, (req: Request<{ id: string }>, res: Response) => {
+    const workflow = workflows.get(req.params.id);
+    if (!workflow) {
+      res.status(404).json({ error: "Workflow not found" });
+      return;
+    }
+
+    if (workflow.status !== "awaiting_confirm") {
+      res.status(409).json({
+        error: `Cannot confirm workflow with status '${workflow.status}'. Workflow must be in 'awaiting_confirm' state.`,
+      });
+      return;
+    }
+
+    workflow.status = "running";
+    workflow.updatedAt = new Date().toISOString();
+
+    // Notify the workflow manager so it can proceed past the confirmation gate
+    const manager = workflow.agents.find((a) => a.role === "manager");
+    if (manager) {
+      messageBus.post({
+        from: "platform",
+        fromName: "platform",
+        to: manager.id,
+        type: "info",
+        content: "User confirmed. Proceed with workflow execution.",
+        metadata: { workflowId: workflow.id, confirmed: true },
+      });
+    }
+
+    res.json({ workflow });
   });
 
   /**
    * DELETE /api/workflows/:id
    * Cancel a workflow and destroy its agents
    */
-  router.delete("/api/workflows/:id", requireHumanUser, async (req: Request<{ id: string }>, res: Response) => {
+  router.delete("/api/workflows/:id", requireNotAgentService, async (req: Request<{ id: string }>, res: Response) => {
     const workflow = workflows.get(req.params.id);
     if (!workflow) {
       res.status(404).json({ error: "Workflow not found" });
@@ -208,24 +801,22 @@ export function createWorkflowsRouter(agentManager: AgentManager, messageBus: Me
     // Destroy all associated agents
     for (const agent of workflow.agents) {
       try {
-        const destroyed = await agentManager.destroy(agent.id);
-        if (!destroyed) {
-          logger.warn("[Workflows] Agent already gone on cancel", { agentId: agent.id });
-        }
-      } catch (err: unknown) {
-        logger.warn(`[Workflows] Failed to destroy agent ${agent.id}`, { error: errorMessage(err) });
+        await agentManager.destroy(agent.id);
+      } catch (err) {
+        logger.warn(`[Workflows] Failed to destroy agent ${agent.id}: ${errorMessage(err)}`);
       }
     }
 
     workflow.status = "cancelled";
     workflow.updatedAt = new Date().toISOString();
+    workflowAgentCache = null;
 
     res.json({ ok: true, workflow });
   });
 
-  // Listen for workflow completion messages
+  // Listen for workflow messages from manager agents
   messageBus.subscribe((msg) => {
-    if (msg.type !== "result" || !msg.metadata?.workflowId) return;
+    if (!msg.metadata?.workflowId) return;
 
     const wfId = msg.metadata.workflowId;
     if (typeof wfId !== "string") return;
@@ -233,14 +824,200 @@ export function createWorkflowsRouter(agentManager: AgentManager, messageBus: Me
     const workflow = workflows.get(wfId);
     if (!workflow) return;
 
-    // Check if message contains a PR URL
-    const prMatch = msg.content.match(/https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/pull\/\d+/);
-    if (prMatch) {
-      workflow.prUrl = prMatch[0];
-      workflow.status = "completed";
+    // §5d-security: Identity-bound triage verdict ingestion.
+    // MUST sit before the metadata-merge / completion branches so it cannot fall through.
+    if (msg.metadata.triageVerdict && workflow.status === "validating") {
+      // Reject any verdict not from the recorded triage agent for this workflow.
+      if (msg.from !== workflow.triageAgentId || !agentManager.get(msg.from)) {
+        logger.warn(`[Workflows] Ignoring triageVerdict from unrecognised agent ${msg.from} for workflow ${wfId}`);
+        return;
+      }
+
+      const verdict = msg.metadata.triageVerdict as Record<string, unknown>;
+      const checks = verdict.checks as TriageChecks | undefined;
+      const missing = Array.isArray(verdict.missing) ? (verdict.missing as string[]) : [];
+      const suggestions = Array.isArray(verdict.suggestions) ? (verdict.suggestions as string[]) : [];
+      const readError =
+        typeof verdict.readError === "string"
+          ? (verdict.readError as NonNullable<LinearWorkflow["validation"]>["readError"])
+          : undefined;
+
+      // Backend computes clarity + verdict from agent-supplied boolean checks.
+      // Any non-accept outcome (incl. any readError) → reject; never trust self-assessed verdict.
+      let triageVerdict: "accept" | "accept_with_caveats" | "reject" = "reject";
+      let clarity: "high" | "medium" | "low" = "low";
+
+      if (!readError && checks) {
+        clarity = clarityFromChecks(checks);
+        triageVerdict = verdictFromClarity(clarity);
+      }
+
+      const validation = buildValidationResult(
+        checks ?? { substance: false, goalClarity: false, doneDef: false, scopeSignal: false, actionability: false },
+        triageVerdict,
+        clarity,
+        missing,
+        suggestions,
+        readError,
+      );
+
+      workflow.validation = validation;
       workflow.updatedAt = new Date().toISOString();
+
+      if (triageVerdict === "reject" || readError) {
+        // Fail-closed: reject → status rejected, destroy triage agent, do NOT spawn manager.
+        workflow.status = "rejected";
+        if (workflow.triageAgentId) agentManager.destroy(workflow.triageAgentId);
+      } else {
+        // Accept: transition to running and spawn the build-team manager.
+        workflow.status = "running";
+        if (workflow.triageAgentId) agentManager.destroy(workflow.triageAgentId);
+
+        const managerPrompt = buildManagerPrompt(workflow.linearUrl, workflow.repository, workflow.id, "issue");
+        const entityLabel = `workflow-${workflow.id.slice(0, 8)}`;
+        try {
+          const { agent: manager } = agentManager.create({
+            prompt: managerPrompt,
+            name: entityLabel,
+            model: DEFAULT_MODEL,
+            maxTurns: 100,
+            role: "workflow-manager",
+            // Never allow Basic-lane agents to self-merge (security invariant)
+          });
+          workflow.agents.push({ id: manager.id, name: entityLabel, role: "manager" });
+          workflowAgentCache = null;
+        } catch (err) {
+          logger.error(`[Workflows] Failed to spawn manager after triage accept: ${errorMessage(err)}`);
+          workflow.status = "failed";
+          workflow.error = errorMessage(err);
+        }
+      }
+
+      workflow.updatedAt = new Date().toISOString();
+      return;
+    }
+
+    // §5e: Identity-bound workflowGrade ingestion.
+    // Handles: grader reports grade → backend runs gradeGate → posts gradeDecision to manager.
+    if (msg.metadata.workflowGrade && workflow.status === "grading") {
+      const raw = msg.metadata.workflowGrade as Record<string, unknown>;
+      const reportedGraderAgentId = typeof raw.graderAgentId === "string" ? raw.graderAgentId : undefined;
+
+      // Reject grade from any agent not recorded as this workflow's grader.
+      if (
+        !reportedGraderAgentId ||
+        reportedGraderAgentId !== workflow.graderAgentId ||
+        !agentManager.get(reportedGraderAgentId)
+      ) {
+        logger.warn(`[Workflows] Ignoring workflowGrade from unrecognised agent ${msg.from} for workflow ${wfId}`);
+        return;
+      }
+
+      // Build a real GradeResult via createGrade (validates axes, computes numericScore).
+      let grade: GradeResult;
+      try {
+        grade = createGrade({
+          taskId: workflow.id,
+          agentId: reportedGraderAgentId,
+          ticketClarity: raw.ticketClarity as "high" | "medium" | "low",
+          fixConfidence: raw.fixConfidence as "high" | "medium" | "low",
+          blastRadius: raw.blastRadius as "isolated" | "moderate" | "broad",
+          reasoning: typeof raw.reasoning === "string" ? raw.reasoning : undefined,
+        });
+      } catch (err) {
+        logger.warn(`[Workflows] Invalid workflowGrade payload for ${wfId}: ${errorMessage(err)}`);
+        workflow.status = "failed";
+        workflow.error = "Grader returned invalid grade payload.";
+        workflow.updatedAt = new Date().toISOString();
+        return;
+      }
+
+      // Store grade + inverted confidence (higher = better for display).
+      workflow.grade = grade;
+      workflow.confidence = confidenceFromGrade(grade);
+      workflow.updatedAt = new Date().toISOString();
+
+      const decision = gradeGate(grade);
+
+      // Post gradeDecision back to the manager so it can act.
+      const manager = workflow.agents.find((a) => a.role === "manager");
+      if (manager) {
+        messageBus.post({
+          from: "platform",
+          fromName: "platform",
+          to: manager.id,
+          type: "info",
+          content: `Grade decision: ${decision}. Risk: ${grade.overallRisk}. ${grade.reasoning ?? ""}`,
+          metadata: { workflowId: wfId, gradeDecision: decision, overallRisk: grade.overallRisk },
+        });
+      }
+
+      if (decision === "NEEDS_HUMAN") {
+        // High risk — withhold PR, no retry in v1.
+        workflow.status = "needs_human";
+        workflow.updatedAt = new Date().toISOString();
+        if (workflow.graderAgentId) agentManager.destroy(workflow.graderAgentId);
+      }
+      // If CREATE_PR: status stays 'grading' until the completion handler sees a PR URL + valid grade.
+      return;
+    }
+
+    // Grader spawned: manager reports grader agent ID so backend can record it for identity binding.
+    // Also transitions workflow to 'grading' status.
+    if (msg.metadata.workflowGraderSpawned && typeof msg.metadata.workflowGraderSpawned === "string") {
+      workflow.graderAgentId = msg.metadata.workflowGraderSpawned;
+      workflow.status = "grading";
+      workflow.updatedAt = new Date().toISOString();
+      return;
+    }
+
+    // Metadata update: manager writes issueDetails/costEstimate before awaiting_confirm
+    if (msg.metadata.workflowMetadata && typeof msg.metadata.workflowMetadata === "object") {
+      workflow.metadata = { ...workflow.metadata, ...(msg.metadata.workflowMetadata as Record<string, unknown>) };
+      workflow.updatedAt = new Date().toISOString();
+    }
+
+    // §5e grade-aware completion: PR-URL result only completes when a passing grade exists.
+    // While status==='grading' without a grade (or high-risk grade), ignore PR-URL results.
+    if (msg.type === "result") {
+      const prMatch = msg.content.match(/https:\/\/github\.com\/[\w.-]+\/[\w.-]+\/pull\/\d+/);
+      if (prMatch) {
+        const hasPassingGrade = workflow.grade && gradeGate(workflow.grade) === "CREATE_PR";
+        if (workflow.status === "grading" && !hasPassingGrade) {
+          // Grade not yet recorded or high-risk — do NOT complete.
+          logger.warn(`[Workflows] Ignoring PR-URL result for ${wfId}: no passing grade yet`);
+          return;
+        }
+        workflow.prUrl = prMatch[0];
+        workflow.status = "completed";
+        workflow.updatedAt = new Date().toISOString();
+      }
     }
   });
 
   return router;
+}
+
+/** Test-only: clear the in-memory workflow store between tests. */
+export function _clearWorkflowsForTest(): void {
+  workflows.clear();
+}
+
+/** Test-only: inject a workflow directly into the store (for concurrency/security tests). */
+export function _injectWorkflowForTest(workflow: LinearWorkflow): void {
+  workflows.set(workflow.id, workflow);
+}
+
+/** Test-only: apply wall-clock timeout check to all running workflows in the store.
+ *  Simulates one watchdog tick without needing to wait for the setInterval. */
+export function _runWallClockTimeoutCheckForTest(): void {
+  for (const [_wfId, workflow] of workflows) {
+    if (workflow.status !== "running") continue;
+    const age = Date.now() - new Date(workflow.createdAt).getTime();
+    if (age > RUNNING_WALL_CLOCK_TIMEOUT_MS) {
+      workflow.status = "failed";
+      workflow.error = "Workflow exceeded the 60-minute wall-clock limit and was terminated.";
+      workflow.updatedAt = new Date().toISOString();
+    }
+  }
 }

--- a/src/workflow-audit.ts
+++ b/src/workflow-audit.ts
@@ -1,0 +1,44 @@
+import { logger } from "./logger";
+
+/**
+ * Workflow credential access audit trail.
+ *
+ * Logs structured [AUDIT] entries for every credential lifecycle event so that
+ * operators can trace exactly when and how credentials were created, read,
+ * injected into agent environments, or deleted.
+ *
+ * All events are emitted through the existing logger so they appear in the
+ * same log stream as other server activity (JSON in production, coloured text
+ * in development) and can be filtered with standard tooling.
+ */
+
+export type CredentialEventType = "create" | "read" | "inject" | "delete";
+
+export interface CredentialAccessEvent {
+  /** Type of operation performed on the credential. */
+  eventType: CredentialEventType;
+  /** Service / integration the credential belongs to (e.g. "github", "linear"). */
+  service: string;
+  /** Agent that performed the operation, if applicable. */
+  agentId?: string;
+  /** Workflow context this credential access belongs to, if applicable. */
+  workflowId?: string;
+  /** Caller location for traceability (e.g. "workflow-credentials:saveWorkflowCredentials"). */
+  caller?: string;
+}
+
+/**
+ * Log a credential access event to the audit trail.
+ *
+ * Example output (production JSON):
+ *   {"level":"info","timestamp":"...","message":"[AUDIT] credential.create","service":"github","workflowId":"abc123","caller":"workflow-credentials:save"}
+ */
+export function logCredentialAccess(event: CredentialAccessEvent): void {
+  const { eventType, service, agentId, workflowId, caller } = event;
+  logger.info(`[AUDIT] credential.${eventType}`, {
+    service,
+    ...(agentId !== undefined && { agentId }),
+    ...(workflowId !== undefined && { workflowId }),
+    ...(caller !== undefined && { caller }),
+  });
+}

--- a/src/workflow-credentials.ts
+++ b/src/workflow-credentials.ts
@@ -1,0 +1,282 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { logger } from "./logger";
+import { registerSecretValue, unregisterSecretValue } from "./sanitize";
+import { errorMessage } from "./types";
+
+/**
+ * Per-workflow credential storage for Linear API keys and GitHub PATs.
+ *
+ * Credentials are:
+ * - Encrypted at rest with AES-256-GCM (key derived via PBKDF2 from ENCRYPTION_KEY or JWT_SECRET)
+ * - Stored at /persistent/workflow-creds/{workflowId}.json with mode 0600
+ * - Auto-expired after 4h TTL
+ * - Registered with sanitize.ts for log redaction
+ * - Deleted on workflow terminal state (completed/failed/cancelled)
+ */
+
+export interface WorkflowCredentials {
+  workflowId: string;
+  linearApiKey?: string;
+  githubPat?: string;
+  expiresAt: string;
+  createdAt: string;
+}
+
+const CREDS_DIR = process.env.WORKFLOW_CREDS_DIR || "/persistent/workflow-creds";
+const MAX_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
+
+const KEY_LEN = 32; // 256-bit key for AES-256-GCM
+const IV_LEN = 12; // 96-bit IV (recommended for GCM)
+const PBKDF2_ITERATIONS = 100_000;
+const PBKDF2_DIGEST = "sha256";
+// Fixed subsystem salt — prevents cross-subsystem key reuse if the secret is shared
+const KDF_SALT = "agentManager-workflow-credentials-v1";
+
+// Lazy-derived key — computed once per process on first use
+let _derivedKey: Buffer | null = null;
+
+/**
+ * Derive a 32-byte AES-256 encryption key via PBKDF2.
+ * Uses ENCRYPTION_KEY env var (preferred) or JWT_SECRET as the input secret.
+ */
+function deriveKey(): Buffer {
+  if (_derivedKey) return _derivedKey;
+  const secret = process.env.ENCRYPTION_KEY || process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error("[workflow-credentials] No encryption key available. Set ENCRYPTION_KEY or JWT_SECRET.");
+  }
+  _derivedKey = crypto.pbkdf2Sync(secret, KDF_SALT, PBKDF2_ITERATIONS, KEY_LEN, PBKDF2_DIGEST);
+  return _derivedKey;
+}
+
+/** Invalidate the cached derived key (e.g. after key rotation in tests). */
+export function invalidateKeyCache(): void {
+  _derivedKey = null;
+}
+
+/** Encrypt plaintext with AES-256-GCM. Returns "iv:authTag:ciphertext" (base64). */
+function encrypt(plaintext: string): string {
+  const key = deriveKey();
+  const iv = crypto.randomBytes(IV_LEN);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return [iv.toString("base64"), authTag.toString("base64"), encrypted.toString("base64")].join(":");
+}
+
+/** Decrypt ciphertext from "iv:authTag:ciphertext" format. Throws on tamper. */
+function decrypt(ciphertext: string): string {
+  const parts = ciphertext.split(":");
+  if (parts.length !== 3) throw new Error("Invalid ciphertext format");
+  const [ivB64, authTagB64, dataB64] = parts;
+  const key = deriveKey();
+  const iv = Buffer.from(ivB64, "base64");
+  const authTag = Buffer.from(authTagB64, "base64");
+  const data = Buffer.from(dataB64, "base64");
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(data), decipher.final()]).toString("utf8");
+}
+
+function ensureCredsDir(): void {
+  if (!fs.existsSync(CREDS_DIR)) {
+    fs.mkdirSync(CREDS_DIR, { recursive: true, mode: 0o700 });
+  }
+}
+
+function getCredsFilePath(workflowId: string): string {
+  // Sanitize to prevent path traversal
+  const safe = workflowId.replace(/[^a-zA-Z0-9_-]/g, "");
+  if (!safe) throw new Error("Invalid workflowId");
+  return path.join(CREDS_DIR, `${safe}.json`);
+}
+
+interface StoredCredFile {
+  workflowId: string;
+  encrypted: string;
+  expiresAt: string;
+  createdAt: string;
+}
+
+/**
+ * Store encrypted workflow credentials.
+ * Registers secret values for log redaction.
+ * Returns the stored credential record (with plaintext values for immediate use).
+ */
+export function storeWorkflowCredentials(
+  workflowId: string,
+  creds: { linearApiKey?: string; githubPat?: string },
+): WorkflowCredentials {
+  ensureCredsDir();
+
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + MAX_TTL_MS).toISOString();
+  const plaintext = JSON.stringify({
+    linearApiKey: creds.linearApiKey,
+    githubPat: creds.githubPat,
+  });
+
+  const encrypted = encrypt(plaintext);
+  const stored: StoredCredFile = {
+    workflowId,
+    encrypted,
+    expiresAt,
+    createdAt: now.toISOString(),
+  };
+
+  const filePath = getCredsFilePath(workflowId);
+  const nonce = crypto.randomBytes(4).toString("hex");
+  const tmpPath = `${filePath}.tmp.${process.pid}.${nonce}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(stored, null, 2), { mode: 0o600 });
+  fs.renameSync(tmpPath, filePath);
+
+  // Register secrets for log redaction
+  if (creds.linearApiKey) registerSecretValue(creds.linearApiKey);
+  if (creds.githubPat) registerSecretValue(creds.githubPat);
+
+  logger.info(`[workflow-credentials] Stored credentials for workflow ${workflowId.slice(0, 8)}`);
+  return {
+    workflowId,
+    linearApiKey: creds.linearApiKey,
+    githubPat: creds.githubPat,
+    expiresAt,
+    createdAt: now.toISOString(),
+  };
+}
+
+/**
+ * Load and decrypt workflow credentials.
+ * Returns null if not found or expired.
+ */
+export function loadWorkflowCredentials(workflowId: string): WorkflowCredentials | null {
+  let filePath: string;
+  try {
+    filePath = getCredsFilePath(workflowId);
+  } catch {
+    return null;
+  }
+
+  if (!fs.existsSync(filePath)) return null;
+
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const stored = JSON.parse(raw) as StoredCredFile;
+
+    // Check TTL
+    if (new Date() >= new Date(stored.expiresAt)) {
+      logger.warn(`[workflow-credentials] Credentials expired for workflow ${workflowId.slice(0, 8)}`);
+      deleteWorkflowCredentials(workflowId);
+      return null;
+    }
+
+    const plaintext = decrypt(stored.encrypted);
+    const creds = JSON.parse(plaintext) as {
+      linearApiKey?: string;
+      githubPat?: string;
+    };
+
+    // Re-register for redaction (e.g. after process restart with warm cache)
+    if (creds.linearApiKey) registerSecretValue(creds.linearApiKey);
+    if (creds.githubPat) registerSecretValue(creds.githubPat);
+
+    return {
+      workflowId,
+      linearApiKey: creds.linearApiKey,
+      githubPat: creds.githubPat,
+      expiresAt: stored.expiresAt,
+      createdAt: stored.createdAt,
+    };
+  } catch (err: unknown) {
+    logger.error(
+      `[workflow-credentials] Failed to load credentials for workflow ${workflowId.slice(0, 8)}: ${errorMessage(err)}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Securely delete workflow credentials.
+ * Called on workflow terminal state (completed/failed/cancelled).
+ */
+export function deleteWorkflowCredentials(workflowId: string): void {
+  let filePath: string;
+  try {
+    filePath = getCredsFilePath(workflowId);
+  } catch {
+    return;
+  }
+
+  if (!fs.existsSync(filePath)) return;
+
+  try {
+    // Best-effort: unregister from redaction before deletion
+    try {
+      const raw = fs.readFileSync(filePath, "utf8");
+      const stored = JSON.parse(raw) as StoredCredFile;
+      const plaintext = decrypt(stored.encrypted);
+      const creds = JSON.parse(plaintext) as {
+        linearApiKey?: string;
+        githubPat?: string;
+      };
+      if (creds.linearApiKey) unregisterSecretValue(creds.linearApiKey);
+      if (creds.githubPat) unregisterSecretValue(creds.githubPat);
+    } catch {
+      // Non-fatal — file may be corrupt or already unregistered
+    }
+
+    fs.unlinkSync(filePath);
+    logger.info(`[workflow-credentials] Deleted credentials for workflow ${workflowId.slice(0, 8)}`);
+  } catch (err: unknown) {
+    logger.error(
+      `[workflow-credentials] Failed to delete credentials for workflow ${workflowId.slice(0, 8)}: ${errorMessage(err)}`,
+    );
+  }
+}
+
+/**
+ * Write a per-workflow MCP settings override into the agent workspace's .claude/ directory.
+ * Overrides the platform's global LINEAR_API_KEY with the user-supplied key so the
+ * Linear MCP server uses the workflow user's credentials, not the platform operator's.
+ */
+export function writeMcpOverride(workspaceDir: string, linearApiKey: string): void {
+  const claudeDir = path.join(workspaceDir, ".claude");
+  fs.mkdirSync(claudeDir, { recursive: true });
+
+  // Read the global settings.json from the platform's CLAUDE_HOME
+  const globalClaudeHome = process.env.CLAUDE_HOME || path.join(os.homedir(), ".claude");
+  const globalSettingsPath = path.join(globalClaudeHome, "settings.json");
+
+  let baseSettings: Record<string, unknown> = {};
+  try {
+    const raw = fs.readFileSync(globalSettingsPath, "utf8");
+    baseSettings = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    // Use empty settings if global not found — agent will use defaults
+  }
+
+  // Override the Linear MCP entry with workflow-scoped credentials
+  const overrideSettings = {
+    ...baseSettings,
+    mcpServers: {
+      ...(baseSettings.mcpServers as Record<string, unknown> | undefined),
+      linear: {
+        type: "http",
+        url: "https://mcp.linear.app/mcp",
+        headers: { Authorization: `Bearer ${linearApiKey}` },
+      },
+    },
+  };
+
+  const settingsPath = path.join(claudeDir, "settings.json");
+  const nonce = crypto.randomBytes(4).toString("hex");
+  const tmpPath = `${settingsPath}.tmp.${process.pid}.${nonce}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(overrideSettings, null, 2), {
+    mode: 0o600,
+  });
+  fs.renameSync(tmpPath, settingsPath);
+
+  logger.info("[workflow-credentials] Wrote MCP override for workflow (Linear key set)");
+}

--- a/src/workflow-engine.ts
+++ b/src/workflow-engine.ts
@@ -1,0 +1,377 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { logger } from "./logger";
+
+// ─── Workflow Status (State Machine) ─────────────────────────────────────────
+
+export type WorkflowStatus =
+  | "created"
+  | "estimating"
+  | "awaiting_confirm"
+  | "running"
+  | "in_review"
+  | "merging"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "recovering";
+
+const TERMINAL_STATES: ReadonlySet<WorkflowStatus> = new Set(["completed", "failed", "cancelled"]);
+
+/** Valid state transitions per TD-4. `failed` and `cancelled` reachable from any non-terminal state. */
+const TRANSITIONS: Record<string, ReadonlySet<WorkflowStatus>> = {
+  created: new Set(["estimating", "failed", "cancelled"]),
+  estimating: new Set(["awaiting_confirm", "failed", "cancelled"]),
+  awaiting_confirm: new Set(["running", "failed", "cancelled"]),
+  running: new Set(["in_review", "recovering", "failed", "cancelled"]),
+  recovering: new Set(["running", "failed"]),
+  in_review: new Set(["merging", "running", "failed", "cancelled"]),
+  merging: new Set(["completed", "failed"]),
+};
+
+// ─── Interfaces ──────────────────────────────────────────────────────────────
+
+export interface WorkflowRun {
+  id: string;
+  linearUrl: string;
+  linearIssueId: string | null;
+  repository: string;
+  githubPatId: string | null;
+  linearTokenId: string | null;
+  status: WorkflowStatus;
+  phase: string | null;
+  costEstimateUsd: number | null;
+  costActualUsd: number | null;
+  taskCount: number;
+  prUrl: string | null;
+  error: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkflowAgent {
+  workflowId: string;
+  agentId: string;
+  role: string;
+  status: string | null;
+  createdAt: string;
+}
+
+export type WorkflowEventType = "status_changed" | "agent_added" | "agent_removed" | "cost_updated" | "error";
+
+export interface WorkflowEvent {
+  type: WorkflowEventType;
+  workflowId: string;
+  data: Record<string, unknown>;
+}
+
+// ─── Database Setup ──────────────────────────────────────────────────────────
+
+// Reuse scheduler.db per TD-1 — same pattern as scheduler.ts and cost-tracker.ts
+const DB_DIR = existsSync("/persistent") ? "/persistent/scheduler-data" : "/tmp/scheduler-data";
+const DB_PATH = path.join(DB_DIR, "scheduler.db");
+
+export const MAX_ACTIVE_WORKFLOWS = 5;
+
+// ─── WorkflowEngine ─────────────────────────────────────────────────────────
+
+export class WorkflowEngine {
+  private db: Database.Database;
+  private insertRunStmt: Database.Statement;
+  private updateStatusStmt: Database.Statement;
+  private setFieldStmt: Record<string, Database.Statement> = {};
+  private getRunStmt: Database.Statement;
+  private listRunsStmt: Database.Statement;
+  private listActiveRunsStmt: Database.Statement;
+  private activeCountStmt: Database.Statement;
+  private insertAgentStmt: Database.Statement;
+  private removeAgentStmt: Database.Statement;
+  private getAgentsStmt: Database.Statement;
+  private getAgentWorkflowStmt: Database.Statement;
+  private updateAgentStatusStmt: Database.Statement;
+  private listeners = new Set<(event: WorkflowEvent) => void>();
+
+  constructor(dbPath?: string) {
+    const resolvedPath = dbPath ?? DB_PATH;
+    mkdirSync(path.dirname(resolvedPath), { recursive: true });
+    this.db = new Database(resolvedPath);
+    this.db.pragma("journal_mode = WAL");
+    this.db.pragma("synchronous = NORMAL");
+    this.db.pragma("foreign_keys = ON");
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS workflow_runs (
+        id TEXT PRIMARY KEY,
+        linear_url TEXT NOT NULL,
+        linear_issue_id TEXT,
+        repository TEXT NOT NULL,
+        github_pat_id TEXT,
+        linear_token_id TEXT,
+        status TEXT NOT NULL DEFAULT 'created',
+        phase TEXT,
+        cost_estimate_usd REAL,
+        cost_actual_usd REAL,
+        task_count INTEGER NOT NULL DEFAULT 0,
+        pr_url TEXT,
+        error TEXT,
+        metadata TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS workflow_agents (
+        workflow_id TEXT NOT NULL REFERENCES workflow_runs(id) ON DELETE CASCADE,
+        agent_id TEXT NOT NULL,
+        role TEXT NOT NULL,
+        status TEXT,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (workflow_id, agent_id)
+      )
+    `);
+
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_wf_runs_status ON workflow_runs(status);
+      CREATE INDEX IF NOT EXISTS idx_wf_agents_agent ON workflow_agents(agent_id);
+    `);
+
+    this.insertRunStmt = this.db.prepare(`
+      INSERT INTO workflow_runs (id, linear_url, linear_issue_id, repository, status,
+                                  phase, cost_estimate_usd, task_count, metadata, created_at, updated_at)
+      VALUES (@id, @linearUrl, @linearIssueId, @repository, @status,
+              @phase, @costEstimateUsd, @taskCount, @metadata, @createdAt, @updatedAt)
+    `);
+
+    this.updateStatusStmt = this.db.prepare(
+      "UPDATE workflow_runs SET status = @status, updated_at = @updatedAt WHERE id = @id",
+    );
+
+    // Generic field update statements
+    for (const col of ["phase", "cost_estimate_usd", "cost_actual_usd", "pr_url", "error", "metadata", "task_count"]) {
+      this.setFieldStmt[col] = this.db.prepare(
+        `UPDATE workflow_runs SET ${col} = @value, updated_at = @updatedAt WHERE id = @id`,
+      );
+    }
+
+    this.getRunStmt = this.db.prepare("SELECT * FROM workflow_runs WHERE id = @id");
+    this.listRunsStmt = this.db.prepare("SELECT * FROM workflow_runs ORDER BY created_at DESC LIMIT @limit");
+    this.listActiveRunsStmt = this.db.prepare(
+      "SELECT * FROM workflow_runs WHERE status NOT IN ('completed','failed','cancelled') ORDER BY created_at DESC",
+    );
+    this.activeCountStmt = this.db.prepare(
+      "SELECT COUNT(*) as count FROM workflow_runs WHERE status NOT IN ('completed','failed','cancelled')",
+    );
+
+    this.insertAgentStmt = this.db.prepare(`
+      INSERT OR REPLACE INTO workflow_agents (workflow_id, agent_id, role, status, created_at)
+      VALUES (@workflowId, @agentId, @role, @status, @createdAt)
+    `);
+    this.removeAgentStmt = this.db.prepare(
+      "DELETE FROM workflow_agents WHERE workflow_id = @workflowId AND agent_id = @agentId",
+    );
+    this.getAgentsStmt = this.db.prepare("SELECT * FROM workflow_agents WHERE workflow_id = @workflowId");
+    this.getAgentWorkflowStmt = this.db.prepare(
+      "SELECT workflow_id FROM workflow_agents WHERE agent_id = @agentId LIMIT 1",
+    );
+    this.updateAgentStatusStmt = this.db.prepare(
+      "UPDATE workflow_agents SET status = @status WHERE workflow_id = @workflowId AND agent_id = @agentId",
+    );
+  }
+
+  // ─── Workflow CRUD ───────────────────────────────────────────────────────
+
+  create(params: {
+    linearUrl: string;
+    linearIssueId?: string;
+    repository: string;
+    metadata?: Record<string, unknown>;
+  }): WorkflowRun {
+    const activeCount = (this.activeCountStmt.get() as { count: number }).count;
+    if (activeCount >= MAX_ACTIVE_WORKFLOWS) {
+      throw new Error(
+        `Maximum ${MAX_ACTIVE_WORKFLOWS} concurrent workflows allowed. Wait for an existing workflow to complete.`,
+      );
+    }
+
+    const now = new Date().toISOString();
+    const id = randomUUID();
+    this.insertRunStmt.run({
+      id,
+      linearUrl: params.linearUrl,
+      linearIssueId: params.linearIssueId ?? null,
+      repository: params.repository,
+      status: "created",
+      phase: null,
+      costEstimateUsd: null,
+      taskCount: 0,
+      metadata: params.metadata ? JSON.stringify(params.metadata) : null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const run = this.get(id);
+    if (!run) throw new Error("Failed to create workflow run");
+    return run;
+  }
+
+  get(id: string): WorkflowRun | null {
+    const row = this.getRunStmt.get({ id }) as Record<string, unknown> | undefined;
+    return row ? this.rowToWorkflow(row) : null;
+  }
+
+  list(limit = 50): WorkflowRun[] {
+    return (this.listRunsStmt.all({ limit }) as Record<string, unknown>[]).map((r) => this.rowToWorkflow(r));
+  }
+
+  listActive(): WorkflowRun[] {
+    return (this.listActiveRunsStmt.all() as Record<string, unknown>[]).map((r) => this.rowToWorkflow(r));
+  }
+
+  activeCount(): number {
+    return (this.activeCountStmt.get() as { count: number }).count;
+  }
+
+  // ─── State Machine ───────────────────────────────────────────────────────
+
+  /** Transition a workflow to a new status. Validates the transition is legal. */
+  transition(id: string, newStatus: WorkflowStatus, error?: string): WorkflowRun {
+    const run = this.get(id);
+    if (!run) throw new Error(`Workflow not found: ${id}`);
+
+    if (TERMINAL_STATES.has(run.status)) {
+      throw new Error(`Cannot transition from terminal state '${run.status}'`);
+    }
+
+    const allowed = TRANSITIONS[run.status];
+    if (!allowed?.has(newStatus)) {
+      throw new Error(`Invalid transition: '${run.status}' → '${newStatus}'`);
+    }
+
+    const now = new Date().toISOString();
+    this.updateStatusStmt.run({ id, status: newStatus, updatedAt: now });
+    if (error) {
+      this.setFieldStmt.error.run({ id, value: error, updatedAt: now });
+    }
+
+    const updated = this.get(id);
+    if (!updated) throw new Error(`Workflow disappeared after transition: ${id}`);
+    this.emit({ type: "status_changed", workflowId: id, data: { from: run.status, to: newStatus } });
+    logger.info(`[workflow-engine] ${id.slice(0, 8)}: ${run.status} → ${newStatus}`, { workflowId: id });
+    return updated;
+  }
+
+  isTerminal(id: string): boolean {
+    const run = this.get(id);
+    return run ? TERMINAL_STATES.has(run.status) : true;
+  }
+
+  // ─── Field Updates ───────────────────────────────────────────────────────
+
+  setPhase(id: string, phase: string): void {
+    this.setFieldStmt.phase.run({ id, value: phase, updatedAt: new Date().toISOString() });
+  }
+
+  setCostEstimate(id: string, costUsd: number): void {
+    this.setFieldStmt.cost_estimate_usd.run({ id, value: costUsd, updatedAt: new Date().toISOString() });
+  }
+
+  setCostActual(id: string, costUsd: number): void {
+    this.setFieldStmt.cost_actual_usd.run({ id, value: costUsd, updatedAt: new Date().toISOString() });
+    this.emit({ type: "cost_updated", workflowId: id, data: { costActualUsd: costUsd } });
+  }
+
+  setPrUrl(id: string, prUrl: string): void {
+    this.setFieldStmt.pr_url.run({ id, value: prUrl, updatedAt: new Date().toISOString() });
+  }
+
+  setMetadata(id: string, metadata: Record<string, unknown>): void {
+    this.setFieldStmt.metadata.run({ id, value: JSON.stringify(metadata), updatedAt: new Date().toISOString() });
+  }
+
+  setTaskCount(id: string, count: number): void {
+    this.setFieldStmt.task_count.run({ id, value: count, updatedAt: new Date().toISOString() });
+  }
+
+  // ─── Agent Tracking ──────────────────────────────────────────────────────
+
+  addAgent(workflowId: string, agentId: string, role: string): void {
+    this.insertAgentStmt.run({ workflowId, agentId, role, status: null, createdAt: new Date().toISOString() });
+    this.emit({ type: "agent_added", workflowId, data: { agentId, role } });
+  }
+
+  removeAgent(workflowId: string, agentId: string): void {
+    this.removeAgentStmt.run({ workflowId, agentId });
+    this.emit({ type: "agent_removed", workflowId, data: { agentId } });
+  }
+
+  getAgents(workflowId: string): WorkflowAgent[] {
+    return (this.getAgentsStmt.all({ workflowId }) as Record<string, unknown>[]).map((r) => ({
+      workflowId: r.workflow_id as string,
+      agentId: r.agent_id as string,
+      role: r.role as string,
+      status: (r.status as string) ?? null,
+      createdAt: r.created_at as string,
+    }));
+  }
+
+  getWorkflowForAgent(agentId: string): string | null {
+    const row = this.getAgentWorkflowStmt.get({ agentId }) as { workflow_id: string } | undefined;
+    return row?.workflow_id ?? null;
+  }
+
+  updateAgentStatus(workflowId: string, agentId: string, status: string): void {
+    this.updateAgentStatusStmt.run({ workflowId, agentId, status });
+  }
+
+  // ─── Events ──────────────────────────────────────────────────────────────
+
+  subscribe(listener: (event: WorkflowEvent) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private emit(event: WorkflowEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch (err) {
+        logger.warn("[workflow-engine] Event listener error", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  // ─── Lifecycle ───────────────────────────────────────────────────────────
+
+  close(): void {
+    this.db.close();
+  }
+
+  // ─── Helpers ─────────────────────────────────────────────────────────────
+
+  private rowToWorkflow(row: Record<string, unknown>): WorkflowRun {
+    return {
+      id: row.id as string,
+      linearUrl: row.linear_url as string,
+      linearIssueId: (row.linear_issue_id as string) ?? null,
+      repository: row.repository as string,
+      githubPatId: (row.github_pat_id as string) ?? null,
+      linearTokenId: (row.linear_token_id as string) ?? null,
+      status: row.status as WorkflowStatus,
+      phase: (row.phase as string) ?? null,
+      costEstimateUsd: (row.cost_estimate_usd as number) ?? null,
+      costActualUsd: (row.cost_actual_usd as number) ?? null,
+      taskCount: (row.task_count as number) ?? 0,
+      prUrl: (row.pr_url as string) ?? null,
+      error: (row.error as string) ?? null,
+      metadata: row.metadata ? (JSON.parse(row.metadata as string) as Record<string, unknown>) : null,
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+    };
+  }
+}

--- a/src/workflow-grading.ts
+++ b/src/workflow-grading.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure grading gate logic for BKL-020 Basic mode confidence grading.
+ * All functions are pure (no I/O, no side effects).
+ * Reuses GradeResult from grading.ts — do NOT redefine.
+ *
+ * Invariant: workflow grade gates PR creation. CI confidence label gates merge. Neither reads the other's store.
+ */
+
+import type { GradeResult } from "./grading";
+
+/**
+ * Gate decision based on overall risk.
+ * low/medium → CREATE_PR; high → NEEDS_HUMAN (withhold, no PR in v1).
+ * Gates on overallRisk (worst-case-axis rule from computeRisk), NOT numericScore.
+ */
+export function gradeGate(g: GradeResult): "CREATE_PR" | "NEEDS_HUMAN" {
+  if (g.overallRisk === "high") return "NEEDS_HUMAN";
+  return "CREATE_PR";
+}
+
+/**
+ * Invert numericScore to a display-safe confidence value where higher = better.
+ * grading.ts numericScore is 0-100 where higher = riskier.
+ * CRITICAL: overallRisk==='high' always yields confidence < 60 (the Medium threshold).
+ */
+export function confidenceFromGrade(g: GradeResult): number {
+  return 100 - g.numericScore;
+}
+
+/** Build the prompt for the workflow grader agent (Opus, maxTurns:12, read-only). */
+export function buildGraderPrompt(workflowId: string, ticketUrl: string): string {
+  return `You are a workflow grader (READ-ONLY). Assess completed engineering work against the original ticket.
+
+Workflow: ${workflowId} | Ticket: ${ticketUrl}
+
+READ-ONLY: use git diff/log/show + /linear MCP. Do NOT make code changes, create PRs, or run mutating commands.
+
+1. Read the Linear ticket for acceptance criteria.
+2. Review the git diff and test results.
+3. Grade along three axes:
+   - ticketClarity: how well-specified was the ticket? (high/medium/low)
+   - fixConfidence: does the implementation correctly solve it? (high/medium/low)
+   - blastRadius: how much of the system is affected? (isolated/moderate/broad)
+4. Post ONE result with metadata:
+{"workflowId":"${workflowId}","workflowGrade":{"graderAgentId":"<YOUR AGENT ID from CLAUDE.md>","ticketClarity":"...","fixConfidence":"...","blastRadius":"...","reasoning":"2-3 sentences"}}
+Be conservative — grade lower when uncertain. A false high-confidence grade is a P0. Then stop.`;
+}

--- a/src/workflow-resource-manager.ts
+++ b/src/workflow-resource-manager.ts
@@ -1,0 +1,144 @@
+/**
+ * Workflow Resource Manager
+ *
+ * Infrastructure-level protections for Linear workflow runs:
+ * - INF-1: Cost cap enforcement — halt workflow agents when actual cost exceeds 2× the estimate
+ * - INF-3: Stall detection — detect when all workflow agents have been idle for >10 minutes
+ * - INF-4: Resource budgeting — system memory threshold and per-workflow agent limits
+ *
+ * These are pure functions designed to be called from the workflow router's periodic watchdog.
+ * They do not modify state directly; callers provide callbacks for side effects.
+ */
+
+import type { AgentManager } from "./agents";
+import { CONFIG } from "./config";
+import { logger } from "./logger";
+import { getContainerMemoryLimit, getContainerMemoryUsage } from "./utils/memory";
+
+/** Max agents allowed per workflow (default 10). Override via WORKFLOW_MAX_AGENTS env var. */
+export const WORKFLOW_MAX_AGENTS = Number(process.env.WORKFLOW_MAX_AGENTS ?? "10");
+
+/** Halt workflow when actual cost reaches this multiple of the cost estimate. */
+export const WORKFLOW_COST_CAP_MULTIPLIER = 2.0;
+
+/**
+ * Duration (ms) all agents must be inactive before declaring a workflow stalled.
+ * Default: 10 minutes. Override via WORKFLOW_STALL_TIMEOUT_MS env var.
+ */
+export const WORKFLOW_STALL_TIMEOUT_MS = Number(process.env.WORKFLOW_STALL_TIMEOUT_MS ?? String(10 * 60_000));
+
+/**
+ * INF-4: Check container/system memory before starting a new workflow.
+ * Uses cgroup v2 memory stats (accurate container-level usage including child processes).
+ * Returns an error message if usage exceeds MEMORY_REJECT_THRESHOLD, null if OK.
+ */
+export function checkMemoryForNewWorkflow(): string | null {
+  const used = getContainerMemoryUsage();
+  const limit = getContainerMemoryLimit();
+  const ratio = used / limit;
+  if (ratio > CONFIG.MEMORY_REJECT_THRESHOLD) {
+    return (
+      `System memory at ${Math.round(ratio * 100)}% ` +
+      `(threshold: ${Math.round(CONFIG.MEMORY_REJECT_THRESHOLD * 100)}%). ` +
+      "Cannot start new workflow."
+    );
+  }
+  return null;
+}
+
+/**
+ * INF-4: Check per-workflow agent count before spawning another agent.
+ * Returns an error message if the limit is reached, null if OK.
+ */
+export function checkWorkflowAgentLimit(currentCount: number, max = WORKFLOW_MAX_AGENTS): string | null {
+  if (currentCount >= max) {
+    return `Workflow agent limit reached (${currentCount}/${max}).`;
+  }
+  return null;
+}
+
+/**
+ * INF-1: Compute the total actual cost for a set of agent IDs by summing
+ * each agent's usage.estimatedCost from the AgentManager registry.
+ * Agents not found in the registry (destroyed) contribute 0.
+ */
+export function computeWorkflowActualCost(agentIds: string[], agentManager: AgentManager): number {
+  let total = 0;
+  for (const agentId of agentIds) {
+    total += agentManager.get(agentId)?.usage?.estimatedCost ?? 0;
+  }
+  return total;
+}
+
+/**
+ * INF-1: Enforce workflow cost cap.
+ * Computes actual cost for all agent IDs; if it meets or exceeds
+ * WORKFLOW_COST_CAP_MULTIPLIER × costEstimate, invokes onCap.
+ * No-op when costEstimate <= 0 (no estimate available, cap disabled).
+ */
+export function enforceWorkflowCostCap(
+  workflowId: string,
+  agentIds: string[],
+  costEstimate: number,
+  agentManager: AgentManager,
+  onCap: (workflowId: string, actualCost: number, cap: number) => void,
+): void {
+  if (costEstimate <= 0) return;
+  const actual = computeWorkflowActualCost(agentIds, agentManager);
+  const cap = costEstimate * WORKFLOW_COST_CAP_MULTIPLIER;
+  if (actual >= cap) {
+    logger.warn("[workflow-guard] INF-1: Workflow cost cap exceeded", {
+      workflowId,
+      actualCost: actual.toFixed(4),
+      cap: cap.toFixed(4),
+      multiplier: WORKFLOW_COST_CAP_MULTIPLIER,
+    });
+    onCap(workflowId, actual, cap);
+  }
+}
+
+/**
+ * INF-3: Detect whether all live agents in a workflow have been idle for
+ * longer than WORKFLOW_STALL_TIMEOUT_MS.
+ *
+ * "Live" means the agent still exists in the AgentManager registry; destroyed agents
+ * are skipped. If any agent is actively running or starting, returns false.
+ * Returns true and invokes onStall if a stall is detected.
+ */
+export function detectWorkflowStall(
+  workflowId: string,
+  agentIds: string[],
+  agentManager: AgentManager,
+  onStall: (workflowId: string, idleMs: number) => void,
+): boolean {
+  if (agentIds.length === 0) return false;
+
+  const now = Date.now();
+  let oldestIdleAt = now;
+  let liveAgents = 0;
+
+  for (const agentId of agentIds) {
+    const agent = agentManager.get(agentId);
+    if (!agent) continue; // agent was destroyed — skip
+    liveAgents++;
+
+    if (agent.status === "running" || agent.status === "starting") return false;
+
+    const lastActivity = new Date(agent.lastActivity).getTime();
+    if (lastActivity < oldestIdleAt) oldestIdleAt = lastActivity;
+  }
+
+  if (liveAgents === 0) return false;
+
+  const idleMs = now - oldestIdleAt;
+  if (idleMs > WORKFLOW_STALL_TIMEOUT_MS) {
+    logger.warn("[workflow-guard] INF-3: Stalled workflow detected", {
+      workflowId,
+      idleForSec: Math.round(idleMs / 1000),
+      liveAgents,
+    });
+    onStall(workflowId, idleMs);
+    return true;
+  }
+  return false;
+}

--- a/src/workflow-triage.ts
+++ b/src/workflow-triage.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure triage logic for BKL-020 Basic mode ticket validation.
+ *
+ * All functions are pure (no I/O, no side effects) so they can be unit-tested
+ * independently of the workflow wiring in routes/workflows.ts.
+ *
+ * Rubric (§5d): agent evaluates 5 boolean checks; backend computes clarity.
+ * This keeps thresholds out of the prompt and prevents agents from self-grading.
+ */
+
+export interface TriageChecks {
+  /** Real content that differs from the title and contains a verb/outcome */
+  substance: boolean;
+  /** A discernible "what should change" (outcome/behavior, not just a symptom) */
+  goalClarity: boolean;
+  /** Acceptance criteria / checklist / "done when" / expected behavior / repro steps */
+  doneDef: boolean;
+  /** Bounds the work: which area/feature/file/flow */
+  scopeSignal: boolean;
+  /** A request to BUILD/FIX — not a question, poll, discussion, or open design debate */
+  actionability: boolean;
+}
+
+export interface ValidationResult {
+  verdict: "accept" | "accept_with_caveats" | "reject";
+  clarity: "high" | "medium" | "low";
+  missing: string[];
+  suggestions: string[];
+  readError?: "not_found" | "forbidden" | "auth_failed" | "rate_limited" | "multi_issue_empty";
+  evaluatedAt: string;
+}
+
+/**
+ * Compute ticket clarity from triage check booleans.
+ *
+ * Hard failures (→ low):
+ *   !actionability OR !substance
+ * Require at least one of {doneDef, scopeSignal} to proceed beyond reject.
+ * sat = count of {goalClarity, doneDef, scopeSignal} that are true:
+ *   sat>=2 && (doneDef||scopeSignal) → high
+ *   sat==1 && (doneDef||scopeSignal) → medium
+ *   else → low
+ */
+export function clarityFromChecks(c: TriageChecks): "high" | "medium" | "low" {
+  if (!c.actionability || !c.substance) return "low";
+  if (!c.doneDef && !c.scopeSignal) return "low";
+  const sat = [c.goalClarity, c.doneDef, c.scopeSignal].filter(Boolean).length;
+  if (sat >= 2) return "high";
+  if (sat === 1) return "medium";
+  return "low";
+}
+
+/**
+ * Map clarity level to a triage verdict.
+ * high → accept, medium → accept_with_caveats, low → reject
+ */
+export function verdictFromClarity(clarity: "high" | "medium" | "low"): "accept" | "accept_with_caveats" | "reject" {
+  if (clarity === "high") return "accept";
+  if (clarity === "medium") return "accept_with_caveats";
+  return "reject";
+}
+
+/**
+ * Build a ValidationResult, injecting generic copy if missing/suggestions are empty on reject.
+ */
+export function buildValidationResult(
+  _checks: TriageChecks,
+  verdict: "accept" | "accept_with_caveats" | "reject",
+  clarity: "high" | "medium" | "low",
+  missing: string[] = [],
+  suggestions: string[] = [],
+  readError?: ValidationResult["readError"],
+): ValidationResult {
+  let resolvedMissing = missing;
+  let resolvedSuggestions = suggestions;
+
+  if (verdict === "reject" && resolvedMissing.length === 0) {
+    resolvedMissing = ["Ticket did not meet the detail rubric"];
+  }
+  if (verdict === "reject" && resolvedSuggestions.length === 0) {
+    resolvedSuggestions = ["Add a description, acceptance criteria, and the affected area"];
+  }
+
+  return {
+    verdict,
+    clarity,
+    missing: resolvedMissing,
+    suggestions: resolvedSuggestions,
+    ...(readError ? { readError } : {}),
+    evaluatedAt: new Date().toISOString(),
+  };
+}
+
+/** Build the prompt for the triage agent (Haiku, maxTurns:15). */
+export function buildTriagePrompt(ticketUrl: string, workflowId: string): string {
+  return `You are a ticket-detail triage agent. Read the Linear ticket, evaluate 5 boolean checks, then POST a verdict message. Posting the verdict is your most important job — if you run low on turns, post your best-effort verdict immediately rather than continuing to read.
+
+Ticket: ${ticketUrl} | Workflow: ${workflowId}
+
+1. Read the ticket via the /linear MCP tools. On 403/404 set readError "not_found"/"forbidden"; auth fail → "auth_failed"; rate limit → "rate_limited". On ANY read error, set all 5 checks to false and still post (with the readError) — do NOT retry reads in a loop.
+2. Evaluate honestly (conservative — false positives waste budget):
+   - substance: description has real content differing from title with a verb/outcome
+   - goalClarity: discernible "what should change" (outcome, not just symptom)
+   - doneDef: acceptance criteria / "done when" / expected behavior / repro steps
+   - scopeSignal: bounds the work — names area, feature, file, or flow
+   - actionability: request to BUILD or FIX — not a question, poll, or discussion
+3. Post EXACTLY ONE message to the platform message bus with your verdict in the metadata field. Run this curl with Bash, substituting your real values:
+
+   curl -s --max-time 10 -X POST "http://localhost:\${PORT}/api/messages" \\
+     -H "Authorization: Bearer $(cat \${WORKSPACE}/.agent-token)" \\
+     -H "Content-Type: application/json" \\
+     -d '{"from":"<YOUR_AGENT_ID>","fromName":"workflow-triage","type":"result","content":"triage verdict","metadata":{"workflowId":"${workflowId}","triageVerdict":{"checks":{"substance":false,"goalClarity":false,"doneDef":false,"scopeSignal":false,"actionability":false},"missing":[],"suggestions":[],"readError":"omit this key entirely if there was no read error"}}}'
+
+   CRITICAL details (the backend silently drops the verdict otherwise):
+   - Use plain http:// (the local server is NOT https — https gives an SSL/EPROTO error).
+   - "from" is REQUIRED and MUST be YOUR OWN agent ID. Find it on the "**ID:**" line in your CLAUDE.md (the workspace path also contains it: /tmp/workspace-<YOUR_AGENT_ID>). A "from" that is missing or not your ID is rejected.
+   - \${PORT} and \${WORKSPACE} are set in your environment / shown in your CLAUDE.md API section. If a curl fails, check the response body and fix it — you have turns to retry the POST.
+   - Set each check to the literal true/false you decided. Replace missing/suggestions with real arrays (use them to explain a low-clarity ticket). Omit the "readError" key entirely when there was no read error.
+
+Do NOT self-assess clarity or verdict — the backend computes them from your 5 booleans. After the POST returns success, stop.`;
+}

--- a/src/workflow-validators.ts
+++ b/src/workflow-validators.ts
@@ -1,0 +1,305 @@
+/**
+ * Workflow Validators & Parsers
+ *
+ * Pure functions for validating and parsing inputs used in Linear workflow automation.
+ * VP-1: parseLinearUrl       — comprehensive URL parsing with validation
+ * VP-2: validateGitHubPatScopes — GitHub PAT scope verification (repo access)
+ * VP-3: validateLinearApiKey — Linear API key format + auth check
+ * VP-4: estimateWorkflowCost — cost estimation by issue size and model
+ */
+
+import { type AllowedModel, DEFAULT_MODEL, MODELS } from "./models";
+import { validateToken } from "./token-validation";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ParsedLinearUrl {
+  issueId: string;
+  team: string;
+  workspace: string;
+  /** Canonical safe URL, reconstructed from parsed parts (query params/fragments stripped) */
+  safeUrl: string;
+}
+
+/** Typed error codes for parseLinearUrl failures — used by the frontend to map to specific copy */
+export type LinearUrlErrorCode =
+  | "EMPTY"
+  | "INVALID_FORMAT"
+  | "NOT_HTTPS"
+  | "WRONG_DOMAIN"
+  | "INVALID_PATH"
+  | "INVALID_WORKSPACE"
+  | "INVALID_ISSUE_ID";
+
+export type LinearUrlParseResult =
+  | { ok: true; parsed: ParsedLinearUrl }
+  | { ok: false; code: LinearUrlErrorCode; error: string };
+
+export interface GitHubPatValidationResult {
+  valid: boolean;
+  login?: string;
+  scopes?: string[];
+  missingScopes?: string[];
+  error?: string;
+}
+
+export interface LinearApiKeyValidationResult {
+  valid: boolean;
+  user?: string;
+  error?: string;
+}
+
+export type IssueSize = "XS" | "S" | "M" | "L" | "XL";
+
+/** All supported models for workflow cost estimation. Alias for AllowedModel in the central MODELS registry. */
+export type SupportedModel = AllowedModel;
+
+export interface CostEstimate {
+  size: IssueSize;
+  model: SupportedModel;
+  agentCount: number;
+  minCostUsd: number;
+  maxCostUsd: number;
+  /** Human-readable signals describing the issue size characteristics */
+  signals: string[];
+}
+
+// ─── VP-1: Linear URL Parser ─────────────────────────────────────────────────
+
+/** Workspace slug: must start with alphanumeric, then alphanumeric or hyphens */
+const WORKSPACE_RE = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/;
+
+/** Issue ID: uppercase letters then digits, e.g. ENG-123, MYTEAM-4567 */
+const ISSUE_ID_RE = /^[A-Z][A-Z0-9]*-\d+$/;
+
+/**
+ * VP-1: Parse and validate a Linear issue URL.
+ *
+ * Accepts:  https://linear.app/{workspace}/issue/{TEAM-NNN}
+ * Strips:   query parameters, URL fragments
+ * Rejects:  http://, spoofed domains, missing or malformed path segments
+ *
+ * The returned `safeUrl` is canonical and safe to embed in agent prompts.
+ */
+export function parseLinearUrl(rawUrl: string): LinearUrlParseResult {
+  if (!rawUrl || typeof rawUrl !== "string") {
+    return { ok: false, code: "EMPTY", error: "URL is required" };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(rawUrl.trim());
+  } catch {
+    return { ok: false, code: "INVALID_FORMAT", error: "Invalid URL format" };
+  }
+
+  if (url.protocol !== "https:") {
+    return { ok: false, code: "NOT_HTTPS", error: "URL must use HTTPS" };
+  }
+
+  // Strict hostname check: must be exactly linear.app
+  // This rejects linear.app.evil.com, app.linear.app, etc.
+  if (url.hostname !== "linear.app") {
+    return { ok: false, code: "WRONG_DOMAIN", error: "URL host must be linear.app" };
+  }
+
+  // Normalise path: strip trailing slash, then split into segments
+  const pathname = url.pathname.replace(/\/$/, "");
+  const segments = pathname.split("/");
+  // Expected: ["", workspace, "issue", issueId] → length 4
+  if (segments.length !== 4 || segments[2] !== "issue") {
+    return {
+      ok: false,
+      code: "INVALID_PATH",
+      error: "Invalid Linear URL path. Expected: https://linear.app/{workspace}/issue/{TEAM-NNN}",
+    };
+  }
+
+  const workspace = segments[1];
+  const rawIssueId = segments[3];
+
+  if (!workspace || !WORKSPACE_RE.test(workspace)) {
+    return { ok: false, code: "INVALID_WORKSPACE", error: "Invalid workspace slug in URL" };
+  }
+
+  // Normalise to uppercase before format validation
+  const issueId = rawIssueId.toUpperCase();
+  if (!ISSUE_ID_RE.test(issueId)) {
+    return {
+      ok: false,
+      code: "INVALID_ISSUE_ID",
+      error: "Invalid issue ID format. Expected TEAM-NNN (e.g. ENG-123)",
+    };
+  }
+
+  const team = issueId.split("-")[0];
+  // Reconstruct canonical URL — drops query params, fragments and normalises case
+  const safeUrl = `https://linear.app/${workspace}/issue/${issueId}`;
+
+  return { ok: true, parsed: { issueId, team, workspace, safeUrl } };
+}
+
+// ─── VP-2: GitHub PAT Scope Validation ───────────────────────────────────────
+
+/**
+ * Scopes that grant PR creation access.
+ * `repo` covers private repos; `public_repo` is sufficient for public repos.
+ * Fine-grained PATs expose `pull_requests:write` and `contents:write` instead.
+ */
+const ACCEPTABLE_REPO_SCOPES = ["repo", "public_repo"] as const;
+
+/**
+ * VP-2: Validate a GitHub Personal Access Token and verify it has PR-creation scopes.
+ *
+ * Makes one call to https://api.github.com/user to authenticate the token and reads
+ * the `x-oauth-scopes` response header. Verifies that at least `repo` or `public_repo`
+ * is granted (required for `gh pr create`).
+ */
+export async function validateGitHubPatScopes(token: string): Promise<GitHubPatValidationResult> {
+  if (!token || typeof token !== "string") {
+    return { valid: false, error: "Token is required" };
+  }
+
+  // Format check: classic PATs → ghp_, fine-grained → github_pat_
+  if (!/^(ghp_|github_pat_)[A-Za-z0-9_]+$/.test(token)) {
+    return {
+      valid: false,
+      error: "Token does not appear to be a GitHub PAT (expected ghp_ or github_pat_ prefix)",
+    };
+  }
+
+  const result = await validateToken("github", token);
+  if (!result.valid) {
+    return { valid: false, error: result.error ?? "GitHub authentication failed" };
+  }
+
+  const scopes = result.scopes ?? [];
+  const hasRepoAccess = ACCEPTABLE_REPO_SCOPES.some((s) => scopes.includes(s));
+
+  if (!hasRepoAccess) {
+    const missingScopes = ["repo"];
+    return {
+      valid: false,
+      login: result.user,
+      scopes,
+      missingScopes,
+      error: `Token is missing required scope: repo. Current scopes: ${scopes.join(", ") || "(none)"}. Add the 'repo' scope and regenerate the token.`,
+    };
+  }
+
+  return { valid: true, login: result.user, scopes };
+}
+
+// ─── VP-3: Linear API Key Validation ─────────────────────────────────────────
+
+/**
+ * Linear API keys follow the pattern:  lin_api_<32+ alphanumeric chars>
+ * Reference: https://linear.app/settings/api
+ */
+const LINEAR_API_KEY_RE = /^lin_api_[A-Za-z0-9]{32,}$/;
+
+/**
+ * VP-3: Validate a Linear API key.
+ *
+ * First checks the `lin_api_` prefix and minimum length, then verifies
+ * authentication via the Linear GraphQL viewer query.
+ */
+export async function validateLinearApiKey(token: string): Promise<LinearApiKeyValidationResult> {
+  if (!token || typeof token !== "string") {
+    return { valid: false, error: "Token is required" };
+  }
+
+  if (!LINEAR_API_KEY_RE.test(token)) {
+    return {
+      valid: false,
+      error: 'Linear API key must start with "lin_api_" followed by at least 32 alphanumeric characters',
+    };
+  }
+
+  const result = await validateToken("linear", token);
+  if (!result.valid) {
+    return { valid: false, error: result.error ?? "Linear API authentication failed" };
+  }
+
+  return { valid: true, user: result.user };
+}
+
+// ─── VP-4: Cost Estimation ────────────────────────────────────────────────────
+
+/**
+ * Base cost ranges in USD for Sonnet 4.6 (from empirical token estimates in cost analysis research).
+ * Source: shared-context/research/linear-workflow/cost-analysis.md §3.4 Per-Issue Sizing Guide
+ */
+const SIZE_BASE_COSTS: Record<IssueSize, { minUsd: number; maxUsd: number; agentCount: number; signals: string[] }> = {
+  XS: {
+    minUsd: 0.05,
+    maxUsd: 0.3,
+    agentCount: 1,
+    signals: ["Single function or trivial change", "Known solution path, no exploration needed"],
+  },
+  S: {
+    minUsd: 0.2,
+    maxUsd: 0.8,
+    agentCount: 2,
+    signals: ["1–3 files to change", "Clear specification with well-defined scope"],
+  },
+  M: {
+    minUsd: 0.8,
+    maxUsd: 3.0,
+    agentCount: 4,
+    signals: ["5–10 files to change", "Some codebase exploration needed"],
+  },
+  L: {
+    minUsd: 2.5,
+    maxUsd: 7.0,
+    agentCount: 6,
+    signals: ["Multi-module changes", "Architecture decision or significant refactor required"],
+  },
+  XL: {
+    minUsd: 6.0,
+    maxUsd: 20.0,
+    agentCount: 10,
+    signals: ["Cross-system feature or epic", "Requires multiple sub-issue implementations"],
+  },
+};
+
+/**
+ * Cost multiplier relative to Sonnet 4.6 baseline (= 1.0), derived from the MODELS registry.
+ * Blended-rate method: 0.8×input + 0.2×output per million tokens.
+ *   Sonnet 4.6:  0.8×$3.0 + 0.2×$15.0 = $5.40/MTok  → 1.00×
+ *   Haiku 4.5:   0.8×$1.0 + 0.2×$5.0  = $1.80/MTok  → 0.33×
+ *   Opus 4.6:    0.8×$5.0 + 0.2×$25.0 = $9.00/MTok  → 1.67×
+ */
+const MODEL_COST_MULTIPLIERS: Record<SupportedModel, number> = Object.fromEntries(
+  Object.entries(MODELS).map(([id, m]) => [id, m.costMultiplier]),
+) as Record<SupportedModel, number>;
+
+/**
+ * VP-4: Estimate the cost of a workflow run given issue size and model.
+ *
+ * Returns a min/max cost range in USD. Base ranges are calibrated for Sonnet 4.6
+ * and scaled proportionally for other models using blended token pricing.
+ *
+ * @param size   Issue size label (XS / S / M / L / XL)
+ * @param model  Claude model to use (defaults to the platform DEFAULT_MODEL)
+ */
+/** Safety buffer applied on top of model-scaled base costs to account for estimation uncertainty */
+const COST_BUFFER_MULTIPLIER = 1.2;
+
+export function estimateWorkflowCost(size: IssueSize, model: SupportedModel = DEFAULT_MODEL): CostEstimate {
+  const base = SIZE_BASE_COSTS[size];
+  const multiplier = MODEL_COST_MULTIPLIERS[model];
+
+  // Round to 2 decimal places for display; 1.2× buffer applied for estimation uncertainty
+  const minCostUsd = Math.round(base.minUsd * multiplier * COST_BUFFER_MULTIPLIER * 100) / 100;
+  const maxCostUsd = Math.round(base.maxUsd * multiplier * COST_BUFFER_MULTIPLIER * 100) / 100;
+
+  return {
+    size,
+    model,
+    agentCount: base.agentCount,
+    minCostUsd,
+    maxCostUsd,
+    signals: base.signals,
+  };
+}


### PR DESCRIPTION
## Summary

Resolves the `/api/workflows` namespace collision (D1 decision):

- `src/routes/workflows.ts` (1023L): **engine-backed** Linear→PR triage/grade/merge state machine, mounted at `/api/workflows`. This replaces Fanbot's namespace.
- `src/routes/linear-workflows.ts` (246L): AM's existing Linear workflow spawner **renamed** to `/api/linear-workflows`. All `/api/workflows/...` paths updated to `/api/linear-workflows/...`. Both features are preserved — neither deleted.
- `server.ts`: mounts both. `createWorkflowsRouter` = engine routes. `createLinearWorkflowsRouter` = renamed spawner.

deps: PR #19 (workflow-logic), PR #20 (workflow-engine), PR #21 (workflow-credentials)

**Note:** routes/workflows.ts is 1023 lines — single concern (one HTTP surface for the workflow engine state machine). Cannot be split further without fragmenting the state machine's route logic.

Zero fanbot/fanvue refs.

## Test plan
- [x] `npm test` passes (414 tests)
- [x] `npx biome check .` clean