### PR TITLE
feat(agents): extract StateNotifier + add setPendingMessageChecker (Phase E PR24)

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -10,6 +10,7 @@ import {
   EVENT_FILE_TRUNCATE_THRESHOLD,
   EVENT_RING_BUFFER_SIZE,
   MAX_PERSISTED_EVENTS,
+  PAUSED_TTL_MS,
   PROMPT_NAME_MAX_INPUT,
   PROMPT_NAME_MAX_SLUG,
 } from "./config";
@@ -27,11 +28,13 @@ import { type AllowedModel, DEFAULT_MODEL, MODELS } from "./models";
 import { EVENTS_DIR, loadAllAgentStates, removeAgentState, saveAgentState, writeTombstone } from "./persistence";
 import { getRepoCredentialsForAgents, writeGitCredentialsFile } from "./repo-credentials";
 import { sanitizeEvent } from "./sanitize";
+import { StateNotifier } from "./state-notifier";
 import { cleanupAgentClaudeData, debouncedSyncToGCS } from "./storage";
 import type {
   Agent,
   AgentMetadata,
   AgentProcess,
+  AgentStateEvent,
   AgentUsage,
   CreateAgentRequest,
   PromptAttachment,
@@ -264,7 +267,8 @@ export class AgentManager {
   private cleanupInterval: ReturnType<typeof setInterval>;
   private flushInterval: ReturnType<typeof setInterval>;
   private watchdogInterval: ReturnType<typeof setInterval>;
-  private idleListeners = new Set<(agentId: string) => void>();
+  private notifier: StateNotifier;
+  private pendingMessageChecker: ((agentId: string) => boolean) | null = null;
   private writeQueues = new Map<string, Promise<void>>();
   /** Per-agent lifecycle lock to prevent concurrent message/destroy operations.
    *  Each entry is a promise chain - operations queue behind the previous one. */
@@ -283,6 +287,7 @@ export class AgentManager {
 
   constructor(opts?: { costTracker?: CostTracker }) {
     this.costTracker = opts?.costTracker ?? null;
+    this.notifier = new StateNotifier(this.agents);
     this.workspace.setAgentListProvider(this);
     // Cleanup idle agents every 60s
     this.cleanupInterval = setInterval(() => this.cleanupExpired(), 60_000);
@@ -294,10 +299,18 @@ export class AgentManager {
 
   /** Register a callback that fires when any agent transitions to idle. */
   onIdle(listener: (agentId: string) => void): () => void {
-    this.idleListeners.add(listener);
-    return () => {
-      this.idleListeners.delete(listener);
-    };
+    return this.notifier.onIdle(listener);
+  }
+
+  /** Register a callback for agent state change events (SSE push). */
+  onAgentState(listener: (event: AgentStateEvent) => void): () => void {
+    return this.notifier.onAgentState(listener);
+  }
+
+  /** Wire the pending-message checker so cleanupExpired() skips agents with queued work.
+   *  Called by message-delivery setup after the message bus is available. */
+  setPendingMessageChecker(checker: ((agentId: string) => boolean) | null): void {
+    this.pendingMessageChecker = checker;
   }
 
   /** Restore agents from persisted state files (call on startup). */
@@ -1156,7 +1169,7 @@ export class AgentManager {
     logger.info("[kill-switch] emergencyDestroyAll - starting nuclear shutdown");
 
     // Clear all idle listeners to prevent auto-delivery from re-triggering agent runs
-    this.idleListeners.clear();
+    this.notifier.clearIdleListeners();
 
     // SIGKILL all tracked processes immediately
     for (const [id, agentProc] of this.agents) {
@@ -1604,21 +1617,21 @@ export class AgentManager {
     }
   }
 
-  private static readonly PAUSED_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-
   private cleanupExpired(): void {
     const now = Date.now();
     for (const [id, agentProc] of [...this.agents]) {
       const lastActivity = new Date(agentProc.agent.lastActivity).getTime();
       // Paused agents get an extended 24-hour TTL instead of indefinite exemption
       if (agentProc.agent.status === "paused") {
-        if (now - lastActivity > AgentManager.PAUSED_TTL_MS) {
+        if (now - lastActivity > PAUSED_TTL_MS) {
           logger.info("Cleaning up paused agent (exceeded 24h TTL)", { agentId: id });
           this.destroy(id);
         }
         continue;
       }
       if (now - lastActivity > SESSION_TTL_MS) {
+        // Skip idle child agents that still have messages queued for delivery
+        if (this.pendingMessageChecker?.(id)) continue;
         logger.info("Cleaning up expired agent", { agentId: id });
         this.destroy(id);
       }
@@ -1631,15 +1644,8 @@ export class AgentManager {
   private static readonly STALL_TIMEOUT_MS = 10 * 60_000; // 10 minutes
   private static readonly MAX_STALL_COUNT = 3;
 
-  /** Notify all idle listeners for an agent. Encapsulates the for-loop + try/catch pattern. */
   private notifyIdleListeners(id: string): void {
-    for (const listener of this.idleListeners) {
-      try {
-        listener(id);
-      } catch (err: unknown) {
-        logger.warn("[agents] Idle listener error", { error: errorMessage(err) });
-      }
-    }
+    this.notifier.notifyIdleListeners(id);
   }
 
   private watchdogCheck(): void {

--- a/src/state-notifier.ts
+++ b/src/state-notifier.ts
@@ -1,0 +1,93 @@
+import { logger } from "./logger";
+import type { Agent, AgentProcess, AgentStateEvent } from "./types";
+import { errorMessage } from "./types";
+
+/** Minimal registry interface for reading agent presence. The AgentManager
+ *  `Map<string, AgentProcess>` satisfies this structurally. */
+export interface NotifierRegistry {
+  get(id: string): AgentProcess | undefined;
+}
+
+export class StateNotifier {
+  private idleListeners = new Set<(agentId: string) => void>();
+  private agentStateListeners = new Set<(event: AgentStateEvent) => void>();
+  private stateNotifyTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor(private readonly agents: NotifierRegistry) {}
+
+  /** Register a callback that fires when any agent transitions to idle.
+   *  Returns an unsubscribe function. */
+  onIdle(listener: (agentId: string) => void): () => void {
+    this.idleListeners.add(listener);
+    return () => {
+      this.idleListeners.delete(listener);
+    };
+  }
+
+  /** Register a callback for agent state change events (SSE push). Returns an unsubscribe function. */
+  onAgentState(listener: (event: AgentStateEvent) => void): () => void {
+    this.agentStateListeners.add(listener);
+    return () => this.agentStateListeners.delete(listener);
+  }
+
+  /** Broadcast an agent state change event to all registered SSE listeners. */
+  notifyAgentState(event: AgentStateEvent): void {
+    for (const listener of this.agentStateListeners) {
+      try {
+        listener(event);
+      } catch (err) {
+        logger.warn("[agents] agentState listener error", { error: errorMessage(err) });
+      }
+    }
+  }
+
+  /** Schedule an agent_updated notification.
+   *  immediate=true: fires synchronously (status transitions).
+   *  immediate=false: debounced 1s (usage-only updates). */
+  scheduleAgentUpdated(id: string, agent: Agent, immediate = false): void {
+    if (immediate) {
+      const timer = this.stateNotifyTimers.get(id);
+      if (timer) {
+        clearTimeout(timer);
+        this.stateNotifyTimers.delete(id);
+      }
+      this.notifyAgentState({ type: "agent_updated", agent: { ...agent } });
+      return;
+    }
+    if (!this.stateNotifyTimers.has(id)) {
+      this.stateNotifyTimers.set(
+        id,
+        setTimeout(() => {
+          this.stateNotifyTimers.delete(id);
+          const ap = this.agents.get(id);
+          if (ap) this.notifyAgentState({ type: "agent_updated", agent: { ...ap.agent } });
+        }, 1000),
+      );
+    }
+  }
+
+  /** Notify all idle listeners for an agent. */
+  notifyIdleListeners(id: string): void {
+    for (const listener of this.idleListeners) {
+      try {
+        listener(id);
+      } catch (err: unknown) {
+        logger.warn("[agents] Idle listener error", { error: errorMessage(err) });
+      }
+    }
+  }
+
+  /** Cancel any pending debounced agent_updated timer for an agent (used on destroy). */
+  cancelTimer(id: string): void {
+    const timer = this.stateNotifyTimers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      this.stateNotifyTimers.delete(id);
+    }
+  }
+
+  /** Clear all idle listeners (used by the kill switch to stop auto-delivery re-triggering). */
+  clearIdleListeners(): void {
+    this.idleListeners.clear();
+  }
+}


### PR DESCRIPTION
## Summary

Phase E PR24 — extract idle-listener / agent-state notification logic into `src/state-notifier.ts` and consume it in `src/agents.ts`.

**New file: `src/state-notifier.ts`**
- `StateNotifier` class owns `idleListeners`, `agentStateListeners`, and per-agent debounce timers for `agent_updated` SSE events
- `onIdle()`, `onAgentState()`, `notifyIdleListeners()`, `notifyAgentState()`, `scheduleAgentUpdated()`, `cancelTimer()`, `clearIdleListeners()`

**Changes to `src/agents.ts`**
- Replace `private idleListeners` Set with `private notifier: StateNotifier` instance
- `onIdle()` delegates to `notifier.onIdle()`
- New `onAgentState()` exposes SSE agent-state push (was absent in AM)
- New `setPendingMessageChecker()` lets message-delivery wire a pending-message callback so `cleanupExpired()` skips idle agents that still have queued work
- `PAUSED_TTL_MS` static member removed — now imported from `config.ts`
- `notifyIdleListeners()` private method replaced by one-line delegation

Diff: +116/-17, 2 files. Behaviour-preserving.

## Test plan

- [x] `tsc --noEmit` — no new errors
- [x] `biome check` — clean
- [x] `npm test` — 651 tests, 42 files, all passing
- [x] grep fanbot/fanvue — clean