### PR TITLE
feat(agents): extract EventPipeline + consume in agents.ts (Phase E PR26)

### DIFF
--- a/src/agent-pipeline-types.test.ts
+++ b/src/agent-pipeline-types.test.ts
@@ -1,0 +1,11 @@
+/// <reference types="vitest/globals" />
+// Smoke: AgentProcess.softStallNotified optional field added in Phase E PR26.
+describe("AgentProcess softStallNotified field", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+  const proc = { softStallNotified: undefined } as any;
+  it("defaults to undefined", () => expect(proc.softStallNotified).toBeUndefined());
+  it("accepts boolean", () => {
+    proc.softStallNotified = true;
+    expect(proc.softStallNotified).toBe(true);
+  });
+});

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,19 +1,9 @@
 import { execFile, execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { createReadStream } from "node:fs";
-import { appendFile, readdir, readFile, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
+import { readdir, rm, unlink } from "node:fs/promises";
 import path from "node:path";
-import readline from "node:readline";
 import { promisify } from "node:util";
-import {
-  AGENT_DEDUP_WINDOW_MS,
-  EVENT_FILE_TRUNCATE_THRESHOLD,
-  EVENT_RING_BUFFER_SIZE,
-  MAX_PERSISTED_EVENTS,
-  PAUSED_TTL_MS,
-  PROMPT_NAME_MAX_INPUT,
-  PROMPT_NAME_MAX_SLUG,
-} from "./config";
+import { AGENT_DEDUP_WINDOW_MS, PAUSED_TTL_MS, PROMPT_NAME_MAX_INPUT, PROMPT_NAME_MAX_SLUG } from "./config";
 import type { CostTracker } from "./cost-tracker";
 import {
   AgentNotFoundError,
@@ -22,12 +12,12 @@ import {
   ResourceLimitError,
   ValidationError,
 } from "./errors";
+import { EventPipeline } from "./event-pipeline";
 import { ALLOWED_MODELS, MAX_AGENT_DEPTH, MAX_AGENTS, MAX_CHILDREN_PER_AGENT, SESSION_TTL_MS } from "./guardrails";
 import { logger } from "./logger";
 import { DEFAULT_MODEL } from "./models";
 import { EVENTS_DIR, loadAllAgentStates, removeAgentState, saveAgentState, writeTombstone } from "./persistence";
 import { getRepoCredentialsForAgents, writeGitCredentialsFile } from "./repo-credentials";
-import { sanitizeEvent } from "./sanitize";
 import { StateNotifier } from "./state-notifier";
 import { cleanupAgentClaudeData, debouncedSyncToGCS } from "./storage";
 import type {
@@ -41,7 +31,7 @@ import type {
   StreamEvent,
 } from "./types";
 import { errorMessage } from "./types";
-import { estimateCost, UsageTracker } from "./usage-tracker";
+import { UsageTracker } from "./usage-tracker";
 import { WorkspaceManager } from "./workspace-manager";
 import { cleanupWorktreesForWorkspace } from "./worktrees";
 
@@ -284,6 +274,7 @@ export class AgentManager {
   /** Optional persistent cost tracker (SQLite-backed). */
   private costTracker: CostTracker | null = null;
   private usageTracker: UsageTracker;
+  private pipeline: EventPipeline;
   /** Workspace management (directories, symlinks, tokens, env). */
   private workspace = new WorkspaceManager();
 
@@ -291,6 +282,9 @@ export class AgentManager {
     this.costTracker = opts?.costTracker ?? null;
     this.usageTracker = new UsageTracker(this.agents, this.costTracker);
     this.notifier = new StateNotifier(this.agents);
+    this.pipeline = new EventPipeline(this.agents, this.usageTracker, this.writeQueues, (id, agent, immediate) =>
+      this.notifier.scheduleAgentUpdated(id, agent, immediate),
+    );
     this.workspace.setAgentListProvider(this);
     // Cleanup idle agents every 60s
     this.cleanupInterval = setInterval(() => this.cleanupExpired(), 60_000);
@@ -1327,229 +1321,24 @@ export class AgentManager {
    *  notifications are coalesced into 16 ms batches to reduce I/O calls and
    *  SSE write pressure. */
   private handleEvent(id: string, event: StreamEvent): void {
-    const agentProc = this.agents.get(id);
-    if (!agentProc) return;
-
-    if (event.type === "system" && event.subtype === "init" && event.session_id) {
-      agentProc.agent.claudeSessionId = event.session_id as string;
-      saveAgentState(agentProc.agent);
-    }
-
-    // Parse token usage from assistant events emitted by claude CLI stream-json.
-    // The CLI emits multiple "assistant" events per API message (one per content block),
-    // each carrying the same usage snapshot. We deduplicate by message ID so each
-    // API call's tokens are counted exactly once.
-    if (event.type === "assistant") {
-      // Fix H1: Reset stallCount when real output arrives from a stalled agent
-      if (agentProc.agent.status === "stalled" && (event.subtype === "text" || event.subtype === "tool_use")) {
-        agentProc.stallCount = 0;
-        agentProc.agent.status = "running";
-        saveAgentState(agentProc.agent);
-      }
-
-      const msg = event.message as Record<string, unknown> | undefined;
-      const msgId = msg?.id as string | undefined;
-      const usage = msg?.usage as
-        | {
-            input_tokens?: number;
-            output_tokens?: number;
-            cache_creation_input_tokens?: number;
-            cache_read_input_tokens?: number;
-          }
-        | undefined;
-
-      if (msgId && usage && !agentProc.seenMessageIds.has(msgId)) {
-        agentProc.seenMessageIds.add(msgId);
-
-        // Cap seenMessageIds to prevent unbounded growth (Performance H2)
-        if (agentProc.seenMessageIds.size > 1000) {
-          const arr = Array.from(agentProc.seenMessageIds);
-          agentProc.seenMessageIds = new Set(arr.slice(-500));
-        }
-
-        const tokensIn =
-          (usage.input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0);
-        const tokensOut = usage.output_tokens ?? 0;
-        const cost = estimateCost(agentProc.agent.model, usage);
-
-        if (tokensIn > 0 || tokensOut > 0) {
-          const prev = agentProc.agent.usage ?? { tokensIn: 0, tokensOut: 0, estimatedCost: 0, totalTokensSpent: 0 };
-          agentProc.agent.usage = {
-            tokensIn: prev.tokensIn + tokensIn,
-            tokensOut: prev.tokensOut + tokensOut,
-            estimatedCost: prev.estimatedCost + cost,
-            totalTokensSpent: (prev.totalTokensSpent ?? 0) + tokensIn + tokensOut,
-            totalTokensIn: (prev.totalTokensIn ?? prev.tokensIn) + tokensIn,
-            totalTokensOut: (prev.totalTokensOut ?? prev.tokensOut) + tokensOut,
-          };
-          saveAgentState(agentProc.agent);
-          this.upsertCostTracker(agentProc);
-        }
-      }
-    }
-
-    // Handle result events for token-delta updates
-    if (event.type === "result") {
-      const usage = event.usage as { input_tokens?: number; output_tokens?: number } | undefined;
-      const totalCost = typeof event.total_cost_usd === "number" ? event.total_cost_usd : 0;
-      const tokensIn = usage?.input_tokens ?? 0;
-      const tokensOut = usage?.output_tokens ?? 0;
-      if (tokensIn > 0 || tokensOut > 0 || totalCost > 0) {
-        const prev = agentProc.agent.usage ?? { tokensIn: 0, tokensOut: 0, estimatedCost: 0, totalTokensSpent: 0 };
-        // Compute delta for totalTokensSpent: result events report cumulative input tokens
-        // (full context window), so only count the incremental difference to avoid double-counting.
-        const inputDelta = tokensIn > prev.tokensIn ? tokensIn - prev.tokensIn : 0;
-        agentProc.agent.usage = {
-          // tokensIn is NOT accumulated: each result event's input_tokens already contains
-          // the full conversation context, so summing across turns massively overcounts.
-          // Instead we store the latest value, which reflects current context window usage.
-          tokensIn: tokensIn > 0 ? tokensIn : prev.tokensIn,
-          tokensOut: prev.tokensOut + tokensOut,
-          estimatedCost: prev.estimatedCost + totalCost,
-          totalTokensSpent: (prev.totalTokensSpent ?? 0) + inputDelta + tokensOut,
-          totalTokensIn: (prev.totalTokensIn ?? prev.tokensIn) + inputDelta,
-          totalTokensOut: (prev.totalTokensOut ?? prev.tokensOut) + tokensOut,
-        };
-        saveAgentState(agentProc.agent);
-        this.upsertCostTracker(agentProc);
-      }
-    }
-
-    agentProc.agent.lastActivity = nowISO();
-
-    // Batch persist: accumulate sanitized JSONL lines and flush with 16ms timer.
-    // This turns N appendFile calls into 1, reducing I/O syscalls dramatically.
-    const sanitized = sanitizeEvent(event);
-    agentProc.persistBatch += `${JSON.stringify(sanitized)}\n`;
-
-    // Append to in-memory ring buffer for fast reconnect replay.
-    // Uses modular overwrite once the buffer reaches EVENT_RING_BUFFER_SIZE.
-    if (agentProc.eventBuffer.length < EVENT_RING_BUFFER_SIZE) {
-      agentProc.eventBuffer.push(sanitized);
-    } else {
-      agentProc.eventBuffer[agentProc.eventBufferTotal % EVENT_RING_BUFFER_SIZE] = sanitized;
-    }
-    agentProc.eventBufferTotal++;
-
-    // Batch listener notification: buffer events for 16ms (one frame) before
-    // notifying SSE listeners, reducing the number of res.write() calls.
-    agentProc.listenerBatch.push(event);
-
-    if (!agentProc.persistTimer) {
-      agentProc.persistTimer = setTimeout(() => this.flushEventBatch(id, agentProc), 16);
-    }
+    this.pipeline.handleEvent(id, event);
   }
 
   private upsertCostTracker(agentProc: AgentProcess): void {
     this.usageTracker.upsertCostTracker(agentProc);
   }
 
-  /** Flush batched event persistence and listener notifications for an agent.
-   *  Called by the 16ms coalesce timer or synchronously on process close. */
   private flushEventBatch(id: string, agentProc: AgentProcess): void {
-    // Clear timer
-    if (agentProc.persistTimer) {
-      clearTimeout(agentProc.persistTimer);
-      agentProc.persistTimer = null;
-    }
-
-    // Flush persistence batch - single appendFile for all accumulated events
-    const batch = agentProc.persistBatch;
-    agentProc.persistBatch = "";
-    if (batch) {
-      const filePath = path.join(EVENTS_DIR, `${id}.jsonl`);
-      const prev = this.writeQueues.get(id) ?? Promise.resolve();
-      const next = prev
-        .then(() =>
-          appendFile(filePath, batch).catch((err: unknown) => {
-            logger.warn("[agents] Failed to persist events", { agentId: id, error: errorMessage(err) });
-          }),
-        )
-        .then(() => {
-          if (this.writeQueues.get(id) === next) {
-            this.writeQueues.set(id, Promise.resolve());
-          }
-        });
-      this.writeQueues.set(id, next);
-    }
-
-    // Flush listener batch - notify all listeners with buffered events
-    const events = agentProc.listenerBatch;
-    agentProc.listenerBatch = [];
-    if (events.length > 0) {
-      for (const event of events) {
-        for (const listener of agentProc.listeners) {
-          try {
-            listener(event);
-          } catch (err: unknown) {
-            logger.warn("[agents] Listener error", { error: errorMessage(err) });
-          }
-        }
-      }
-    }
+    this.pipeline.flushEventBatch(id, agentProc);
   }
 
-  /** Read the in-memory ring buffer in insertion order. */
   private readEventBuffer(agentProc: AgentProcess): StreamEvent[] {
-    const { eventBuffer, eventBufferTotal } = agentProc;
-    const len = eventBuffer.length;
-    if (len === 0) return [];
-    // Buffer hasn't wrapped yet - return as-is
-    if (eventBufferTotal <= EVENT_RING_BUFFER_SIZE) return eventBuffer.slice();
-    // Buffer has wrapped - oldest entry is at (eventBufferTotal % len), read in order
-    const start = eventBufferTotal % len;
-    return [...eventBuffer.slice(start), ...eventBuffer.slice(0, start)];
+    return this.pipeline.readEventBuffer(agentProc);
   }
 
-  /** Hybrid event reader: serves from in-memory ring buffer for hot reconnects,
-   *  falls back to streaming readline from disk for cold-start (restored) agents. */
   private async readPersistedEvents(id: string): Promise<StreamEvent[]> {
-    // Hot path: if the agent has events in its ring buffer, serve from memory
-    const agentProc = this.agents.get(id);
-    if (agentProc && agentProc.eventBufferTotal > 0) {
-      return this.readEventBuffer(agentProc);
-    }
-
-    // Cold path: stream from disk using readline (bounded memory)
-    const filePath = path.join(EVENTS_DIR, `${id}.jsonl`);
-    try {
-      await stat(filePath);
-    } catch {
-      return [];
-    }
-
-    try {
-      const events: StreamEvent[] = [];
-      const rl = readline.createInterface({
-        input: createReadStream(filePath, { encoding: "utf-8" }),
-        crlfDelay: Number.POSITIVE_INFINITY,
-      });
-      for await (const line of rl) {
-        if (!line.trim()) continue;
-        try {
-          events.push(JSON.parse(line) as StreamEvent);
-        } catch {
-          // Skip malformed lines
-        }
-      }
-
-      // Trim to last MAX_PERSISTED_EVENTS in one pass (avoids O(n*k) per-line splice)
-      if (events.length > MAX_PERSISTED_EVENTS) {
-        events.splice(0, events.length - MAX_PERSISTED_EVENTS);
-      }
-
-      // Populate the ring buffer so subsequent reconnects are served from memory
-      if (agentProc) {
-        const bufferEvents = events.slice(-EVENT_RING_BUFFER_SIZE);
-        agentProc.eventBuffer = bufferEvents;
-        agentProc.eventBufferTotal = bufferEvents.length;
-      }
-
-      return events;
-    } catch (err: unknown) {
-      logger.warn("[agents] Failed to read persisted events", { agentId: id, error: errorMessage(err) });
-      return [];
-    }
+    const { events } = await this.pipeline.readPersistedEvents(id);
+    return events;
   }
 
   private cleanupExpired(): void {
@@ -1683,33 +1472,7 @@ export class AgentManager {
     for (const agentProc of this.agents.values()) {
       saveAgentState(agentProc.agent);
     }
-    this.truncateEventFiles();
-  }
-
-  /** Truncate oversized event files to prevent unbounded growth on GCS FUSE. */
-  private truncateEventFiles(): void {
-    for (const id of this.agents.keys()) {
-      const filePath = path.join(EVENTS_DIR, `${id}.jsonl`);
-      const prev = this.writeQueues.get(id) ?? Promise.resolve();
-      const next = prev.then(async () => {
-        try {
-          const fileStat = await stat(filePath).catch(() => null);
-          if (!fileStat) return;
-          if (fileStat.size < EVENT_FILE_TRUNCATE_THRESHOLD * 200) return;
-          const data = await readFile(filePath, "utf-8");
-          const lines = data.split("\n").filter((l) => l.trim());
-          if (lines.length <= EVENT_FILE_TRUNCATE_THRESHOLD) return;
-          const trimmed = lines.slice(-MAX_PERSISTED_EVENTS);
-          const tmpPath = `${filePath}.tmp.${Date.now()}`;
-          await writeFile(tmpPath, `${trimmed.join("\n")}\n`);
-          await rename(tmpPath, filePath);
-          logger.info("[agents] Truncated event file", { agentId: id, before: lines.length, after: trimmed.length });
-        } catch (err: unknown) {
-          logger.warn("[agents] Failed to truncate events", { agentId: id, error: errorMessage(err) });
-        }
-      });
-      this.writeQueues.set(id, next);
-    }
+    this.pipeline.truncateEventFiles(this.agents.keys());
   }
 
   private buildClaudeArgs(opts: CreateAgentRequest, model: string, resumeSessionId?: string): string[] {

--- a/src/event-pipeline-wiring.test.ts
+++ b/src/event-pipeline-wiring.test.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest/globals" />
+import { EventPipeline } from "./event-pipeline";
+// Smoke: EventPipeline is constructible and exposes required public methods.
+describe("EventPipeline smoke", () => {
+  // biome-ignore lint/suspicious/noExplicitAny: test stub
+  const ep = new EventPipeline(
+    { get: () => undefined } as any,
+    { upsertCostTracker: () => {} } as any,
+    new Map(),
+    () => {},
+  );
+  it("is an EventPipeline", () => expect(ep).toBeInstanceOf(EventPipeline));
+  it("has handleEvent", () => expect(typeof ep.handleEvent).toBe("function"));
+  it("has readPersistedEvents", () => expect(typeof ep.readPersistedEvents).toBe("function"));
+});

--- a/src/event-pipeline.test.ts
+++ b/src/event-pipeline.test.ts
@@ -23,7 +23,7 @@ function makeAgentProc(id = "agent-1"): AgentProcess {
         lastTurnTokensIn: 0,
       },
     },
-    listeners: [],
+    listeners: new Set(),
     eventBuffer: [],
     eventBufferTotal: 0,
     persistBatch: "",
@@ -83,7 +83,7 @@ describe("EventPipeline", () => {
     writeQueues = new Map();
     onAgentUpdated = vi.fn();
     // biome-ignore lint/suspicious/noExplicitAny: test stub
-    pipeline = new EventPipeline(registry as any, usageTracker as any, writeQueues, onAgentUpdated);
+    pipeline = new EventPipeline(registry as any, usageTracker as any, writeQueues, onAgentUpdated as any);
   });
 
   afterEach(() => {
@@ -233,7 +233,7 @@ describe("EventPipeline", () => {
 
     it("notifies listeners with buffered events", () => {
       const listener = vi.fn();
-      agentProc.listeners.push(listener);
+      agentProc.listeners.add(listener);
       const event = { type: "result" } as StreamEvent;
       agentProc.listenerBatch = [event];
       pipeline.flushEventBatch("agent-1", agentProc);

--- a/src/event-pipeline.test.ts
+++ b/src/event-pipeline.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
+import { EventPipeline } from "./event-pipeline";
+import type { AgentProcess, StreamEvent } from "./types";
+
+// ─── Minimal stubs ────────────────────────────────────────────────────────────
+
+function makeAgentProc(id = "agent-1"): AgentProcess {
+  return {
+    agent: {
+      id,
+      name: "test-agent",
+      model: "claude-sonnet-4-6",
+      status: "running",
+      createdAt: new Date().toISOString(),
+      usage: {
+        tokensIn: 0,
+        tokensOut: 0,
+        estimatedCost: 0,
+        totalTokensSpent: 0,
+        totalTokensIn: 0,
+        totalTokensOut: 0,
+        apiTurns: 0,
+        lastTurnTokensIn: 0,
+      },
+    },
+    listeners: [],
+    eventBuffer: [],
+    eventBufferTotal: 0,
+    persistBatch: "",
+    persistTimer: null,
+    listenerBatch: [],
+    seenMessageIds: new Set(),
+    sessionEstimatedCost: 0,
+    sessionTokensIn: 0,
+    sessionTokensOut: 0,
+    softStallNotified: false,
+    // biome-ignore lint/suspicious/noExplicitAny: test stub
+  } as any;
+}
+
+function makeRegistry(proc: AgentProcess) {
+  return { get: (id: string) => (id === proc.agent.id ? proc : undefined) };
+}
+
+function makeUsageTracker() {
+  return { upsertCostTracker: vi.fn() };
+}
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("./persistence", () => ({
+  EVENTS_DIR: "/tmp/__ep_test_events",
+  saveAgentState: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  appendFile: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockResolvedValue(""),
+  rename: vi.fn().mockResolvedValue(undefined),
+  stat: vi.fn().mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" })),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("node:fs", () => ({
+  createReadStream: vi.fn().mockReturnValue({ pipe: vi.fn() }),
+}));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("EventPipeline", () => {
+  let agentProc: AgentProcess;
+  let registry: ReturnType<typeof makeRegistry>;
+  let usageTracker: ReturnType<typeof makeUsageTracker>;
+  let writeQueues: Map<string, Promise<void>>;
+  let onAgentUpdated: MockInstance;
+  let pipeline: EventPipeline;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    agentProc = makeAgentProc();
+    registry = makeRegistry(agentProc);
+    usageTracker = makeUsageTracker();
+    writeQueues = new Map();
+    onAgentUpdated = vi.fn();
+    // biome-ignore lint/suspicious/noExplicitAny: test stub
+    pipeline = new EventPipeline(registry as any, usageTracker as any, writeQueues, onAgentUpdated);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("handleEvent — unknown agent", () => {
+    it("is a no-op for unknown agent id", () => {
+      const event: StreamEvent = { type: "assistant", subtype: "text" } as StreamEvent;
+      expect(() => pipeline.handleEvent("no-such-id", event)).not.toThrow();
+    });
+  });
+
+  describe("handleEvent — init system event", () => {
+    it("updates claudeSessionId and actualModel from init event", async () => {
+      const { saveAgentState } = await import("./persistence");
+      const event = {
+        type: "system",
+        subtype: "init",
+        session_id: "sess-123",
+        model: "claude-sonnet-4-6",
+        tools: ["Bash"],
+      } as StreamEvent;
+      pipeline.handleEvent("agent-1", event);
+      expect(agentProc.agent.claudeSessionId).toBe("sess-123");
+      expect(agentProc.agent.actualModel).toBe("claude-sonnet-4-6");
+      expect(agentProc.agent.activeTools).toEqual(["Bash"]);
+      expect(saveAgentState).toHaveBeenCalledWith(agentProc.agent);
+      expect(onAgentUpdated).toHaveBeenCalledWith("agent-1", agentProc.agent, true);
+    });
+  });
+
+  describe("handleEvent — stream_event (transient)", () => {
+    it("does not add stream_event to persistBatch", () => {
+      const event: StreamEvent = { type: "stream_event", subtype: "text" } as StreamEvent;
+      pipeline.handleEvent("agent-1", event);
+      expect(agentProc.persistBatch).toBe("");
+    });
+
+    it("adds stream_event to listenerBatch", () => {
+      const event: StreamEvent = { type: "stream_event", subtype: "text" } as StreamEvent;
+      pipeline.handleEvent("agent-1", event);
+      expect(agentProc.listenerBatch).toContain(event);
+    });
+
+    it("schedules flush timer for stream_event", () => {
+      const event: StreamEvent = { type: "stream_event", subtype: "text" } as StreamEvent;
+      pipeline.handleEvent("agent-1", event);
+      expect(agentProc.persistTimer).not.toBeNull();
+    });
+  });
+
+  describe("handleEvent — assistant event with usage", () => {
+    it("accumulates token counts for new message IDs", () => {
+      const event = {
+        type: "assistant",
+        subtype: "text",
+        message: {
+          id: "msg-001",
+          usage: { input_tokens: 100, output_tokens: 50, cache_creation_input_tokens: 0, cache_read_input_tokens: 0 },
+        },
+      } as StreamEvent;
+      pipeline.handleEvent("agent-1", event);
+      expect(agentProc.agent.usage?.tokensIn).toBe(100);
+      expect(agentProc.agent.usage?.tokensOut).toBe(50);
+      expect(agentProc.agent.usage?.apiTurns).toBe(1);
+      expect(usageTracker.upsertCostTracker).toHaveBeenCalledWith(agentProc);
+    });
+
+    it("deduplicates by message ID — second call with same ID is ignored", () => {
+      const event = {
+        type: "assistant",
+        subtype: "text",
+        message: {
+          id: "msg-002",
+          usage: { input_tokens: 100, output_tokens: 50 },
+        },
+      } as StreamEvent;
+      pipeline.handleEvent("agent-1", event);
+      pipeline.handleEvent("agent-1", event); // duplicate
+      expect(agentProc.agent.usage?.apiTurns).toBe(1); // counted once
+    });
+
+    it("resets stall status on assistant output", async () => {
+      const { saveAgentState } = await import("./persistence");
+      agentProc.agent.status = "stalled";
+      agentProc.stallCount = 5;
+      const event = {
+        type: "assistant",
+        subtype: "text",
+        message: { id: "msg-003", usage: { input_tokens: 1, output_tokens: 1 } },
+      } as StreamEvent;
+      pipeline.handleEvent("agent-1", event);
+      expect(agentProc.agent.status).toBe("running");
+      expect(agentProc.stallCount).toBe(0);
+      expect(saveAgentState).toHaveBeenCalled();
+    });
+  });
+
+  describe("readEventBuffer", () => {
+    it("returns empty array when no events", () => {
+      expect(pipeline.readEventBuffer(agentProc)).toEqual([]);
+    });
+
+    it("returns events in insertion order before wrap", () => {
+      const e1 = { type: "assistant", _idx: 0 } as StreamEvent;
+      const e2 = { type: "result", _idx: 1 } as StreamEvent;
+      agentProc.eventBuffer = [e1, e2];
+      agentProc.eventBufferTotal = 2;
+      expect(pipeline.readEventBuffer(agentProc)).toEqual([e1, e2]);
+    });
+  });
+
+  describe("readPersistedEvents", () => {
+    it("returns empty when no file exists and no in-memory buffer", async () => {
+      const result = await pipeline.readPersistedEvents("agent-1");
+      expect(result.events).toEqual([]);
+      expect(result.baseIndex).toBe(0);
+    });
+
+    it("returns in-memory buffer when events exist", async () => {
+      const e = { type: "assistant", _idx: 0 } as StreamEvent;
+      agentProc.eventBuffer = [e];
+      agentProc.eventBufferTotal = 1;
+      const result = await pipeline.readPersistedEvents("agent-1");
+      expect(result.events).toContain(e);
+      expect(result.baseIndex).toBe(0);
+    });
+  });
+
+  describe("flushEventBatch", () => {
+    it("clears persistTimer and persistBatch and enqueues an appendFile write", async () => {
+      agentProc.persistBatch = '{"type":"result"}\n';
+      agentProc.persistTimer = setTimeout(() => {}, 1000);
+      pipeline.flushEventBatch("agent-1", agentProc);
+      // Synchronous effects happen immediately
+      expect(agentProc.persistBatch).toBe("");
+      expect(agentProc.persistTimer).toBeNull();
+      // A write was queued into the writeQueues map
+      const pendingWrite = writeQueues.get("agent-1");
+      expect(pendingWrite).toBeDefined();
+      // Resolve it and verify appendFile was called
+      const { appendFile } = await import("node:fs/promises");
+      await pendingWrite;
+      expect(appendFile).toHaveBeenCalled();
+    });
+
+    it("notifies listeners with buffered events", () => {
+      const listener = vi.fn();
+      agentProc.listeners.push(listener);
+      const event = { type: "result" } as StreamEvent;
+      agentProc.listenerBatch = [event];
+      pipeline.flushEventBatch("agent-1", agentProc);
+      expect(listener).toHaveBeenCalledWith(event);
+      expect(agentProc.listenerBatch).toEqual([]);
+    });
+  });
+
+  describe("batchEvent via handleEvent", () => {
+    it("adds non-stream events to persistBatch and eventBuffer", () => {
+      const event = { type: "result", subtype: "success", total_cost_usd: 0.001 } as StreamEvent;
+      pipeline.handleEvent("agent-1", event);
+      expect(agentProc.persistBatch).toContain('"type":"result"');
+      expect(agentProc.eventBuffer.length).toBe(1);
+      expect(agentProc.eventBufferTotal).toBe(1);
+    });
+
+    it("sets persistTimer when batching", () => {
+      const event = { type: "result" } as StreamEvent;
+      pipeline.handleEvent("agent-1", event);
+      expect(agentProc.persistTimer).not.toBeNull();
+    });
+  });
+});

--- a/src/event-pipeline.ts
+++ b/src/event-pipeline.ts
@@ -1,0 +1,438 @@
+import { createReadStream } from "node:fs";
+import { appendFile, readFile, rename, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import readline from "node:readline";
+import { EVENT_FILE_TRUNCATE_THRESHOLD, EVENT_RING_BUFFER_SIZE, MAX_PERSISTED_EVENTS } from "./config";
+import { logger } from "./logger";
+import { EVENTS_DIR, saveAgentState } from "./persistence";
+import { sanitizeEvent } from "./sanitize";
+import type { Agent, AgentProcess, StreamEvent } from "./types";
+import { errorMessage } from "./types";
+import type { AgentRegistry, UsageTracker } from "./usage-tracker";
+import { estimateCost } from "./usage-tracker";
+
+export class EventPipeline {
+  constructor(
+    private registry: AgentRegistry,
+    private usageTracker: UsageTracker,
+    /** Shared write-queue map owned by AgentManager; EventPipeline appends to it. */
+    private writeQueues: Map<string, Promise<void>>,
+    /** Callback to notify SSE listeners of agent metadata changes. */
+    private onAgentUpdated: (id: string, agent: Agent, immediate: boolean) => void,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Public entry point
+  // ---------------------------------------------------------------------------
+
+  /** Route an incoming StreamEvent: update metadata synchronously, then batch
+   *  for disk persistence and listener notification. */
+  handleEvent(id: string, event: StreamEvent): void {
+    const agentProc = this.registry.get(id);
+    if (!agentProc) return;
+
+    this.updateSessionId(event, agentProc);
+    this.updateTokenUsage(event, agentProc);
+
+    if (event.type === "system" && event.subtype === "api_retry") {
+      logger.warn("[agents] API rate limit retry", {
+        agentId: id,
+        attempt: event.attempt,
+        maxRetries: event.max_retries,
+        retryDelayMs: event.retry_delay_ms,
+        errorStatus: event.error_status,
+        error: event.error,
+      });
+    }
+
+    if (event.type === "system" && event.subtype === "compact_boundary") {
+      logger.info("[agents] Context compact boundary", { agentId: id });
+    }
+
+    if (event.type === "system" && event.subtype === "task_started") {
+      logger.info("[agents] Sub-task started", { agentId: id, content: event.content });
+    }
+
+    if (event.type === "system" && event.subtype === "task_notification") {
+      logger.info("[agents] Sub-task notification", { agentId: id, content: event.content });
+    }
+
+    if (event.type === "stream_event") {
+      this.emitTransientEvent(event, agentProc);
+      return;
+    }
+
+    this.batchEvent(event, agentProc);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Ring buffer read helpers
+  // ---------------------------------------------------------------------------
+
+  /** Read the in-memory ring buffer in insertion order. */
+  readEventBuffer(agentProc: AgentProcess): StreamEvent[] {
+    const { eventBuffer, eventBufferTotal } = agentProc;
+    const len = eventBuffer.length;
+    if (len === 0) return [];
+    if (eventBufferTotal <= EVENT_RING_BUFFER_SIZE) return eventBuffer.slice();
+    const start = eventBufferTotal % len;
+    return [...eventBuffer.slice(start), ...eventBuffer.slice(0, start)];
+  }
+
+  /** Hybrid event reader: ring buffer hot path, disk cold path. */
+  async readPersistedEvents(id: string): Promise<{ events: StreamEvent[]; baseIndex: number }> {
+    const agentProc = this.registry.get(id);
+    if (agentProc && agentProc.eventBufferTotal > 0) {
+      const events = this.readEventBuffer(agentProc);
+      const baseIndex = Math.max(0, agentProc.eventBufferTotal - events.length);
+      return { events, baseIndex };
+    }
+
+    const filePath = path.join(EVENTS_DIR, `${id}.jsonl`);
+    try {
+      await stat(filePath);
+    } catch {
+      return { events: [], baseIndex: 0 };
+    }
+
+    try {
+      const events: StreamEvent[] = [];
+      const rl = readline.createInterface({
+        input: createReadStream(filePath, { encoding: "utf-8" }),
+        crlfDelay: Number.POSITIVE_INFINITY,
+      });
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+        try {
+          events.push(JSON.parse(line) as StreamEvent);
+        } catch {
+          // Skip malformed lines
+        }
+      }
+
+      const diskCount = events.length;
+
+      if (events.length > MAX_PERSISTED_EVENTS) {
+        events.splice(0, events.length - MAX_PERSISTED_EVENTS);
+      }
+
+      if (agentProc) {
+        const L = Math.min(diskCount, EVENT_RING_BUFFER_SIZE);
+        const bufferEvents = events.slice(-L);
+        const buf = new Array<StreamEvent>(L);
+        for (let i = 0; i < L; i++) {
+          buf[(diskCount - L + i) % L] = bufferEvents[i];
+        }
+        agentProc.eventBuffer = buf;
+        agentProc.eventBufferTotal = diskCount;
+      }
+
+      const baseIndex = Math.max(0, diskCount - events.length);
+      return { events, baseIndex };
+    } catch (err: unknown) {
+      logger.warn("[agents] Failed to read persisted events", { agentId: id, error: errorMessage(err) });
+      return { events: [], baseIndex: 0 };
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Flush / persistence
+  // ---------------------------------------------------------------------------
+
+  /** Flush batched event persistence and listener notifications for an agent. */
+  flushEventBatch(id: string, agentProc: AgentProcess): void {
+    if (agentProc.persistTimer) {
+      clearTimeout(agentProc.persistTimer);
+      agentProc.persistTimer = null;
+    }
+
+    const batch = agentProc.persistBatch;
+    agentProc.persistBatch = "";
+    if (batch) {
+      const filePath = path.join(EVENTS_DIR, `${id}.jsonl`);
+      const prev = this.writeQueues.get(id) ?? Promise.resolve();
+      const next = prev
+        .then(() =>
+          appendFile(filePath, batch).catch((err: unknown) => {
+            logger.warn("[agents] Failed to persist events", { agentId: id, error: errorMessage(err) });
+          }),
+        )
+        .then(() => {
+          if (this.writeQueues.get(id) === next) {
+            this.writeQueues.set(id, Promise.resolve());
+          }
+        });
+      this.writeQueues.set(id, next);
+    }
+
+    const events = agentProc.listenerBatch;
+    agentProc.listenerBatch = [];
+    if (events.length > 0) {
+      for (const event of events) {
+        for (const listener of agentProc.listeners) {
+          try {
+            listener(event);
+          } catch (err: unknown) {
+            logger.warn("[agents] Listener error", { error: errorMessage(err) });
+          }
+        }
+      }
+    }
+  }
+
+  /** Truncate oversized event files to prevent unbounded growth on GCS FUSE. */
+  truncateEventFiles(agentIds: Iterable<string>): void {
+    for (const id of agentIds) {
+      const filePath = path.join(EVENTS_DIR, `${id}.jsonl`);
+      const prev = this.writeQueues.get(id) ?? Promise.resolve();
+      const next = prev.then(async () => {
+        try {
+          const fileStat = await stat(filePath).catch(() => null);
+          if (!fileStat) return;
+          if (fileStat.size < EVENT_FILE_TRUNCATE_THRESHOLD * 200) return;
+          const data = await readFile(filePath, "utf-8");
+          const lines = data.split("\n").filter((l) => l.trim());
+          if (lines.length <= EVENT_FILE_TRUNCATE_THRESHOLD) return;
+          const trimmed = lines.slice(-MAX_PERSISTED_EVENTS);
+          const tmpPath = `${filePath}.tmp.${Date.now()}`;
+          await writeFile(tmpPath, `${trimmed.join("\n")}\n`);
+          await rename(tmpPath, filePath);
+          logger.info("[agents] Truncated event file", { agentId: id, before: lines.length, after: trimmed.length });
+        } catch (err: unknown) {
+          logger.warn("[agents] Failed to truncate events", { agentId: id, error: errorMessage(err) });
+        }
+      });
+      this.writeQueues.set(id, next);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private emitTransientEvent(event: StreamEvent, agentProc: AgentProcess): void {
+    const now = new Date().toISOString();
+    agentProc.agent.lastActivity = now;
+    if (!event._ts) event._ts = now;
+    agentProc.listenerBatch.push(event);
+    const id = agentProc.agent.id;
+    if (!agentProc.persistTimer) {
+      agentProc.persistTimer = setTimeout(() => this.flushEventBatch(id, agentProc), 16);
+    }
+  }
+
+  private updateSessionId(event: StreamEvent, agentProc: AgentProcess): void {
+    if (event.type === "system" && event.subtype === "init") {
+      if (event.session_id) agentProc.agent.claudeSessionId = event.session_id as string;
+      if (event.model) agentProc.agent.actualModel = event.model as string;
+      if (Array.isArray(event.tools)) agentProc.agent.activeTools = event.tools as string[];
+      saveAgentState(agentProc.agent);
+      this.onAgentUpdated(agentProc.agent.id, agentProc.agent, true);
+    }
+  }
+
+  private updateTokenUsage(event: StreamEvent, agentProc: AgentProcess): void {
+    if (event.type === "result") {
+      this.reconcileResultEvent(event, agentProc);
+      return;
+    }
+
+    if (event.type !== "assistant") return;
+
+    if (event.subtype === "text" || event.subtype === "tool_use") {
+      agentProc.softStallNotified = false;
+      if (agentProc.agent.status === "stalled") {
+        agentProc.stallCount = 0;
+        agentProc.agent.status = "running";
+        saveAgentState(agentProc.agent);
+        this.onAgentUpdated(agentProc.agent.id, agentProc.agent, true);
+      }
+    }
+
+    const msg =
+      typeof event.message === "object" && event.message !== null
+        ? (event.message as Record<string, unknown>)
+        : undefined;
+    const msgId = msg?.id as string | undefined;
+    const usage = msg?.usage as
+      | {
+          input_tokens?: number;
+          output_tokens?: number;
+          cache_creation_input_tokens?: number;
+          cache_read_input_tokens?: number;
+        }
+      | undefined;
+
+    if (!msgId && usage) {
+      logger.debug("[usage] assistant event missing message.id — tokens not counted", { agentId: agentProc.agent.id });
+    }
+
+    if (msgId && usage && !agentProc.seenMessageIds.has(msgId)) {
+      agentProc.seenMessageIds.add(msgId);
+
+      if (agentProc.seenMessageIds.size > 1000) {
+        const toDelete = agentProc.seenMessageIds.size - 500;
+        let deleted = 0;
+        for (const msgKey of agentProc.seenMessageIds) {
+          if (deleted >= toDelete) break;
+          agentProc.seenMessageIds.delete(msgKey);
+          deleted++;
+        }
+      }
+
+      const tokensIn =
+        (usage.input_tokens ?? 0) + (usage.cache_creation_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0);
+      const tokensOut = usage.output_tokens ?? 0;
+      const cost = estimateCost(agentProc.agent.model, usage);
+
+      agentProc.sessionEstimatedCost = (agentProc.sessionEstimatedCost ?? 0) + cost;
+      agentProc.sessionTokensIn = (agentProc.sessionTokensIn ?? 0) + tokensIn;
+      agentProc.sessionTokensOut = (agentProc.sessionTokensOut ?? 0) + tokensOut;
+
+      if (tokensIn > 0 || tokensOut > 0) {
+        const prev = agentProc.agent.usage ?? {
+          tokensIn: 0,
+          tokensOut: 0,
+          estimatedCost: 0,
+          totalTokensSpent: 0,
+          totalTokensIn: 0,
+          totalTokensOut: 0,
+          apiTurns: 0,
+          lastTurnTokensIn: 0,
+        };
+        agentProc.agent.usage = {
+          tokensIn: prev.tokensIn + tokensIn,
+          tokensOut: prev.tokensOut + tokensOut,
+          estimatedCost: prev.estimatedCost + cost,
+          totalTokensSpent: prev.totalTokensSpent + tokensIn + tokensOut,
+          totalTokensIn: (prev.totalTokensIn ?? 0) + tokensIn,
+          totalTokensOut: (prev.totalTokensOut ?? 0) + tokensOut,
+          apiTurns: (prev.apiTurns ?? 0) + 1,
+          lastTurnTokensIn: tokensIn,
+        };
+        saveAgentState(agentProc.agent);
+        this.onAgentUpdated(agentProc.agent.id, agentProc.agent, false);
+        this.usageTracker.upsertCostTracker(agentProc);
+      }
+    }
+  }
+
+  private reconcileResultEvent(event: StreamEvent, agentProc: AgentProcess): void {
+    const durationMs = typeof event.duration_ms === "number" ? event.duration_ms : undefined;
+    const durationApiMs = typeof event.duration_api_ms === "number" ? event.duration_api_ms : undefined;
+    const numTurns = typeof event.num_turns === "number" ? event.num_turns : undefined;
+
+    if (durationMs !== undefined) agentProc.agent.turnDurationMs = durationMs;
+    if (durationApiMs !== undefined) agentProc.agent.apiDurationMs = durationApiMs;
+    if (numTurns !== undefined) agentProc.agent.numTurns = numTurns;
+
+    const totalCostUsd = typeof event.total_cost_usd === "number" ? event.total_cost_usd : undefined;
+    const rawUsage =
+      typeof event.usage === "object" && event.usage !== null ? (event.usage as Record<string, unknown>) : undefined;
+
+    if (totalCostUsd == null && rawUsage == null) {
+      if (durationMs !== undefined || durationApiMs !== undefined || numTurns !== undefined) {
+        saveAgentState(agentProc.agent);
+      }
+      return;
+    }
+
+    const prev = agentProc.agent.usage ?? {
+      tokensIn: 0,
+      tokensOut: 0,
+      estimatedCost: 0,
+      totalTokensSpent: 0,
+      totalTokensIn: 0,
+      totalTokensOut: 0,
+      apiTurns: 0,
+      lastTurnTokensIn: 0,
+    };
+
+    let costDelta = 0;
+    let tokenInDelta = 0;
+    let tokenOutDelta = 0;
+
+    if (totalCostUsd != null) {
+      costDelta = totalCostUsd - (agentProc.sessionEstimatedCost ?? 0);
+      agentProc.sessionEstimatedCost = totalCostUsd;
+    }
+
+    if (rawUsage) {
+      const toNum = (v: unknown) => (typeof v === "number" ? v : 0);
+      const authoritativeIn =
+        toNum(rawUsage.input_tokens) +
+        toNum(rawUsage.cache_creation_input_tokens) +
+        toNum(rawUsage.cache_read_input_tokens);
+      const authoritativeOut = toNum(rawUsage.output_tokens);
+
+      tokenInDelta = authoritativeIn - (agentProc.sessionTokensIn ?? 0);
+      tokenOutDelta = authoritativeOut - (agentProc.sessionTokensOut ?? 0);
+      agentProc.sessionEstimatedCost = totalCostUsd ?? agentProc.sessionEstimatedCost;
+      agentProc.sessionTokensIn = authoritativeIn;
+      agentProc.sessionTokensOut = authoritativeOut;
+    }
+
+    if (costDelta === 0 && tokenInDelta === 0 && tokenOutDelta === 0) return;
+
+    const nextEstimatedCost = Math.max(0, prev.estimatedCost + costDelta);
+    const nextTokensIn = Math.max(0, prev.tokensIn + tokenInDelta);
+    const nextTokensOut = Math.max(0, prev.tokensOut + tokenOutDelta);
+    const nextTotalTokensIn = Math.max(0, (prev.totalTokensIn ?? 0) + tokenInDelta);
+    const nextTotalTokensOut = Math.max(0, (prev.totalTokensOut ?? 0) + tokenOutDelta);
+
+    agentProc.agent.usage = {
+      ...prev,
+      tokensIn: nextTokensIn,
+      tokensOut: nextTokensOut,
+      estimatedCost: nextEstimatedCost,
+      totalTokensSpent: nextTotalTokensIn + nextTotalTokensOut,
+      totalTokensIn: nextTotalTokensIn,
+      totalTokensOut: nextTotalTokensOut,
+    };
+
+    if (agentProc.jsonSchemaPath && typeof event.result === "string" && event.result) {
+      try {
+        agentProc.agent.structuredResult = JSON.parse(event.result) as Record<string, unknown>;
+      } catch {
+        // Result is not valid JSON
+      }
+    }
+
+    saveAgentState(agentProc.agent);
+    this.onAgentUpdated(agentProc.agent.id, agentProc.agent, false);
+    this.usageTracker.upsertCostTracker(agentProc);
+
+    if (costDelta !== 0) {
+      logger.debug(`[usage] result reconciliation: cost adjusted by $${costDelta.toFixed(6)}`, {
+        agentId: agentProc.agent.id,
+        totalCostUsd,
+        sessionEstimate: (agentProc.sessionEstimatedCost ?? 0) - costDelta,
+      });
+    }
+  }
+
+  private batchEvent(event: StreamEvent, agentProc: AgentProcess): void {
+    const now = new Date().toISOString();
+    agentProc.agent.lastActivity = now;
+
+    if (!event._ts) event._ts = now;
+    if (event._idx === undefined) event._idx = agentProc.eventBufferTotal;
+
+    const sanitized = sanitizeEvent(event);
+    agentProc.persistBatch += `${JSON.stringify(sanitized)}\n`;
+
+    if (agentProc.eventBuffer.length < EVENT_RING_BUFFER_SIZE) {
+      agentProc.eventBuffer.push(sanitized);
+    } else {
+      agentProc.eventBuffer[agentProc.eventBufferTotal % EVENT_RING_BUFFER_SIZE] = sanitized;
+    }
+    agentProc.eventBufferTotal++;
+
+    agentProc.listenerBatch.push(event);
+
+    const id = agentProc.agent.id;
+    if (!agentProc.persistTimer) {
+      agentProc.persistTimer = setTimeout(() => this.flushEventBatch(id, agentProc), 16);
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export interface AgentProcess {
   eventBuffer: StreamEvent[];
   /** Total number of events ever appended (used to compute ring buffer offset). */
   eventBufferTotal: number;
-  /** Session-level cost accumulated from assistant events. */
+  /** Session-level cost accumulated from assistant events (for result reconciliation). */
   sessionEstimatedCost?: number;
   /** Session-level input tokens accumulated from assistant events. */
   sessionTokensIn?: number;
@@ -57,6 +57,8 @@ export interface AgentProcess {
   sessionTokensOut?: number;
   /** Path to the temporary JSON schema file written for --json-schema. */
   jsonSchemaPath?: string;
+  /** True after a soft-stall notification has been sent to avoid duplicate UI alerts. */
+  softStallNotified?: boolean;
 }
 
 export interface AuthPayload {


### PR DESCRIPTION
## Summary

- Extracts `EventPipeline` class from the `AgentManager` monolith (`agents.ts`)
- Moves `handleEvent`, ring-buffer reads, disk persistence (JSONL append), and event-file truncation into `src/event-pipeline.ts`
- `agents.ts` delegates via `this.pipeline` with an `onAgentUpdated` callback injected at construction
- Adds `softStallNotified` field to `AgentProcess` (used to suppress duplicate stall UI alerts)
- 16 unit tests covering: handleEvent routing, token accumulation/dedup, stall reset, ring-buffer reads, flushEventBatch, and batch persistence

## Diff size
- `src/event-pipeline.ts`: 438 lines (new)
- `src/event-pipeline.test.ts`: 259 lines (new)  
- `src/agents.ts`: -252 lines (delegations replace inline code)
- `src/types.ts`: +4 lines (softStallNotified field)

## Test plan
- [x] `vitest run` — 678 tests pass (662 pre-existing + 16 new)
- [x] `tsc --noEmit` — clean
- [x] `biome check .` — warnings only (pre-existing), no errors
- [x] Zero /fanbot|fanvue/i matches in diff