### PR TITLE
feat: add /api/tokens route + token-storage tests (PR 16b)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -32,6 +32,7 @@ import { createRepositoriesRouter } from "./src/routes/repositories";
 import { createSchedulerRouter } from "./src/routes/scheduler";
 import { createStartupRouter } from "./src/routes/startup";
 import { createTasksRouter } from "./src/routes/tasks";
+import { createTokensRouter } from "./src/routes/tokens";
 import { createUsageRouter } from "./src/routes/usage";
 import { createWorkflowsRouter } from "./src/routes/workflows";
 import { Scheduler } from "./src/scheduler";
@@ -217,6 +218,7 @@ app.use(createContextPolicyRouter());
 app.use(createStartupRouter(agentManager, messageBus));
 app.use("/api/agents", hookConfigRouter);
 app.use(createHooksRouter(agentManager));
+app.use(createTokensRouter());
 // Layer 1: Kill switch endpoint (no extra auth beyond authMiddleware above)
 app.use(createKillSwitchRouter(agentManager));
 

--- a/src/routes/tokens.ts
+++ b/src/routes/tokens.ts
@@ -1,0 +1,143 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import express, { type Response } from "express";
+import { requireNotAgentService } from "../auth";
+import { logger } from "../logger";
+import { debouncedSyncToGCS } from "../storage";
+import {
+  deleteToken,
+  getTokenStatuses,
+  KNOWN_SERVICES,
+  loadToken,
+  SERVICE_TO_ENV,
+  saveUIToken,
+} from "../token-storage";
+import { validateToken } from "../token-validation";
+import type { AuthenticatedRequest } from "../types";
+import { errorMessage } from "../types";
+
+const execFileAsync = promisify(execFile);
+
+/** Re-run MCP bootstrap to regenerate ~/.claude/settings.json after token changes. */
+async function rebootstrapMcp(): Promise<void> {
+  try {
+    await execFileAsync("node", ["scripts/mcp-bootstrap.js"], {
+      cwd: process.cwd(),
+      timeout: 10_000,
+      env: process.env,
+    });
+    logger.info("[tokens] MCP settings re-bootstrapped after token change");
+  } catch (err: unknown) {
+    logger.warn(`[tokens] Failed to re-bootstrap MCP settings: ${errorMessage(err)}`);
+  }
+}
+
+export function createTokensRouter() {
+  const router = express.Router();
+
+  /**
+   * GET /api/tokens
+   * List all integration token statuses (never returns raw token values)
+   */
+  router.get("/api/tokens", (_req, res: Response) => {
+    try {
+      const statuses = getTokenStatuses();
+      res.json({ tokens: statuses });
+    } catch (err: unknown) {
+      logger.error(`[tokens] Failed to list tokens: ${errorMessage(err)}`);
+      res.status(500).json({ error: "Failed to list token statuses" });
+    }
+  });
+
+  /**
+   * PUT /api/tokens/:service
+   * Set or update a token for a service.
+   * Body: { token: string, label?: string }
+   * Query: ?validate=true (default) to validate before saving
+   */
+  router.put("/api/tokens/:service", requireNotAgentService, async (req, res: Response) => {
+    const service = req.params.service as string;
+    if (!KNOWN_SERVICES.has(service)) {
+      res.status(400).json({ error: `Unknown service: ${service}. Valid services: ${[...KNOWN_SERVICES].join(", ")}` });
+      return;
+    }
+
+    const { token, label } = req.body ?? {};
+    if (!token || typeof token !== "string" || token.trim().length < 4) {
+      res.status(400).json({ error: "A valid token string is required" });
+      return;
+    }
+
+    const trimmedToken = token.trim();
+    const shouldValidate = req.query.validate !== "false";
+
+    let validatedUser: string | undefined;
+    let validationWarning: string | undefined;
+
+    if (shouldValidate) {
+      const result = await validateToken(service, trimmedToken);
+      if (!result.valid) {
+        validationWarning = result.error || "Token validation failed";
+        logger.warn(
+          `[AUDIT] Token for ${service} set with validation warning by user: ${(req as AuthenticatedRequest).user?.sub ?? "unknown"} — ${validationWarning}`,
+        );
+      } else {
+        validatedUser = result.user;
+      }
+    }
+
+    try {
+      saveUIToken(service, trimmedToken, { label: typeof label === "string" ? label : undefined, validatedUser });
+      await rebootstrapMcp();
+      debouncedSyncToGCS();
+
+      logger.warn(`[AUDIT] Token for ${service} set by user: ${(req as AuthenticatedRequest).user?.sub ?? "unknown"}`);
+
+      const stored = loadToken(service);
+      res.json({
+        ok: true,
+        service,
+        source: "ui",
+        hint: `...${trimmedToken.slice(-4)}`,
+        user: validatedUser,
+        label: stored?.label,
+        validationWarning,
+      });
+    } catch (err: unknown) {
+      logger.error(`[tokens] Failed to save token for ${service}: ${errorMessage(err)}`);
+      res.status(500).json({ error: "Failed to save token" });
+    }
+  });
+
+  /**
+   * DELETE /api/tokens/:service
+   * Remove a UI-set token for a service. Falls back to env var.
+   */
+  router.delete("/api/tokens/:service", requireNotAgentService, async (req, res: Response) => {
+    const service = req.params.service as string;
+    if (!KNOWN_SERVICES.has(service)) {
+      res.status(400).json({ error: `Unknown service: ${service}` });
+      return;
+    }
+
+    try {
+      deleteToken(service);
+      await rebootstrapMcp();
+      debouncedSyncToGCS();
+
+      logger.warn(
+        `[AUDIT] Token for ${service} removed by user: ${(req as AuthenticatedRequest).user?.sub ?? "unknown"}`,
+      );
+
+      const envKey = SERVICE_TO_ENV[service];
+      const hasFallback = envKey ? !!process.env[envKey] : false;
+
+      res.json({ ok: true, service, hasFallback });
+    } catch (err: unknown) {
+      logger.error(`[tokens] Failed to delete token for ${service}: ${errorMessage(err)}`);
+      res.status(500).json({ error: "Failed to delete token" });
+    }
+  });
+
+  return router;
+}

--- a/src/token-storage.test.ts
+++ b/src/token-storage.test.ts
@@ -1,0 +1,255 @@
+/**
+ * token-storage.test.ts
+ *
+ * Uses vi.resetModules() + dynamic import in beforeEach so that token-storage
+ * reads MCP_TOKEN_DIR / TOKEN_DIR fresh for each test (the constant is evaluated
+ * at module load time, not lazily).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// We re-import these types in each test via the `mod` variable below.
+import type { MCPOAuthToken as _MCPOAuthToken, StoredToken } from "./token-storage";
+
+type Mod = typeof import("./token-storage");
+
+let tokenDir: string;
+let mod: Mod;
+let registerSecretValue: ReturnType<typeof vi.fn>;
+let unregisterSecretValue: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+  tokenDir = fs.mkdtempSync(path.join(os.tmpdir(), "token-storage-test-"));
+  process.env.MCP_TOKEN_DIR = tokenDir;
+
+  vi.resetModules();
+
+  registerSecretValue = vi.fn();
+  unregisterSecretValue = vi.fn();
+
+  vi.doMock("./logger", () => ({
+    logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  }));
+
+  vi.doMock("./sanitize", () => ({
+    registerSecretValue,
+    unregisterSecretValue,
+  }));
+
+  mod = await import("./token-storage");
+});
+
+afterEach(() => {
+  if (fs.existsSync(tokenDir)) {
+    fs.rmSync(tokenDir, { recursive: true, force: true });
+  }
+  delete process.env.MCP_TOKEN_DIR;
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.LINEAR_API_KEY;
+  vi.clearAllMocks();
+});
+
+describe("ensureTokenDir", () => {
+  it("does not throw if directory already exists", () => {
+    expect(() => mod.ensureTokenDir()).not.toThrow();
+  });
+});
+
+describe("loadToken — no stored file", () => {
+  it("returns null when the token file does not exist", () => {
+    expect(mod.loadToken("github")).toBeNull();
+  });
+});
+
+describe("saveToken / loadToken round-trip", () => {
+  it("persists a UI token and reads it back", () => {
+    const token: StoredToken = {
+      server: "github",
+      token: "ghp_test123456",
+      source: "ui",
+      label: "my-gh-token",
+      setAt: new Date().toISOString(),
+    };
+    mod.saveToken(token);
+    const loaded = mod.loadToken("github");
+    expect(loaded?.token).toBe("ghp_test123456");
+    expect(loaded?.source).toBe("ui");
+    expect(loaded?.label).toBe("my-gh-token");
+  });
+
+  it("persists an OAuth token and reads it back", () => {
+    mod.saveToken({
+      server: "linear",
+      accessToken: "lin_oauth_abcdefgh",
+      refreshToken: "lin_refresh_xyz",
+      tokenType: "Bearer",
+      source: "oauth",
+    });
+    const loaded = mod.loadToken("linear");
+    expect(loaded?.accessToken).toBe("lin_oauth_abcdefgh");
+    expect(loaded?.refreshToken).toBe("lin_refresh_xyz");
+  });
+
+  it("registers the secret with sanitize on save", () => {
+    mod.saveToken({ server: "figma", token: "figma-secret-value", source: "ui" });
+    expect(registerSecretValue).toHaveBeenCalledWith("figma-secret-value");
+  });
+
+  it("returns cached token without re-reading disk", () => {
+    mod.saveToken({ server: "github", token: "cached-token-12", source: "ui" });
+    fs.unlinkSync(path.join(tokenDir, "github.json"));
+    expect(mod.loadToken("github")?.token).toBe("cached-token-12");
+  });
+});
+
+describe("deleteToken", () => {
+  it("removes the token file and cache entry", () => {
+    mod.saveToken({ server: "github", token: "ghp_delete_me12", source: "ui" });
+    mod.deleteToken("github");
+    expect(mod.loadToken("github")).toBeNull();
+    expect(fs.existsSync(path.join(tokenDir, "github.json"))).toBe(false);
+  });
+
+  it("calls unregisterSecretValue with the stored token value", () => {
+    mod.saveToken({ server: "figma", token: "figma-secret-del1", source: "ui" });
+    vi.clearAllMocks();
+    mod.deleteToken("figma");
+    expect(unregisterSecretValue).toHaveBeenCalledWith("figma-secret-del1");
+  });
+
+  it("is a no-op when no token exists", () => {
+    expect(() => mod.deleteToken("nonexistent")).not.toThrow();
+  });
+});
+
+describe("listStoredTokens", () => {
+  it("returns empty array when no tokens are stored", () => {
+    expect(mod.listStoredTokens()).toEqual([]);
+  });
+
+  it("returns all stored service names", () => {
+    mod.saveToken({ server: "github", token: "ghp_list_test01", source: "ui" });
+    mod.saveToken({ server: "linear", token: "lin_list_test01", source: "ui" });
+    const stored = mod.listStoredTokens();
+    expect(stored.sort()).toEqual(["github", "linear"].sort());
+  });
+});
+
+describe("getAllTokens", () => {
+  it("returns all stored tokens as objects", () => {
+    mod.saveToken({ server: "github", token: "ghp_all_test0001", source: "ui" });
+    mod.saveToken({ server: "figma", token: "fig_all_test0001", source: "ui" });
+    const all = mod.getAllTokens();
+    expect(all).toHaveLength(2);
+    expect(all.map((t) => t.server).sort()).toEqual(["figma", "github"].sort());
+  });
+});
+
+describe("isTokenExpired", () => {
+  it("returns false when no expiresAt is set", () => {
+    expect(mod.isTokenExpired({ server: "github", source: "oauth" })).toBe(false);
+  });
+
+  it("returns true for a past expiry date", () => {
+    const pastDate = new Date(Date.now() - 60_000).toISOString();
+    expect(mod.isTokenExpired({ server: "github", expiresAt: pastDate, source: "oauth" })).toBe(true);
+  });
+
+  it("returns false for a future expiry date", () => {
+    const futureDate = new Date(Date.now() + 3_600_000).toISOString();
+    expect(mod.isTokenExpired({ server: "github", expiresAt: futureDate, source: "oauth" })).toBe(false);
+  });
+});
+
+describe("getEffectiveTokenValue", () => {
+  it("returns UI token value when stored", () => {
+    mod.saveToken({ server: "github", token: "ghp_effective_12", source: "ui" });
+    expect(mod.getEffectiveTokenValue("github")).toBe("ghp_effective_12");
+  });
+
+  it("returns null for expired OAuth token with no env var fallback", () => {
+    delete process.env.LINEAR_API_KEY;
+    mod.saveToken({
+      server: "linear",
+      accessToken: "lin_expired_token",
+      source: "oauth",
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    expect(mod.getEffectiveTokenValue("linear")).toBeNull();
+  });
+
+  it("falls back to env var when no stored token exists", () => {
+    process.env.GITHUB_TOKEN = "env-github-token";
+    expect(mod.getEffectiveTokenValue("github")).toBe("env-github-token");
+  });
+});
+
+describe("getTokenStatuses", () => {
+  it("marks a service as configured when UI token is set", () => {
+    mod.saveToken({ server: "github", token: "ghp_status_12345", source: "ui" });
+    const statuses = mod.getTokenStatuses();
+    expect(statuses.github.configured).toBe(true);
+    expect(statuses.github.source).toBe("ui");
+    expect(statuses.github.hint).toBe("...2345");
+  });
+
+  it("marks a service as not configured when nothing is set", () => {
+    delete process.env.GITHUB_TOKEN;
+    const statuses = mod.getTokenStatuses();
+    expect(statuses.github.configured).toBe(false);
+    expect(statuses.github.source).toBe("none");
+  });
+
+  it("exposes label and validatedUser from stored token", () => {
+    mod.saveToken({ server: "figma", token: "fig_status_12345", source: "ui", label: "prod-figma", validatedUser: "alice" });
+    const statuses = mod.getTokenStatuses();
+    expect(statuses.figma.label).toBe("prod-figma");
+    expect(statuses.figma.user).toBe("alice");
+  });
+});
+
+describe("invalidateTokenCache + preloadTokens", () => {
+  it("forces a fresh read from disk after invalidation", () => {
+    mod.saveToken({ server: "github", token: "ghp_cache_v1_1234", source: "ui" });
+    const filePath = path.join(tokenDir, "github.json");
+    fs.writeFileSync(filePath, JSON.stringify({ server: "github", token: "ghp_cache_v2_1234", source: "ui" }));
+    expect(mod.loadToken("github")?.token).toBe("ghp_cache_v1_1234");
+    mod.invalidateTokenCache();
+    expect(mod.loadToken("github")?.token).toBe("ghp_cache_v2_1234");
+  });
+
+  it("preloadTokens: loads all stored tokens into cache", () => {
+    mod.saveToken({ server: "github", token: "ghp_preload12345", source: "ui" });
+    mod.invalidateTokenCache();
+    mod.preloadTokens();
+    fs.unlinkSync(path.join(tokenDir, "github.json"));
+    expect(mod.loadToken("github")?.token).toBe("ghp_preload12345");
+  });
+});
+
+describe("overwrite unregisters old secret", () => {
+  it("calls unregisterSecretValue then registerSecretValue with new value", () => {
+    mod.saveToken({ server: "github", token: "ghp_old_secret123", source: "ui" });
+    vi.clearAllMocks();
+    mod.saveToken({ server: "github", token: "ghp_new_secret123", source: "ui" });
+    expect(unregisterSecretValue).toHaveBeenCalledWith("ghp_old_secret123");
+    expect(registerSecretValue).toHaveBeenCalledWith("ghp_new_secret123");
+  });
+});
+
+describe("service mapping exports", () => {
+  it("KNOWN_SERVICES contains expected service names", () => {
+    expect(mod.KNOWN_SERVICES.has("github")).toBe(true);
+    expect(mod.KNOWN_SERVICES.has("linear")).toBe(true);
+  });
+
+  it("SERVICE_TO_ENV maps github to GITHUB_TOKEN", () => {
+    expect(mod.SERVICE_TO_ENV["github"]).toBe("GITHUB_TOKEN");
+  });
+
+  it("ENV_TO_SERVICE maps GITHUB_TOKEN to github", () => {
+    expect(mod.ENV_TO_SERVICE["GITHUB_TOKEN"]).toBe("github");
+  });
+});


### PR DESCRIPTION
Adds GET/PUT/DELETE /api/tokens route for credential management and unit tests for token-storage. Depends on PR 16a (#191). Split from #155. All tests pass, biome clean, zero fanbot/fanvue.

## Changes
- `src/routes/tokens.ts`: CRUD endpoints for stored credentials with validation
- `src/token-storage.test.ts`: 27 unit tests covering save/load/delete/list/expiry/cache/sanitize behavior

## Test plan
- [ ] All tests pass (634 total, 27 new)
- [ ] Biome clean
- [ ] Merge after PR 16a (#191) is merged