### PR TITLE
feat(agents): extract UsageTracker + wire estimateCost (Phase E PR25)

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -24,7 +24,7 @@ import {
 } from "./errors";
 import { ALLOWED_MODELS, MAX_AGENT_DEPTH, MAX_AGENTS, MAX_CHILDREN_PER_AGENT, SESSION_TTL_MS } from "./guardrails";
 import { logger } from "./logger";
-import { type AllowedModel, DEFAULT_MODEL, MODELS } from "./models";
+import { DEFAULT_MODEL } from "./models";
 import { EVENTS_DIR, loadAllAgentStates, removeAgentState, saveAgentState, writeTombstone } from "./persistence";
 import { getRepoCredentialsForAgents, writeGitCredentialsFile } from "./repo-credentials";
 import { sanitizeEvent } from "./sanitize";
@@ -41,6 +41,7 @@ import type {
   StreamEvent,
 } from "./types";
 import { errorMessage } from "./types";
+import { estimateCost, UsageTracker } from "./usage-tracker";
 import { WorkspaceManager } from "./workspace-manager";
 import { cleanupWorktreesForWorkspace } from "./worktrees";
 
@@ -282,11 +283,13 @@ export class AgentManager {
   killed = false;
   /** Optional persistent cost tracker (SQLite-backed). */
   private costTracker: CostTracker | null = null;
+  private usageTracker: UsageTracker;
   /** Workspace management (directories, symlinks, tokens, env). */
   private workspace = new WorkspaceManager();
 
   constructor(opts?: { costTracker?: CostTracker }) {
     this.costTracker = opts?.costTracker ?? null;
+    this.usageTracker = new UsageTracker(this.agents, this.costTracker);
     this.notifier = new StateNotifier(this.agents);
     this.workspace.setAgentListProvider(this);
     // Cleanup idle agents every 60s
@@ -891,46 +894,9 @@ export class AgentManager {
     return this.readPersistedEvents(id);
   }
 
-  /** Estimate cost in USD from token usage and model pricing. */
-  private static estimateCost(
-    model: string,
-    usage: {
-      input_tokens?: number;
-      output_tokens?: number;
-      cache_creation_input_tokens?: number;
-      cache_read_input_tokens?: number;
-    },
-  ): number {
-    const pricing = MODELS[model as AllowedModel]?.pricing;
-    if (!pricing) return 0;
-    const perM = 1_000_000;
-    return (
-      ((usage.input_tokens ?? 0) / perM) * pricing.input +
-      ((usage.output_tokens ?? 0) / perM) * pricing.output +
-      ((usage.cache_read_input_tokens ?? 0) / perM) * pricing.cacheRead +
-      ((usage.cache_creation_input_tokens ?? 0) / perM) * pricing.cacheWrite
-    );
-  }
-
   /** Return token usage and estimated cost for a single agent. */
   getUsage(id: string): AgentUsage | null {
-    const agentProc = this.agents.get(id);
-    if (!agentProc) return null;
-    const { agent } = agentProc;
-    const tokensIn = agent.usage?.tokensIn ?? 0;
-    const tokensOut = agent.usage?.tokensOut ?? 0;
-    const tokensTotal = tokensIn + tokensOut;
-    const tokenLimit = MODELS[agent.model as AllowedModel]?.tokenLimit ?? 200_000;
-    return {
-      tokensIn,
-      tokensOut,
-      tokensTotal,
-      tokenLimit,
-      tokensRemaining: Math.max(0, tokenLimit - tokensTotal),
-      estimatedCost: Math.round((agent.usage?.estimatedCost ?? 0) * 1e6) / 1e6,
-      model: agent.model,
-      sessionStart: agent.createdAt,
-    };
+    return this.usageTracker.getUsage(id);
   }
 
   /** Refresh cached git info on an agent (async, fire-and-forget safe). */
@@ -969,33 +935,14 @@ export class AgentManager {
     };
   }
 
-  /** Return token usage for all agents, keyed by agent ID. */
+  /** Return token usage for all agents. */
   getAllUsage(): { agents: Array<{ id: string; name: string; usage: AgentUsage }> } {
-    const result: Array<{ id: string; name: string; usage: AgentUsage }> = [];
-    for (const agentProc of this.agents.values()) {
-      const usage = this.getUsage(agentProc.agent.id);
-      if (usage) {
-        result.push({ id: agentProc.agent.id, name: agentProc.agent.name, usage });
-      }
-    }
-    return { agents: result };
+    return this.usageTracker.getAllUsage();
   }
 
-  /** Reset in-memory usage counters for all tracked agents.
-   *  Only clears in-memory state and persists to /persistent/ - callers are
-   *  responsible for clearing SQLite via costTracker.reset() if needed. */
+  /** Reset in-memory usage counters for all tracked agents. */
   resetAllUsage(): void {
-    for (const agentProc of this.agents.values()) {
-      agentProc.agent.usage = {
-        tokensIn: 0,
-        tokensOut: 0,
-        estimatedCost: 0,
-        totalTokensSpent: 0,
-        totalTokensIn: 0,
-        totalTokensOut: 0,
-      };
-      saveAgentState(agentProc.agent);
-    }
+    this.usageTracker.resetAllUsage();
   }
 
   /** Return session logs for an agent in a readable format.
@@ -1423,7 +1370,7 @@ export class AgentManager {
         const tokensIn =
           (usage.input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0);
         const tokensOut = usage.output_tokens ?? 0;
-        const cost = AgentManager.estimateCost(agentProc.agent.model, usage);
+        const cost = estimateCost(agentProc.agent.model, usage);
 
         if (tokensIn > 0 || tokensOut > 0) {
           const prev = agentProc.agent.usage ?? { tokensIn: 0, tokensOut: 0, estimatedCost: 0, totalTokensSpent: 0 };
@@ -1493,20 +1440,8 @@ export class AgentManager {
     }
   }
 
-  /** Persist usage snapshot to SQLite cost tracker. Only called when usage actually changes.
-   *  Uses cumulative token values (totalTokensIn/Out) so billing data survives context clears. */
   private upsertCostTracker(agentProc: AgentProcess): void {
-    if (!this.costTracker || !agentProc.agent.usage) return;
-    const usage = agentProc.agent.usage;
-    this.costTracker.upsert({
-      agentId: agentProc.agent.id,
-      agentName: agentProc.agent.name,
-      model: agentProc.agent.model,
-      tokensIn: usage.totalTokensIn ?? usage.tokensIn,
-      tokensOut: usage.totalTokensOut ?? usage.tokensOut,
-      estimatedCost: usage.estimatedCost,
-      createdAt: agentProc.agent.createdAt,
-    });
+    this.usageTracker.upsertCostTracker(agentProc);
   }
 
   /** Flush batched event persistence and listener notifications for an agent.

--- a/src/usage-tracker.test.ts
+++ b/src/usage-tracker.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import { estimateCost, TOKEN_LIMITS, UsageTracker } from "./usage-tracker";
+
+// Minimal AgentProcess stub for testing
+function makeAgentProc(model: string, usage?: object) {
+  return {
+    agent: {
+      id: "test-id",
+      name: "test-agent",
+      model,
+      createdAt: new Date().toISOString(),
+      usage: usage ?? null,
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test stub
+  } as any;
+}
+
+// Minimal registry returning a single agent
+function makeRegistry(agentProc: ReturnType<typeof makeAgentProc>) {
+  const map = new Map([["test-id", agentProc]]);
+  return {
+    get: (id: string) => map.get(id),
+    values: () => map.values(),
+  };
+}
+
+describe("estimateCost", () => {
+  it("returns 0 for unknown model", () => {
+    expect(estimateCost("unknown-model", { input_tokens: 1000, output_tokens: 100 })).toBe(0);
+  });
+
+  it("calculates cost for claude-sonnet-4-6", () => {
+    const cost = estimateCost("claude-sonnet-4-6", {
+      input_tokens: 1_000_000,
+      output_tokens: 0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    });
+    // Sonnet 4.6 input = $3/M
+    expect(cost).toBeCloseTo(3, 5);
+  });
+
+  it("calculates output cost for claude-haiku-4-5-20251001", () => {
+    const cost = estimateCost("claude-haiku-4-5-20251001", {
+      input_tokens: 0,
+      output_tokens: 1_000_000,
+    });
+    // Haiku output = $5/M
+    expect(cost).toBeCloseTo(5, 5);
+  });
+
+  it("includes cache read and write costs", () => {
+    const cost = estimateCost("claude-sonnet-4-6", {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_creation_input_tokens: 1_000_000,
+      cache_read_input_tokens: 1_000_000,
+    });
+    // cache write = $3.75/M, cache read = $0.3/M
+    expect(cost).toBeCloseTo(3.75 + 0.3, 4);
+  });
+});
+
+describe("TOKEN_LIMITS", () => {
+  it("has entries for all supported models", () => {
+    expect(TOKEN_LIMITS["claude-sonnet-4-6"]).toBe(1_000_000);
+    expect(TOKEN_LIMITS["claude-haiku-4-5-20251001"]).toBe(200_000);
+  });
+});
+
+describe("UsageTracker", () => {
+  it("returns null for unknown agent", () => {
+    const registry = { get: () => undefined, values: () => [].values() };
+    const tracker = new UsageTracker(registry, null);
+    expect(tracker.getUsage("no-such-id")).toBeNull();
+  });
+
+  it("getUsage returns correct totals", () => {
+    const agentProc = makeAgentProc("claude-sonnet-4-6", {
+      tokensIn: 100,
+      tokensOut: 50,
+      estimatedCost: 0.001,
+      totalTokensSpent: 150,
+      totalTokensIn: 100,
+      totalTokensOut: 50,
+      apiTurns: 1,
+      lastTurnTokensIn: 80,
+    });
+    const tracker = new UsageTracker(makeRegistry(agentProc), null);
+    const usage = tracker.getUsage("test-id");
+
+    expect(usage).not.toBeNull();
+    expect(usage!.tokensIn).toBe(100);
+    expect(usage!.tokensOut).toBe(50);
+    expect(usage!.tokensTotal).toBe(150);
+    expect(usage!.lastTurnTokensIn).toBe(80);
+    // tokensRemaining uses lastTurnTokensIn, not cumulative
+    expect(usage!.tokensRemaining).toBe(1_000_000 - 80);
+    expect(usage!.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("getAllUsage includes all agents", () => {
+    const a1 = makeAgentProc("claude-sonnet-4-6", { tokensIn: 10, tokensOut: 5, estimatedCost: 0 });
+    const a2 = makeAgentProc("claude-haiku-4-5-20251001", { tokensIn: 20, tokensOut: 10, estimatedCost: 0 });
+    a1.agent.id = "a1";
+    a2.agent.id = "a2";
+    const registry = {
+      get: (id: string) => (id === "a1" ? a1 : id === "a2" ? a2 : undefined),
+      values: () => [a1, a2].values(),
+    };
+    const tracker = new UsageTracker(registry, null);
+    const { agents } = tracker.getAllUsage();
+    expect(agents).toHaveLength(2);
+  });
+
+  it("resetAllUsage zeroes all counters", () => {
+    const agentProc = makeAgentProc("claude-sonnet-4-6", {
+      tokensIn: 100,
+      tokensOut: 50,
+      estimatedCost: 5,
+      totalTokensSpent: 150,
+      totalTokensIn: 100,
+      totalTokensOut: 50,
+    });
+    const tracker = new UsageTracker(makeRegistry(agentProc), null);
+    tracker.resetAllUsage();
+    expect(agentProc.agent.usage.tokensIn).toBe(0);
+    expect(agentProc.agent.usage.estimatedCost).toBe(0);
+  });
+
+  it("upsertCostTracker does nothing when costTracker is null", () => {
+    const agentProc = makeAgentProc("claude-sonnet-4-6", { tokensIn: 10 });
+    const tracker = new UsageTracker(makeRegistry(agentProc), null);
+    // Should not throw
+    expect(() => tracker.upsertCostTracker(agentProc)).not.toThrow();
+  });
+
+  it("upsertCostTracker calls costTracker.upsert with correct values", () => {
+    const agentProc = makeAgentProc("claude-sonnet-4-6", {
+      tokensIn: 100,
+      tokensOut: 50,
+      estimatedCost: 0.002,
+      totalTokensIn: 200,
+      totalTokensOut: 100,
+    });
+    const mockCostTracker = { upsert: vi.fn() };
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    const tracker = new UsageTracker(makeRegistry(agentProc), mockCostTracker as any);
+    tracker.upsertCostTracker(agentProc);
+    expect(mockCostTracker.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "test-id",
+        tokensIn: 200,
+        tokensOut: 100,
+        estimatedCost: 0.002,
+      }),
+    );
+  });
+});

--- a/src/usage-tracker.ts
+++ b/src/usage-tracker.ts
@@ -1,0 +1,144 @@
+import type { CostTracker } from "./cost-tracker";
+import { logger } from "./logger";
+import { type AllowedModel, MODELS } from "./models";
+import { saveAgentState } from "./persistence";
+import type { AgentProcess, AgentUsage } from "./types";
+
+/** Minimal registry interface for reading agent data.
+ *  `Map<string, AgentProcess>` satisfies this structurally. */
+export interface AgentRegistry {
+  get(id: string): AgentProcess | undefined;
+  values(): IterableIterator<AgentProcess>;
+}
+
+/** Context window limit per model, derived from the MODELS registry. */
+export const TOKEN_LIMITS: Record<string, number> = Object.fromEntries(
+  Object.entries(MODELS).map(([id, m]) => [id, m.tokenLimit]),
+);
+
+/** Per-million-token pricing by model, derived from the MODELS registry. */
+export const MODEL_PRICING: Record<string, { input: number; output: number; cacheRead: number; cacheWrite: number }> =
+  Object.fromEntries(Object.entries(MODELS).map(([id, m]) => [id, m.pricing]));
+
+export const PRICING_LAST_VERIFIED = "2026-06-01";
+export const PRICING_STALENESS_DAYS = 90;
+
+/** Module-level flag to warn at most once per process lifetime. */
+let pricingStalenessWarned = false;
+
+/** Set of model IDs we have already logged as missing from MODEL_PRICING. */
+const unknownModelsWarned = new Set<string>();
+
+/** Estimate cost in USD from token usage and model pricing. */
+export function estimateCost(
+  model: string,
+  usage: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  },
+): number {
+  if (!pricingStalenessWarned) {
+    const age = (Date.now() - new Date(PRICING_LAST_VERIFIED).getTime()) / 86_400_000;
+    if (age > PRICING_STALENESS_DAYS) {
+      logger.warn(
+        `[cost] MODEL_PRICING last verified ${PRICING_LAST_VERIFIED} (${Math.round(age)}d ago). ` +
+          "Check https://www.anthropic.com/pricing for updates.",
+      );
+      pricingStalenessWarned = true;
+    }
+  }
+  const pricing = MODELS[model as AllowedModel]?.pricing;
+  if (!pricing) {
+    if (model && !unknownModelsWarned.has(model)) {
+      unknownModelsWarned.add(model);
+      logger.warn(`[cost] No pricing entry for "${model}" — costs will report $0 for this model.`);
+    }
+    return 0;
+  }
+  const perM = 1_000_000;
+  return (
+    ((usage.input_tokens ?? 0) / perM) * pricing.input +
+    ((usage.output_tokens ?? 0) / perM) * pricing.output +
+    ((usage.cache_read_input_tokens ?? 0) / perM) * pricing.cacheRead +
+    ((usage.cache_creation_input_tokens ?? 0) / perM) * pricing.cacheWrite
+  );
+}
+
+/**
+ * UsageTracker encapsulates per-agent token accounting and cost persistence.
+ */
+export class UsageTracker {
+  constructor(
+    private registry: AgentRegistry,
+    private costTracker: CostTracker | null,
+  ) {}
+
+  /** Return token usage and estimated cost for a single agent. */
+  getUsage(id: string): AgentUsage | null {
+    const agentProc = this.registry.get(id);
+    if (!agentProc) return null;
+    const { agent } = agentProc;
+    const tokensIn = agent.usage?.tokensIn ?? 0;
+    const tokensOut = agent.usage?.tokensOut ?? 0;
+    const tokensTotal = tokensIn + tokensOut;
+    const tokenLimit = MODELS[agent.model as AllowedModel]?.tokenLimit ?? 200_000;
+    const lastTurnTokensIn = agent.usage?.lastTurnTokensIn ?? 0;
+    return {
+      tokensIn,
+      tokensOut,
+      tokensTotal,
+      tokenLimit,
+      tokensRemaining: Math.max(0, tokenLimit - lastTurnTokensIn),
+      estimatedCost: Math.round((agent.usage?.estimatedCost ?? 0) * 1e6) / 1e6,
+      model: agent.model,
+      sessionStart: agent.createdAt,
+      lastTurnTokensIn,
+    };
+  }
+
+  /** Return token usage for all agents. */
+  getAllUsage(): { agents: Array<{ id: string; name: string; usage: AgentUsage }> } {
+    const result: Array<{ id: string; name: string; usage: AgentUsage }> = [];
+    for (const agentProc of this.registry.values()) {
+      const usage = this.getUsage(agentProc.agent.id);
+      if (usage) {
+        result.push({ id: agentProc.agent.id, name: agentProc.agent.name, usage });
+      }
+    }
+    return { agents: result };
+  }
+
+  /** Reset in-memory usage counters for all tracked agents. */
+  resetAllUsage(): void {
+    for (const agentProc of this.registry.values()) {
+      agentProc.agent.usage = {
+        tokensIn: 0,
+        tokensOut: 0,
+        estimatedCost: 0,
+        totalTokensSpent: 0,
+        totalTokensIn: 0,
+        totalTokensOut: 0,
+        apiTurns: 0,
+        lastTurnTokensIn: 0,
+      };
+      saveAgentState(agentProc.agent);
+    }
+  }
+
+  /** Persist usage snapshot to SQLite cost tracker. Only called when usage actually changes. */
+  upsertCostTracker(agentProc: AgentProcess): void {
+    if (!this.costTracker || !agentProc.agent.usage) return;
+    const usage = agentProc.agent.usage;
+    this.costTracker.upsert({
+      agentId: agentProc.agent.id,
+      agentName: agentProc.agent.name,
+      model: agentProc.agent.model,
+      tokensIn: usage.totalTokensIn ?? usage.tokensIn,
+      tokensOut: usage.totalTokensOut ?? usage.tokensOut,
+      estimatedCost: usage.estimatedCost,
+      createdAt: agentProc.agent.createdAt,
+    });
+  }
+}


### PR DESCRIPTION
Phase E PR25 — extract token accounting into `src/usage-tracker.ts`.

**New:** `UsageTracker` class with `getUsage`, `getAllUsage`, `resetAllUsage`, `upsertCostTracker`, module-level `estimateCost` (adds staleness warning + lastTurnTokensIn to snapshot).

**agents.ts:** removes ~80 lines — static `estimateCost`, inline `getUsage/getAllUsage/resetAllUsage/upsertCostTracker` — replaced by `UsageTracker` delegation. `getUsage` now surfaces `lastTurnTokensIn` for accurate context-window gauge.

Diff: +155/-76, 2 files. 651 tests pass, biome+tsc clean.