### PR TITLE
fix: add missing getContainerMemoryLimit export to utils/memory.ts

### DIFF
--- a/src/utils/memory.ts
+++ b/src/utils/memory.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
+import os from "node:os";
 
 const CGROUP_MEMORY_PATH = "/sys/fs/cgroup/memory.current";
+const CGROUP_MEMORY_LIMIT_PATH = "/sys/fs/cgroup/memory.max";
 
 /**
  * Read container-level memory usage from cgroup v2. This captures the server
@@ -16,5 +18,23 @@ export function getContainerMemoryUsage(): number {
     return bytes;
   } catch {
     return process.memoryUsage().rss;
+  }
+}
+
+/**
+ * Read the container memory limit from cgroup v2. Returns the hard limit set
+ * by the container runtime (Cloud Run memory allocation). Falls back to
+ * os.totalmem() when cgroup files aren't available (local dev) or when the
+ * limit is set to "max" (unlimited cgroup).
+ */
+export function getContainerMemoryLimit(): number {
+  try {
+    const raw = fs.readFileSync(CGROUP_MEMORY_LIMIT_PATH, "utf-8").trim();
+    if (raw === "max") return os.totalmem();
+    const bytes = Number(raw);
+    if (Number.isNaN(bytes) || bytes <= 0) return os.totalmem();
+    return bytes;
+  } catch {
+    return os.totalmem();
   }
 }


### PR DESCRIPTION
## Summary

1-line fix (actually 15 lines with impl + fallback): adds the missing `getContainerMemoryLimit` export that `workflow-resource-manager.ts` imports but was never defined.

**Root cause:** PR #177 added `workflow-resource-manager.ts` which imports `{ getContainerMemoryLimit, getContainerMemoryUsage }` from `./utils/memory`, but only `getContainerMemoryUsage` was ever exported — `getContainerMemoryLimit` was missing. This caused a TS2305 compile error failing the Typecheck step on **every PR** branched from main.

**Fix:** Adds `getContainerMemoryLimit()` to `src/utils/memory.ts`:
- Reads `/sys/fs/cgroup/memory.max` (cgroup v2 hard limit set by Cloud Run)
- Falls back to `os.totalmem()` when unavailable or set to `"max"` (unlimited)
- Mirrors the pattern of the existing `getContainerMemoryUsage()`

## Test plan
- [x] `npm run typecheck` — no more TS2305 on workflow-resource-manager.ts
- [x] `npx biome check .` → exit 0
- [x] `npm test` — 27 utils tests pass
- [x] `grep -i fanvue/fanbot` → clean
