### PR TITLE
fix: add HooksConfigPanel stub to resolve TS2307 blocking CI

### DIFF
--- a/ui/src/components/HooksConfigPanel.tsx
+++ b/ui/src/components/HooksConfigPanel.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+/**
+ * Placeholder — full implementation lands with the hooks UI PR.
+ * AgentView.tsx imports this; stub prevents the TS2307 compile error
+ * that was blocking CI on every PR.
+ */
+interface HooksConfigPanelProps {
+  agentId: string;
+}
+
+export function HooksConfigPanel(_props: HooksConfigPanelProps): null {
+  return null;
+}


### PR DESCRIPTION
## Summary

1-file fix: adds a minimal `HooksConfigPanel` stub that resolves the TS2307 compile error failing Typecheck on every PR.

**Root cause:** `ui/src/views/AgentView.tsx` (merged in PR #179) imports `HooksConfigPanel` but the component file was never merged to main — it exists only in pending FE PRs. This caused `tsc --noEmit` to fail with TS2307 on the Typecheck CI step.

**Fix:** Adds `ui/src/components/HooksConfigPanel.tsx` as a minimal stub (renders null) until the full hooks UI implementation lands.

## Test plan
- [x] `npm run typecheck` (with UI deps) → exit 0, no errors
- [x] `npx biome check .` → exit 0
- [x] Zero fanvue/fanbot refs
