### PR TITLE
fix: resolve pre-existing biome lint errors blocking CI on every PR

### DIFF
--- a/src/context-autoreset.test.ts
+++ b/src/context-autoreset.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   COMPACT_COMMAND,
   ContextAutoResetManager,
   contextFillRatio,
   DEFAULT_AUTORESET_THRESHOLD,
-  DEFAULT_COOLDOWN_TURNS,
   shouldAutoReset,
 } from "./context-autoreset";
 

--- a/src/context-policy-store.test.ts
+++ b/src/context-policy-store.test.ts
@@ -51,10 +51,8 @@ describe("context-policy-store", () => {
 
       return {
         ...actual,
-        writeFile: (p: string, data: string, enc?: BufferEncoding) =>
-          actual.writeFile(patchPath(p), data, enc),
-        rename: (from: string, to: string) =>
-          actual.rename(patchPath(from), patchPath(to)),
+        writeFile: (p: string, data: string, enc?: BufferEncoding) => actual.writeFile(patchPath(p), data, enc),
+        rename: (from: string, to: string) => actual.rename(patchPath(from), patchPath(to)),
       };
     });
 
@@ -292,7 +290,7 @@ describe("context-policy-store", () => {
       const effective = store.getEffectiveContextPolicy("agent-z");
       expect(effective.autoReset.cooldownTurns).toBe(2);
       expect(effective.autoReset.threshold).toBe(0.8); // from global
-      expect(effective.autoReset.enabled).toBe(true);  // from builtin
+      expect(effective.autoReset.enabled).toBe(true); // from builtin
     });
 
     it("deleting per-agent override reverts to global", async () => {
@@ -317,9 +315,9 @@ describe("context-policy-store", () => {
       await store.setGlobalPolicy({ autoReset: { cooldownTurns: 10 } });
       await store.setAgentPolicy("agent-full", { autoReset: { enabled: false } });
       const effective = store.getEffectiveContextPolicy("agent-full");
-      expect(effective.autoReset.enabled).toBe(false);        // from agent
-      expect(effective.autoReset.cooldownTurns).toBe(10);     // from global
-      expect(effective.autoReset.threshold).toBe(0.72);       // from builtin
+      expect(effective.autoReset.enabled).toBe(false); // from agent
+      expect(effective.autoReset.cooldownTurns).toBe(10); // from global
+      expect(effective.autoReset.threshold).toBe(0.72); // from builtin
     });
 
     it("effective policy has no optional/undefined fields (fully resolved)", async () => {

--- a/src/route-helpers.test.ts
+++ b/src/route-helpers.test.ts
@@ -1,23 +1,24 @@
+import type { Response } from "express";
 import { describe, expect, it, vi } from "vitest";
 import { extractErrorMessage, requireExists } from "./route-helpers";
 
 describe("requireExists", () => {
   it("returns true when value is truthy", () => {
-    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as unknown as Response;
     expect(requireExists(res, "value", "not found")).toBe(true);
     expect(res.status).not.toHaveBeenCalled();
   });
 
   it("returns false and sends 404 when value is falsy", () => {
     const json = vi.fn();
-    const res = { status: vi.fn().mockReturnValue({ json }), json } as any;
+    const res = { status: vi.fn().mockReturnValue({ json }), json } as unknown as Response;
     expect(requireExists(res, null, "item not found")).toBe(false);
     expect(res.status).toHaveBeenCalledWith(404);
   });
 
   it("sends the error message in the json body", () => {
     const json = vi.fn();
-    const res = { status: vi.fn().mockReturnValue({ json }), json } as any;
+    const res = { status: vi.fn().mockReturnValue({ json }), json } as unknown as Response;
     requireExists(res, undefined, "custom error");
     expect(json).toHaveBeenCalledWith({ error: "custom error" });
   });

--- a/src/routes/hooks.test.ts
+++ b/src/routes/hooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DANGEROUS_BASH_PATTERNS, checkDangerousCommand } from "./hook-config";
+import { checkDangerousCommand, DANGEROUS_BASH_PATTERNS } from "./hook-config";
 
 describe("DANGEROUS_BASH_PATTERNS", () => {
   it("exports a non-empty array of patterns", () => {

--- a/src/routes/hooks.ts
+++ b/src/routes/hooks.ts
@@ -1,9 +1,8 @@
-import { checkDangerousCommand } from "./hook-config";
 import express, { type Request, type Response } from "express";
 import type { AgentManager } from "../agents";
 import { logger } from "../logger";
 import { param } from "../utils/express";
-
+import { checkDangerousCommand } from "./hook-config";
 
 // ── Tool timeline in-memory store ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes 5 files with pre-existing biome lint errors that caused CI to fail on every PR branched from main, blocking the entire team:

- `src/context-autoreset.test.ts`: remove unused `vi` and `DEFAULT_COOLDOWN_TURNS` imports
- `src/context-policy-store.test.ts`: fix import ordering (biome organizeImports)
- `src/route-helpers.test.ts`: replace `as any` with `as unknown as Response`
- `src/routes/hooks.ts`: fix import ordering (biome organizeImports)
- `src/routes/hooks.test.ts`: fix import ordering (biome organizeImports)

No logic changes — lint/formatting only.

## Test plan
- [x] `npx biome check .` → exit 0 (no errors, 7 pre-existing warnings)
- [x] `npm test` → 651/651 pass
- [x] `grep -i fanbot/fanvue` on diff → no matches