### PR TITLE
fix: resolve Biome lint failures blocking CI on main

### DIFF
--- a/src/token-storage-smoke.test.ts
+++ b/src/token-storage-smoke.test.ts
@@ -10,8 +10,13 @@ vi.mock("./service-mapping.json", () => ({
 vi.mock("./logger", () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
 
 let tmpDir: string;
-beforeEach(() => { tmpDir = mkdtempSync(path.join(os.tmpdir(), "ts-test-")); });
-afterEach(() => { rmSync(tmpDir, { recursive: true, force: true }); vi.resetModules(); });
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), "ts-test-"));
+});
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.resetModules();
+});
 
 describe("token-storage constants", async () => {
   it("ENV_TO_SERVICE and SERVICE_TO_ENV are populated", async () => {

--- a/src/workflow-resource-manager.test.ts
+++ b/src/workflow-resource-manager.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { AgentManager } from "./agents";
 import {
   checkWorkflowAgentLimit,
   computeWorkflowActualCost,
@@ -37,12 +38,12 @@ describe("computeWorkflowActualCost", () => {
       a1: { usage: { estimatedCost: 1.5 }, status: "idle", lastActivity: new Date().toISOString() },
       a2: { usage: { estimatedCost: 0.5 }, status: "idle", lastActivity: new Date().toISOString() },
     });
-    expect(computeWorkflowActualCost(["a1", "a2"], am as any)).toBe(2);
+    expect(computeWorkflowActualCost(["a1", "a2"], am as unknown as AgentManager)).toBe(2);
   });
 
   it("treats missing agents as 0 cost", () => {
     const am = makeAgentManager({});
-    expect(computeWorkflowActualCost(["missing"], am as any)).toBe(0);
+    expect(computeWorkflowActualCost(["missing"], am as unknown as AgentManager)).toBe(0);
   });
 });
 
@@ -52,7 +53,7 @@ describe("enforceWorkflowCostCap", () => {
     const am = makeAgentManager({
       a1: { usage: { estimatedCost: 5 }, status: "idle", lastActivity: new Date().toISOString() },
     });
-    enforceWorkflowCostCap("wf1", ["a1"], 2, am as any, onCap);
+    enforceWorkflowCostCap("wf1", ["a1"], 2, am as unknown as AgentManager, onCap);
     expect(onCap).toHaveBeenCalledWith("wf1", 5, 2 * WORKFLOW_COST_CAP_MULTIPLIER);
   });
 
@@ -61,7 +62,7 @@ describe("enforceWorkflowCostCap", () => {
     const am = makeAgentManager({
       a1: { usage: { estimatedCost: 1 }, status: "idle", lastActivity: new Date().toISOString() },
     });
-    enforceWorkflowCostCap("wf1", ["a1"], 10, am as any, onCap);
+    enforceWorkflowCostCap("wf1", ["a1"], 10, am as unknown as AgentManager, onCap);
     expect(onCap).not.toHaveBeenCalled();
   });
 
@@ -70,7 +71,7 @@ describe("enforceWorkflowCostCap", () => {
     const am = makeAgentManager({
       a1: { usage: { estimatedCost: 999 }, status: "idle", lastActivity: new Date().toISOString() },
     });
-    enforceWorkflowCostCap("wf1", ["a1"], 0, am as any, onCap);
+    enforceWorkflowCostCap("wf1", ["a1"], 0, am as unknown as AgentManager, onCap);
     expect(onCap).not.toHaveBeenCalled();
   });
 });
@@ -78,13 +79,13 @@ describe("enforceWorkflowCostCap", () => {
 describe("detectWorkflowStall", () => {
   it("returns false for empty agent list", () => {
     const am = makeAgentManager({});
-    expect(detectWorkflowStall("wf1", [], am as any, vi.fn())).toBe(false);
+    expect(detectWorkflowStall("wf1", [], am as unknown as AgentManager, vi.fn())).toBe(false);
   });
 
   it("returns false when agent is running", () => {
     const am = makeAgentManager({
       a1: { status: "running", lastActivity: new Date(Date.now() - 99999999).toISOString() },
     });
-    expect(detectWorkflowStall("wf1", ["a1"], am as any, vi.fn())).toBe(false);
+    expect(detectWorkflowStall("wf1", ["a1"], am as unknown as AgentManager, vi.fn())).toBe(false);
   });
 });

--- a/ui/src/components/ToolTimeline.tsx
+++ b/ui/src/components/ToolTimeline.tsx
@@ -81,7 +81,6 @@ export function ToolTimeline({ agentId }: ToolTimelineProps) {
           {!error && reversed.length > 0 && (
             <div className="space-y-0.5 max-h-48 overflow-y-auto">
               {reversed.map((entry, i) => (
-                // biome-ignore lint/suspicious/noArrayIndexKey: stable index for timeline rows
                 <ToolTimelineRow key={`${entry.timestamp}-${i}`} entry={entry} />
               ))}
             </div>


### PR DESCRIPTION
## Summary
- Replace \`as any\` with \`as unknown as AgentManager\` in \`src/workflow-resource-manager.test.ts\` — fixes 7x \`lint/suspicious/noExplicitAny\` errors
- Expand single-line arrow callbacks in \`src/token-storage-smoke.test.ts\` — fixes Biome formatter error (the only hard \`EXIT: 1\` cause)
- Remove unused \`biome-ignore\` suppression comment in \`ui/src/components/ToolTimeline.tsx\` — fixes \`suppressions/unused\` warning

## Test plan
- [x] \`npx biome check .\` exits 0 (208 files checked, no errors)
- [x] \`workflow-resource-manager.test.ts\` — 9 tests pass
- [x] \`token-storage-smoke.test.ts\` — 1 test passes