### PR TITLE
feat: add workflow resource manager (cost cap, stall detection, memory guard) with tests (PR 19b2)

### DIFF
--- a/src/workflow-resource-manager.test.ts
+++ b/src/workflow-resource-manager.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  checkWorkflowAgentLimit,
+  computeWorkflowActualCost,
+  detectWorkflowStall,
+  enforceWorkflowCostCap,
+  WORKFLOW_COST_CAP_MULTIPLIER,
+} from "./workflow-resource-manager";
+
+vi.mock("./utils/memory", () => ({
+  getContainerMemoryUsage: vi.fn(() => 0.5 * 1024 * 1024 * 1024),
+  getContainerMemoryLimit: vi.fn(() => 2 * 1024 * 1024 * 1024),
+}));
+
+vi.mock("./config", () => ({ CONFIG: { MEMORY_REJECT_THRESHOLD: 0.9 } }));
+vi.mock("./logger", () => ({ logger: { warn: vi.fn(), info: vi.fn() } }));
+
+function makeAgentManager(
+  agents: Record<string, { usage?: { estimatedCost: number }; status: string; lastActivity: string }>,
+) {
+  return { get: (id: string) => agents[id] };
+}
+
+describe("checkWorkflowAgentLimit", () => {
+  it("returns null when under limit", () => {
+    expect(checkWorkflowAgentLimit(5, 10)).toBeNull();
+  });
+
+  it("returns error when at limit", () => {
+    expect(checkWorkflowAgentLimit(10, 10)).toContain("10/10");
+  });
+});
+
+describe("computeWorkflowActualCost", () => {
+  it("sums estimatedCost across agents", () => {
+    const am = makeAgentManager({
+      a1: { usage: { estimatedCost: 1.5 }, status: "idle", lastActivity: new Date().toISOString() },
+      a2: { usage: { estimatedCost: 0.5 }, status: "idle", lastActivity: new Date().toISOString() },
+    });
+    expect(computeWorkflowActualCost(["a1", "a2"], am as any)).toBe(2);
+  });
+
+  it("treats missing agents as 0 cost", () => {
+    const am = makeAgentManager({});
+    expect(computeWorkflowActualCost(["missing"], am as any)).toBe(0);
+  });
+});
+
+describe("enforceWorkflowCostCap", () => {
+  it("calls onCap when actual >= cap", () => {
+    const onCap = vi.fn();
+    const am = makeAgentManager({
+      a1: { usage: { estimatedCost: 5 }, status: "idle", lastActivity: new Date().toISOString() },
+    });
+    enforceWorkflowCostCap("wf1", ["a1"], 2, am as any, onCap);
+    expect(onCap).toHaveBeenCalledWith("wf1", 5, 2 * WORKFLOW_COST_CAP_MULTIPLIER);
+  });
+
+  it("does not call onCap when under cap", () => {
+    const onCap = vi.fn();
+    const am = makeAgentManager({
+      a1: { usage: { estimatedCost: 1 }, status: "idle", lastActivity: new Date().toISOString() },
+    });
+    enforceWorkflowCostCap("wf1", ["a1"], 10, am as any, onCap);
+    expect(onCap).not.toHaveBeenCalled();
+  });
+
+  it("no-op when costEstimate is 0", () => {
+    const onCap = vi.fn();
+    const am = makeAgentManager({
+      a1: { usage: { estimatedCost: 999 }, status: "idle", lastActivity: new Date().toISOString() },
+    });
+    enforceWorkflowCostCap("wf1", ["a1"], 0, am as any, onCap);
+    expect(onCap).not.toHaveBeenCalled();
+  });
+});
+
+describe("detectWorkflowStall", () => {
+  it("returns false for empty agent list", () => {
+    const am = makeAgentManager({});
+    expect(detectWorkflowStall("wf1", [], am as any, vi.fn())).toBe(false);
+  });
+
+  it("returns false when agent is running", () => {
+    const am = makeAgentManager({
+      a1: { status: "running", lastActivity: new Date(Date.now() - 99999999).toISOString() },
+    });
+    expect(detectWorkflowStall("wf1", ["a1"], am as any, vi.fn())).toBe(false);
+  });
+});

--- a/src/workflow-resource-manager.ts
+++ b/src/workflow-resource-manager.ts
@@ -1,0 +1,105 @@
+/**
+ * Workflow Resource Manager
+ *
+ * Infrastructure-level protections for Linear workflow runs:
+ * - INF-1: Cost cap enforcement
+ * - INF-3: Stall detection
+ * - INF-4: Resource budgeting
+ */
+
+import type { AgentManager } from "./agents";
+import { CONFIG } from "./config";
+import { logger } from "./logger";
+import { getContainerMemoryLimit, getContainerMemoryUsage } from "./utils/memory";
+
+export const WORKFLOW_MAX_AGENTS = Number(process.env.WORKFLOW_MAX_AGENTS ?? "10");
+export const WORKFLOW_COST_CAP_MULTIPLIER = 2.0;
+export const WORKFLOW_STALL_TIMEOUT_MS = Number(process.env.WORKFLOW_STALL_TIMEOUT_MS ?? String(10 * 60_000));
+
+export function checkMemoryForNewWorkflow(): string | null {
+  const used = getContainerMemoryUsage();
+  const limit = getContainerMemoryLimit();
+  const ratio = used / limit;
+  if (ratio > CONFIG.MEMORY_REJECT_THRESHOLD) {
+    return (
+      `System memory at ${Math.round(ratio * 100)}% ` +
+      `(threshold: ${Math.round(CONFIG.MEMORY_REJECT_THRESHOLD * 100)}%). ` +
+      "Cannot start new workflow."
+    );
+  }
+  return null;
+}
+
+export function checkWorkflowAgentLimit(currentCount: number, max = WORKFLOW_MAX_AGENTS): string | null {
+  if (currentCount >= max) {
+    return `Workflow agent limit reached (${currentCount}/${max}).`;
+  }
+  return null;
+}
+
+export function computeWorkflowActualCost(agentIds: string[], agentManager: AgentManager): number {
+  let total = 0;
+  for (const agentId of agentIds) {
+    total += agentManager.get(agentId)?.usage?.estimatedCost ?? 0;
+  }
+  return total;
+}
+
+export function enforceWorkflowCostCap(
+  workflowId: string,
+  agentIds: string[],
+  costEstimate: number,
+  agentManager: AgentManager,
+  onCap: (workflowId: string, actualCost: number, cap: number) => void,
+): void {
+  if (costEstimate <= 0) return;
+  const actual = computeWorkflowActualCost(agentIds, agentManager);
+  const cap = costEstimate * WORKFLOW_COST_CAP_MULTIPLIER;
+  if (actual >= cap) {
+    logger.warn("[workflow-guard] INF-1: Workflow cost cap exceeded", {
+      workflowId,
+      actualCost: actual.toFixed(4),
+      cap: cap.toFixed(4),
+      multiplier: WORKFLOW_COST_CAP_MULTIPLIER,
+    });
+    onCap(workflowId, actual, cap);
+  }
+}
+
+export function detectWorkflowStall(
+  workflowId: string,
+  agentIds: string[],
+  agentManager: AgentManager,
+  onStall: (workflowId: string, idleMs: number) => void,
+): boolean {
+  if (agentIds.length === 0) return false;
+
+  const now = Date.now();
+  let oldestIdleAt = now;
+  let liveAgents = 0;
+
+  for (const agentId of agentIds) {
+    const agent = agentManager.get(agentId);
+    if (!agent) continue;
+    liveAgents++;
+
+    if (agent.status === "running" || agent.status === "starting") return false;
+
+    const lastActivity = new Date(agent.lastActivity).getTime();
+    if (lastActivity < oldestIdleAt) oldestIdleAt = lastActivity;
+  }
+
+  if (liveAgents === 0) return false;
+
+  const idleMs = now - oldestIdleAt;
+  if (idleMs > WORKFLOW_STALL_TIMEOUT_MS) {
+    logger.warn("[workflow-guard] INF-3: Stalled workflow detected", {
+      workflowId,
+      idleForSec: Math.round(idleMs / 1000),
+      liveAgents,
+    });
+    onStall(workflowId, idleMs);
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Pure-logic workflow modules split from #162 (part 3 of 3):

- `workflow-resource-manager.ts` (105L): Infrastructure-level workflow guards:
  - `checkMemoryForNewWorkflow`: memory gate before starting a workflow
  - `checkWorkflowAgentLimit`: per-workflow agent count guard
  - `computeWorkflowActualCost`: sum actual cost across agent IDs
  - `enforceWorkflowCostCap`: halt when actual cost >= 2× estimate
  - `detectWorkflowStall`: detect when all agents have been idle >10min

All functions are pure (callers provide callbacks for side effects). Zero fanbot/fanvue references. 195 lines total.

**Depends on:** no new deps beyond main
**Split from:** #162 (superseded by PR 19a + 19b1 + 19b2)

## Test plan
- [x] `npm test` passes (all new resource manager tests green)
- [x] `npx biome check` clean (7 acceptable `any` warnings in test mocks)
- [x] Zero fanbot/fanvue refs