### PR TITLE
fix: neutralize fanvue example in merge-gate JSDoc

### DIFF
--- a/src/routes/merge-gate.ts
+++ b/src/routes/merge-gate.ts
@@ -91,7 +91,7 @@ export function getMergePolicy(
 
 /**
  * Extract the short repo name from an "owner/repo" string.
- * Returns the sanitized repo name (e.g. "fanvue/AgentManager" → "AgentManager").
+ * Returns the sanitized repo name (e.g. "owner/AgentManager" → "AgentManager").
  */
 export function repoKeyFromOwnerRepo(ownerRepo: string): string {
   const slash = ownerRepo.lastIndexOf("/");


### PR DESCRIPTION
## Summary

- Changes `"fanvue/AgentManager"` → `"owner/AgentManager"` in the `repoKeyFromOwnerRepo` JSDoc comment in `src/routes/merge-gate.ts` (line 94)
- 1-line change, no logic changes
- Operator mandate: zero fanvue/fanbot references in AgentManager

## Test plan
- [x] `grep -i fanvue/fanbot src/routes/merge-gate.ts` → no matches
- [x] `npx tsc --noEmit` → clean