### PR TITLE
fix: replace null with undefined in pull-requests-pure.test.ts (TS2322 CI blocker)

### DIFF
--- a/src/routes/pull-requests-pure.test.ts
+++ b/src/routes/pull-requests-pure.test.ts
@@ -7,14 +7,14 @@ describe("deriveChecksStatus", () => {
     expect(deriveChecksStatus(null as never)).toBe("none");
   });
   it("returns failing when any check failed", () => {
-    expect(deriveChecksStatus([{ conclusion: "FAILURE", state: null, status: null }])).toBe("failing");
-    expect(deriveChecksStatus([{ conclusion: "ERROR", state: null, status: null }])).toBe("failing");
+    expect(deriveChecksStatus([{ conclusion: "FAILURE", state: undefined, status: undefined }])).toBe("failing");
+    expect(deriveChecksStatus([{ conclusion: "ERROR", state: undefined, status: undefined }])).toBe("failing");
   });
   it("returns pending when any check is in progress", () => {
-    expect(deriveChecksStatus([{ conclusion: null, state: null, status: "IN_PROGRESS" }])).toBe("pending");
+    expect(deriveChecksStatus([{ conclusion: undefined, state: undefined, status: "IN_PROGRESS" }])).toBe("pending");
   });
   it("returns passing when all checks succeeded", () => {
-    expect(deriveChecksStatus([{ conclusion: "SUCCESS", state: null, status: null }])).toBe("passing");
+    expect(deriveChecksStatus([{ conclusion: "SUCCESS", state: undefined, status: undefined }])).toBe("passing");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes TS2322 errors in `src/routes/pull-requests-pure.test.ts` that are failing Typecheck CI on **every PR** branched from main.

**Root cause:** PR #194 added `pull-requests-pure.test.ts` with test fixtures passing `null` for `conclusion`, `state`, and `status` fields. The `deriveChecksStatus` function accepts `{ conclusion?: string; state?: string; status?: string }` — TypeScript rejects `null` (not assignable to `string | undefined`).

**Fix:** Replace all `null` with `undefined` in the test fixtures. 4 substitutions, 1 file.

## Test plan
- [x] `npx tsc --noEmit` → no pull-requests-pure errors
- [x] `npx biome check .` → exit 0
- [x] `npm test -- src/routes/pull-requests-pure.test.ts` → 11/11 pass
