### PR TITLE
feat(ui): add ContextPolicyPanel (split from #163)

### DIFF
--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -197,6 +197,48 @@ export interface RepoGateConfig {
   updatedBy: string | null;
 }
 
+// ─── Context Policy ────────────────────────────────────────────────────────────
+
+export interface AutoResetPolicy {
+  enabled?: boolean;
+  threshold?: number;
+  cooldownTurns?: number;
+}
+
+export interface ContextPolicy {
+  autoReset?: AutoResetPolicy;
+}
+
+export interface EffectiveAutoReset {
+  enabled: boolean;
+  threshold: number;
+  cooldownTurns: number;
+}
+
+export interface EffectiveContextPolicy {
+  autoReset: EffectiveAutoReset;
+}
+
+export interface ContextPolicyRecord {
+  scope: string;
+  policy: ContextPolicy;
+  updatedAt: string;
+}
+
+export interface ContextPolicyBounds {
+  autoReset: {
+    threshold: { min: number; max: number };
+    cooldownTurns: { min: number; max: number };
+  };
+}
+
+export interface ContextPolicyResponse {
+  effective: EffectiveContextPolicy;
+  global: ContextPolicyRecord;
+  agent?: ContextPolicyRecord;
+  bounds: ContextPolicyBounds;
+}
+
 export interface TokenStatus {
   configured: boolean;
   source: string;
@@ -988,6 +1030,53 @@ export function createApi(authFetch: AuthFetch) {
         method: "DELETE",
       });
       if (!res.ok) throw new Error(`Failed to reset gate config: ${res.status}`);
+      return res.json();
+    },
+
+    // Context Policy
+    async getContextPolicy(): Promise<ContextPolicyResponse> {
+      const res = await authFetch("/api/context-policy");
+      if (!res.ok) throw new Error("Failed to get context policy");
+      return res.json();
+    },
+
+    async updateContextPolicy(patch: ContextPolicy): Promise<ContextPolicyResponse> {
+      const res = await authFetch("/api/context-policy", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error ?? "Failed to save context policy");
+      }
+      return res.json();
+    },
+
+    async getAgentContextPolicy(agentId: string): Promise<ContextPolicyResponse> {
+      const res = await authFetch(`/api/context-policy/${encodeURIComponent(agentId)}`);
+      if (!res.ok) throw new Error(`Failed to get context policy for agent: ${res.status}`);
+      return res.json();
+    },
+
+    async updateAgentContextPolicy(agentId: string, patch: ContextPolicy): Promise<ContextPolicyResponse> {
+      const res = await authFetch(`/api/context-policy/${encodeURIComponent(agentId)}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error ?? "Failed to save agent context policy");
+      }
+      return res.json();
+    },
+
+    async resetAgentContextPolicy(agentId: string): Promise<ContextPolicyResponse> {
+      const res = await authFetch(`/api/context-policy/${encodeURIComponent(agentId)}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error(`Failed to reset agent context policy: ${res.status}`);
       return res.json();
     },
 

--- a/ui/src/components/ContextPolicyPanel.tsx
+++ b/ui/src/components/ContextPolicyPanel.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Alert } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ContextPolicy, ContextPolicyResponse, createApi } from "../api";
+
+interface ContextPolicyPanelProps {
+  api: ReturnType<typeof createApi>;
+  /** If provided, shows per-agent policy UI (agent detail view). */
+  agentId?: string;
+  /** Compact layout for agent detail sidebar. */
+  compact?: boolean;
+}
+
+export function ContextPolicyPanel({ api, agentId, compact = false }: ContextPolicyPanelProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [data, setData] = useState<ContextPolicyResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+  const [messageType, setMessageType] = useState<"success" | "error">("success");
+  const messageTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Editable fields
+  const [enabled, setEnabled] = useState(true);
+  const [threshold, setThreshold] = useState(0.72);
+  const [cooldownTurns, setCooldownTurns] = useState(3);
+
+  useEffect(
+    () => () => {
+      if (messageTimeoutRef.current != null) clearTimeout(messageTimeoutRef.current);
+    },
+    [],
+  );
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = agentId ? await api.getAgentContextPolicy(agentId) : await api.getContextPolicy();
+      setData(result);
+      const eff = result.effective.autoReset;
+      setEnabled(eff.enabled);
+      setThreshold(eff.threshold);
+      setCooldownTurns(eff.cooldownTurns);
+    } catch (err) {
+      console.error("[ContextPolicyPanel] load failed", err);
+    } finally {
+      setLoading(false);
+    }
+  }, [api, agentId]);
+
+  useEffect(() => {
+    if (compact) {
+      // In compact mode (agent detail), load immediately when rendered
+      if (!data) load();
+    } else if (expanded && !data) {
+      load();
+    }
+  }, [compact, expanded, data, load]);
+
+  const showMessage = (msg: string, type: "success" | "error") => {
+    setMessage(msg);
+    setMessageType(type);
+    if (messageTimeoutRef.current != null) clearTimeout(messageTimeoutRef.current);
+    messageTimeoutRef.current = setTimeout(() => {
+      messageTimeoutRef.current = null;
+      setMessage("");
+    }, 4000);
+  };
+
+  const save = async () => {
+    setSaving(true);
+    const patch: ContextPolicy = {
+      autoReset: { enabled, threshold, cooldownTurns },
+    };
+    try {
+      const result = agentId
+        ? await api.updateAgentContextPolicy(agentId, patch)
+        : await api.updateContextPolicy(patch);
+      setData(result);
+      const eff = result.effective.autoReset;
+      setEnabled(eff.enabled);
+      setThreshold(eff.threshold);
+      setCooldownTurns(eff.cooldownTurns);
+      showMessage("Policy saved", "success");
+    } catch (err) {
+      showMessage(err instanceof Error ? err.message : "Failed to save", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const reset = async () => {
+    if (!agentId) return;
+    setSaving(true);
+    try {
+      const result = await api.resetAgentContextPolicy(agentId);
+      setData(result);
+      const eff = result.effective.autoReset;
+      setEnabled(eff.enabled);
+      setThreshold(eff.threshold);
+      setCooldownTurns(eff.cooldownTurns);
+      showMessage("Reset to global default", "success");
+    } catch (err) {
+      showMessage(err instanceof Error ? err.message : "Failed to reset", "error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const hasAgentOverride = agentId && data?.agent && data.agent.updatedAt !== "";
+
+  const bounds = data?.bounds.autoReset ?? {
+    threshold: { min: 0.5, max: 0.9 },
+    cooldownTurns: { min: 1, max: 50 },
+  };
+
+  // Compact layout used in agent detail sidebar
+  if (compact) {
+    return (
+      <div className="border-b border-zinc-800">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="w-full flex items-center justify-between px-4 py-1.5 text-xs text-zinc-400 hover:text-zinc-300 hover:bg-zinc-800/30 transition-colors"
+        >
+          <div className="flex items-center gap-1.5">
+            <span>Context Policy</span>
+            {hasAgentOverride && (
+              <span className="px-1 py-0.5 rounded text-[9px] font-semibold bg-amber-900/50 text-amber-400">
+                override
+              </span>
+            )}
+          </div>
+          <svg
+            aria-hidden="true"
+            className={`w-3 h-3 transition-transform ${expanded ? "rotate-180" : ""}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        {expanded && (
+          <div className="px-4 pb-3 space-y-3">
+            {loading && <p className="text-xs text-zinc-500">Loading...</p>}
+            {!loading && data && (
+              <>
+                <div className="flex items-center justify-between py-0.5">
+                  <span className="text-xs text-zinc-400">Auto-reset</span>
+                  <button
+                    type="button"
+                    onClick={() => setEnabled((v) => !v)}
+                    className={`relative inline-flex h-4 w-8 items-center rounded-full transition-colors ${
+                      enabled ? "bg-zinc-300" : "bg-zinc-700"
+                    }`}
+                    role="switch"
+                    aria-checked={enabled}
+                  >
+                    <span
+                      className={`inline-block h-3 w-3 transform rounded-full bg-zinc-900 transition-transform ${
+                        enabled ? "translate-x-4" : "translate-x-0.5"
+                      }`}
+                    />
+                  </button>
+                </div>
+
+                <div className="space-y-1">
+                  <div className="flex justify-between">
+                    <span className="text-xs text-zinc-400">
+                      Threshold <span className="text-zinc-500">({Math.round(threshold * 100)}%)</span>
+                    </span>
+                  </div>
+                  <input
+                    type="range"
+                    min={bounds.threshold.min}
+                    max={bounds.threshold.max}
+                    step={0.01}
+                    value={threshold}
+                    onChange={(e) => setThreshold(Number(e.target.value))}
+                    disabled={!enabled}
+                    className="w-full h-1.5 accent-zinc-300 disabled:opacity-40"
+                  />
+                </div>
+
+                <div className="flex items-center justify-between py-0.5">
+                  <span className="text-xs text-zinc-400">Cooldown turns</span>
+                  <Input
+                    type="number"
+                    value={cooldownTurns}
+                    onChange={(e) => setCooldownTurns(Number(e.target.value))}
+                    min={bounds.cooldownTurns.min}
+                    max={bounds.cooldownTurns.max}
+                    disabled={!enabled}
+                    className="h-6 w-16 text-xs"
+                  />
+                </div>
+
+                {message && (
+                  <Alert variant={messageType === "error" ? "destructive" : "default"} className="py-2 text-xs">
+                    {message}
+                  </Alert>
+                )}
+
+                <div className="flex gap-1.5">
+                  <Button variant="default" size="xs" onClick={save} disabled={saving}>
+                    {saving ? "Saving..." : "Save"}
+                  </Button>
+                  {hasAgentOverride && (
+                    <Button variant="secondary" size="xs" onClick={reset} disabled={saving}>
+                      Reset
+                    </Button>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Full layout for settings/context page
+  return (
+    <div className="space-y-5">
+      <div>
+        <p className="text-xs font-medium text-zinc-400 uppercase tracking-wider mb-1">Context Auto-Reset Policy</p>
+        <p className="text-xs text-zinc-400">
+          Configure when agents automatically compact their context window. Applies globally; per-agent overrides are
+          available from the agent detail panel.
+        </p>
+      </div>
+
+      {loading && (
+        <div className="space-y-3">
+          <div className="h-8 rounded bg-zinc-800 animate-pulse" />
+          <div className="h-8 rounded bg-zinc-800 animate-pulse" />
+          <div className="h-8 rounded bg-zinc-800 animate-pulse" />
+        </div>
+      )}
+
+      {!loading && data && (
+        <div className="space-y-5 max-w-md">
+          {/* Enable toggle */}
+          <div className="flex items-center justify-between">
+            <div>
+              <Label className="text-sm text-zinc-200">Enable auto-reset</Label>
+              <p className="text-xs text-zinc-500 mt-0.5">
+                Automatically compact agent context when the window fills up.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setEnabled((v) => !v)}
+              className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none ${
+                enabled ? "bg-zinc-300" : "bg-zinc-700"
+              }`}
+              role="switch"
+              aria-checked={enabled}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-zinc-900 transition-transform ${
+                  enabled ? "translate-x-4" : "translate-x-1"
+                }`}
+              />
+            </button>
+          </div>
+
+          {/* Threshold slider */}
+          <div className="space-y-2">
+            <div className="flex justify-between items-center">
+              <Label htmlFor="ctx-threshold" className="text-sm text-zinc-200">
+                Reset threshold
+              </Label>
+              <span className="text-xs text-zinc-400">{Math.round(threshold * 100)}%</span>
+            </div>
+            <p className="text-xs text-zinc-500">
+              Context utilisation at which an auto-reset is triggered ({bounds.threshold.min * 100}–
+              {bounds.threshold.max * 100}%).
+            </p>
+            <input
+              id="ctx-threshold"
+              type="range"
+              min={bounds.threshold.min}
+              max={bounds.threshold.max}
+              step={0.01}
+              value={threshold}
+              onChange={(e) => setThreshold(Number(e.target.value))}
+              disabled={!enabled}
+              className="w-full h-2 accent-zinc-300 disabled:opacity-40"
+            />
+          </div>
+
+          {/* Cooldown turns */}
+          <div className="space-y-1.5">
+            <Label htmlFor="ctx-cooldown" className="text-sm text-zinc-200">
+              Cooldown turns
+            </Label>
+            <p className="text-xs text-zinc-500">
+              Idle turns to wait after a reset before triggering another ({bounds.cooldownTurns.min}–
+              {bounds.cooldownTurns.max}).
+            </p>
+            <Input
+              id="ctx-cooldown"
+              type="number"
+              value={cooldownTurns}
+              onChange={(e) => setCooldownTurns(Number(e.target.value))}
+              min={bounds.cooldownTurns.min}
+              max={bounds.cooldownTurns.max}
+              disabled={!enabled}
+              className="h-9 w-28"
+            />
+          </div>
+
+          {/* Audit info */}
+          {data.global.updatedAt && (
+            <p className="text-[11px] text-zinc-500">
+              Last updated: {new Date(data.global.updatedAt).toLocaleString()}
+            </p>
+          )}
+
+          {message && <Alert variant={messageType === "error" ? "destructive" : "default"}>{message}</Alert>}
+
+          <div className="flex gap-2">
+            <Button variant="default" size="default" onClick={save} disabled={saving}>
+              {saving ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/views/AgentView.tsx
+++ b/ui/src/views/AgentView.tsx
@@ -8,6 +8,7 @@ import type { Agent, GradeResult } from "../api";
 import { AgentMetadataPanel } from "../components/AgentMetadataPanel";
 import { AgentTerminal } from "../components/AgentTerminal";
 import { ConfirmDialog } from "../components/ConfirmDialog";
+import { ContextPolicyPanel } from "../components/ContextPolicyPanel";
 import { Header } from "../components/Header";
 import { type Attachment, PromptInput } from "../components/PromptInput";
 import { RiskBadge } from "../components/RiskBadge";
@@ -414,6 +415,9 @@ export function AgentView({ agentId }: { agentId: string }) {
 
           {/* Metadata panel */}
           {id && <AgentMetadataPanel agentId={id} />}
+
+          {/* Context policy panel */}
+          {id && <ContextPolicyPanel api={api} agentId={id} compact />}
 
           {/* Disconnected warning banner */}
           {agent?.status === "disconnected" && (

--- a/ui/src/views/Settings/context.tsx
+++ b/ui/src/views/Settings/context.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { ContextFile, createApi } from "../../api";
 import { ConfirmDialog } from "../../components/ConfirmDialog";
+import { ContextPolicyPanel } from "../../components/ContextPolicyPanel";
 import { TreeListSkeleton } from "../../components/Skeleton";
 import { useFileEditor, useFolderToggle } from "./hooks";
 import { allFolderPaths, buildTree, TreeList } from "./tree";
@@ -101,89 +102,95 @@ export function ContextPanel({ api }: { api: ReturnType<typeof createApi> }) {
   const tree = buildTree(files.map((f) => ({ key: f.name })));
 
   return (
-    <div className="flex gap-4 h-[600px]">
-      <ConfirmDialog
-        open={pendingDelete !== null}
-        title="Delete file"
-        description={`Are you sure you want to delete ${pendingDelete ?? "this file"}?`}
-        confirmLabel="Delete"
-        cancelLabel="Cancel"
-        variant="destructive"
-        onConfirm={() => {
-          if (pendingDelete) deleteFile(pendingDelete);
-          setPendingDelete(null);
-        }}
-        onCancel={() => setPendingDelete(null)}
-      />
-      <div className="w-56 flex-shrink-0 space-y-2">
-        <p className="text-xs font-medium text-zinc-400 uppercase tracking-wider mb-2">Context files</p>
-        <p className="text-xs text-zinc-400 mb-3">Shared .md files accessible to all agents</p>
-        {loading ? (
-          <TreeListSkeleton rows={5} />
-        ) : (
-          <TreeList
-            nodes={tree}
-            depth={0}
-            selectedKey={selected}
-            expandedFolders={folders.expanded}
-            onToggleFolder={folders.toggle}
-            onSelectNode={(node) => loadFile(node.fullPath)}
-            renderActions={(node) =>
-              !node.isFolder && (
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setPendingDelete(node.fullPath);
-                  }}
-                  className="text-zinc-400 hover:text-red-400"
-                >
-                  x
-                </Button>
-              )
-            }
-          />
-        )}
-        <div className="flex gap-1 mt-3">
-          <Input
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            placeholder="file.md or folder/file.md"
-            onKeyDown={(e) => e.key === "Enter" && createFile()}
-            className="h-8 flex-1 min-w-0"
-          />
-          <Button variant="secondary" size="sm" onClick={createFile} disabled={!newName.trim()}>
-            +
-          </Button>
+    <div className="space-y-8">
+      <div className="flex gap-4 h-[600px]">
+        <ConfirmDialog
+          open={pendingDelete !== null}
+          title="Delete file"
+          description={`Are you sure you want to delete ${pendingDelete ?? "this file"}?`}
+          confirmLabel="Delete"
+          cancelLabel="Cancel"
+          variant="destructive"
+          onConfirm={() => {
+            if (pendingDelete) deleteFile(pendingDelete);
+            setPendingDelete(null);
+          }}
+          onCancel={() => setPendingDelete(null)}
+        />
+        <div className="w-56 flex-shrink-0 space-y-2">
+          <p className="text-xs font-medium text-zinc-400 uppercase tracking-wider mb-2">Context files</p>
+          <p className="text-xs text-zinc-400 mb-3">Shared .md files accessible to all agents</p>
+          {loading ? (
+            <TreeListSkeleton rows={5} />
+          ) : (
+            <TreeList
+              nodes={tree}
+              depth={0}
+              selectedKey={selected}
+              expandedFolders={folders.expanded}
+              onToggleFolder={folders.toggle}
+              onSelectNode={(node) => loadFile(node.fullPath)}
+              renderActions={(node) =>
+                !node.isFolder && (
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setPendingDelete(node.fullPath);
+                    }}
+                    className="text-zinc-400 hover:text-red-400"
+                  >
+                    x
+                  </Button>
+                )
+              }
+            />
+          )}
+          <div className="flex gap-1 mt-3">
+            <Input
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="file.md or folder/file.md"
+              onKeyDown={(e) => e.key === "Enter" && createFile()}
+              className="h-8 flex-1 min-w-0"
+            />
+            <Button variant="secondary" size="sm" onClick={createFile} disabled={!newName.trim()}>
+              +
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex-1 flex flex-col">
+          {selected ? (
+            <>
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-sm text-zinc-400 font-mono">{selected}</span>
+                <div className="flex items-center gap-2">
+                  {editor.message && <span className="text-xs text-zinc-400">{editor.message}</span>}
+                  {editor.isDirty && !editor.message && <span className="text-xs text-amber-400">Unsaved</span>}
+                  <Button variant="default" size="sm" onClick={saveFile} disabled={editor.saving}>
+                    {editor.saving ? "Saving..." : "Save"}
+                  </Button>
+                </div>
+              </div>
+              <textarea
+                value={editor.content}
+                onChange={(e) => editor.setContent(e.target.value)}
+                className="flex-1 p-3 text-sm font-mono rounded-lg border border-zinc-700 bg-zinc-900 text-zinc-200 focus:outline-none focus:border-zinc-500 resize-none leading-relaxed"
+                spellCheck={false}
+              />
+            </>
+          ) : (
+            <div className="flex-1 flex items-center justify-center text-zinc-400 text-sm">
+              Select a file or create a new one
+            </div>
+          )}
         </div>
       </div>
 
-      <div className="flex-1 flex flex-col">
-        {selected ? (
-          <>
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-sm text-zinc-400 font-mono">{selected}</span>
-              <div className="flex items-center gap-2">
-                {editor.message && <span className="text-xs text-zinc-400">{editor.message}</span>}
-                {editor.isDirty && !editor.message && <span className="text-xs text-amber-400">Unsaved</span>}
-                <Button variant="default" size="sm" onClick={saveFile} disabled={editor.saving}>
-                  {editor.saving ? "Saving..." : "Save"}
-                </Button>
-              </div>
-            </div>
-            <textarea
-              value={editor.content}
-              onChange={(e) => editor.setContent(e.target.value)}
-              className="flex-1 p-3 text-sm font-mono rounded-lg border border-zinc-700 bg-zinc-900 text-zinc-200 focus:outline-none focus:border-zinc-500 resize-none leading-relaxed"
-              spellCheck={false}
-            />
-          </>
-        ) : (
-          <div className="flex-1 flex items-center justify-center text-zinc-400 text-sm">
-            Select a file or create a new one
-          </div>
-        )}
+      <div className="max-w-2xl border-t border-zinc-800 pt-8">
+        <ContextPolicyPanel api={api} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Split from PR #163 (877L). This PR covers the ContextPolicyPanel component and context-policy API integration only.

- Add `ContextPolicy` types and API methods (`getContextPolicy`, `updateContextPolicy`, `getAgentContextPolicy`, `updateAgentContextPolicy`, `resetAgentContextPolicy`) to `ui/src/api.ts`
- Add `ContextPolicyPanel` component: dual-mode (full for settings/context page, compact accordion for agent sidebar)
- Integrate `ContextPolicyPanel` into `settings/context.tsx` for global policy
- Integrate compact `ContextPolicyPanel` into `AgentView.tsx` agent sidebar

**Deps:** Requires backend PR #141 (context-policy routes) - MERGED

## Constraints verified
- No fanbot/fanvue references
- No #49f264 green brand color
- No @fanvue/ui imports (uses components/ui/ shadcn)
- shadcn design system maintained

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Tests pass (`npm test`) - 531 tests green
- [ ] Biome check clean (5 pre-existing warnings only)
- [ ] Context Settings page shows ContextPolicyPanel with auto-reset controls
- [ ] Agent sidebar shows compact ContextPolicyPanel accordion