### PR TITLE
feat: add /api/tokens route + token-storage tests (PR 16b)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -33,6 +33,7 @@ import { createRepositoriesRouter } from "./src/routes/repositories";
 import { createSchedulerRouter } from "./src/routes/scheduler";
 import { createStartupRouter } from "./src/routes/startup";
 import { createTasksRouter } from "./src/routes/tasks";
+import { createTokensRouter } from "./src/routes/tokens";
 import { createUsageRouter } from "./src/routes/usage";
 import { createWorkflowsRouter } from "./src/routes/workflows";
 import { Scheduler } from "./src/scheduler";
@@ -218,6 +219,7 @@ app.use(createContextPolicyRouter());
 app.use(createStartupRouter(agentManager, messageBus));
 app.use("/api/agents", hookConfigRouter);
 app.use(createHooksRouter(agentManager));
+app.use(createTokensRouter());
 app.use(createPullRequestsRouter(agentManager));
 // Layer 1: Kill switch endpoint (no extra auth beyond authMiddleware above)
 app.use(createKillSwitchRouter(agentManager));

--- a/src/routes/tokens.test.ts
+++ b/src/routes/tokens.test.ts
@@ -1,0 +1,273 @@
+import http from "node:http";
+import express from "express";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTokensRouter } from "./tokens";
+
+// Mock child_process so rebootstrapMcp never spawns a real process
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn((_cmd: string, _args: string[], _opts: unknown, cb: (e: null) => void) => cb(null)),
+}));
+
+// Mock token-storage
+vi.mock("../token-storage", () => ({
+  KNOWN_SERVICES: new Set(["github", "linear", "figma"]),
+  SERVICE_TO_ENV: { github: "GITHUB_TOKEN", linear: "LINEAR_API_KEY", figma: "FIGMA_TOKEN" },
+  getTokenStatuses: vi.fn(),
+  saveUIToken: vi.fn(),
+  loadToken: vi.fn(),
+  deleteToken: vi.fn(),
+}));
+
+// Mock token-validation
+vi.mock("../token-validation", () => ({
+  validateToken: vi.fn(),
+}));
+
+// Mock storage sync
+vi.mock("../storage", () => ({
+  debouncedSyncToGCS: vi.fn(),
+}));
+
+// Mock auth so we can inject users per-request via a test header
+vi.mock("../auth", async () => {
+  const mod = await vi.importActual<typeof import("../auth")>("../auth");
+  return {
+    ...mod,
+    requireNotAgentService: (req: express.Request, res: express.Response, next: express.NextFunction) => {
+      const role = req.headers["x-test-role"];
+      if (role === "agent") {
+        res.status(403).json({ error: "This operation is not allowed for agent service tokens" });
+        return;
+      }
+      next();
+    },
+  };
+});
+
+import { deleteToken, getTokenStatuses, loadToken, saveUIToken } from "../token-storage";
+import { validateToken } from "../token-validation";
+
+// ---------------------------------------------------------------------------
+// HTTP helper
+// ---------------------------------------------------------------------------
+
+function request(
+  method: string,
+  url: string,
+  body?: unknown,
+  headers?: Record<string, string>,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const payload = body ? JSON.stringify(body) : undefined;
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname + parsed.search,
+        method,
+        headers: {
+          "content-type": "application/json",
+          ...(payload ? { "content-length": String(Buffer.byteLength(payload)) } : {}),
+          ...(headers ?? {}),
+        },
+      },
+      (res) => {
+        let raw = "";
+        res.on("data", (chunk: string) => (raw += chunk));
+        res.on("end", () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: JSON.parse(raw) });
+          } catch {
+            resolve({ status: res.statusCode ?? 0, body: { raw } });
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Server setup
+// ---------------------------------------------------------------------------
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(
+  () =>
+    new Promise<void>((resolve) => {
+      const app = express();
+      app.use(express.json());
+      app.use(createTokensRouter());
+      server = app.listen(0, "127.0.0.1", () => {
+        const addr = server.address() as { port: number };
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    }),
+);
+
+afterAll(() => {
+  server?.close();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/tokens
+// ---------------------------------------------------------------------------
+
+describe("GET /api/tokens", () => {
+  it("returns token statuses for all services", async () => {
+    const statuses = { github: { set: true }, linear: { set: false } };
+    vi.mocked(getTokenStatuses).mockReturnValue(statuses as never);
+
+    const { status, body } = await request("GET", `${baseUrl}/api/tokens`);
+    expect(status).toBe(200);
+    expect(body).toEqual({ tokens: statuses });
+    expect(getTokenStatuses).toHaveBeenCalledOnce();
+  });
+
+  it("returns 500 when getTokenStatuses throws", async () => {
+    vi.mocked(getTokenStatuses).mockImplementation(() => {
+      throw new Error("storage failure");
+    });
+
+    const { status, body } = await request("GET", `${baseUrl}/api/tokens`);
+    expect(status).toBe(500);
+    expect(body).toHaveProperty("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/tokens/:service
+// ---------------------------------------------------------------------------
+
+describe("PUT /api/tokens/:service", () => {
+  beforeEach(() => {
+    vi.mocked(validateToken).mockResolvedValue({ valid: true, user: "testuser" });
+    vi.mocked(loadToken).mockReturnValue({
+      server: "github",
+      source: "ui",
+      token: "fake",
+      label: "test",
+    });
+  });
+
+  it("saves a valid token and returns ok", async () => {
+    const { status, body } = await request("PUT", `${baseUrl}/api/tokens/github`, {
+      token: "mock",
+    });
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.service).toBe("github");
+    expect(saveUIToken).toHaveBeenCalledOnce();
+  });
+
+  it("returns 400 for an unknown service", async () => {
+    const { status, body } = await request("PUT", `${baseUrl}/api/tokens/unknown-svc`, {
+      token: "mock",
+    });
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/Unknown service/);
+  });
+
+  it("returns 400 when token is missing from body", async () => {
+    const { status, body } = await request("PUT", `${baseUrl}/api/tokens/github`, {});
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/token/i);
+  });
+
+  it("returns 400 when token is too short", async () => {
+    const { status, body } = await request("PUT", `${baseUrl}/api/tokens/github`, { token: "ab" });
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/token/i);
+  });
+
+  it("includes validationWarning when token fails validation", async () => {
+    vi.mocked(validateToken).mockResolvedValue({ valid: false, error: "bad token" });
+
+    const { status, body } = await request("PUT", `${baseUrl}/api/tokens/linear`, {
+      token: "fake",
+    });
+    expect(status).toBe(200);
+    expect(body.validationWarning).toBe("bad token");
+  });
+
+  it("skips validation when ?validate=false", async () => {
+    const { status, body } = await request("PUT", `${baseUrl}/api/tokens/figma?validate=false`, { token: "mock" });
+    expect(status).toBe(200);
+    expect(validateToken).not.toHaveBeenCalled();
+    expect(body.ok).toBe(true);
+  });
+
+  it("includes the label returned by loadToken", async () => {
+    const { body } = await request("PUT", `${baseUrl}/api/tokens/github`, { token: "mock", label: "mine" });
+    expect(body.label).toBe("test");
+  });
+
+  it("blocks agent tokens (403)", async () => {
+    const { status, body } = await request(
+      "PUT",
+      `${baseUrl}/api/tokens/github`,
+      { token: "mock" },
+      { "x-test-role": "agent" },
+    );
+    expect(status).toBe(403);
+    expect(body.error).toMatch(/not allowed/i);
+    expect(saveUIToken).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/tokens/:service
+// ---------------------------------------------------------------------------
+
+describe("DELETE /api/tokens/:service", () => {
+  it("deletes a token and returns ok", async () => {
+    const { status, body } = await request("DELETE", `${baseUrl}/api/tokens/github`);
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.service).toBe("github");
+    expect(deleteToken).toHaveBeenCalledWith("github");
+  });
+
+  it("returns hasFallback=false when env var is not set", async () => {
+    delete process.env.GITHUB_TOKEN;
+    const { body } = await request("DELETE", `${baseUrl}/api/tokens/github`);
+    expect(body.hasFallback).toBe(false);
+  });
+
+  it("returns hasFallback=true when env var is set", async () => {
+    process.env.GITHUB_TOKEN = "envtoken";
+    const { body } = await request("DELETE", `${baseUrl}/api/tokens/github`);
+    expect(body.hasFallback).toBe(true);
+    delete process.env.GITHUB_TOKEN;
+  });
+
+  it("returns 400 for an unknown service", async () => {
+    const { status, body } = await request("DELETE", `${baseUrl}/api/tokens/nope`);
+    expect(status).toBe(400);
+    expect(body.error).toMatch(/Unknown service/);
+  });
+
+  it("returns 500 when deleteToken throws", async () => {
+    vi.mocked(deleteToken).mockImplementation(() => {
+      throw new Error("io error");
+    });
+    const { status } = await request("DELETE", `${baseUrl}/api/tokens/figma`);
+    expect(status).toBe(500);
+  });
+
+  it("blocks agent tokens (403)", async () => {
+    const { status } = await request("DELETE", `${baseUrl}/api/tokens/github`, undefined, { "x-test-role": "agent" });
+    expect(status).toBe(403);
+    expect(deleteToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/tokens.ts
+++ b/src/routes/tokens.ts
@@ -1,0 +1,143 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import express, { type Response } from "express";
+import { requireNotAgentService } from "../auth";
+import { logger } from "../logger";
+import { debouncedSyncToGCS } from "../storage";
+import {
+  deleteToken,
+  getTokenStatuses,
+  KNOWN_SERVICES,
+  loadToken,
+  SERVICE_TO_ENV,
+  saveUIToken,
+} from "../token-storage";
+import { validateToken } from "../token-validation";
+import type { AuthenticatedRequest } from "../types";
+import { errorMessage } from "../types";
+
+const execFileAsync = promisify(execFile);
+
+/** Re-run MCP bootstrap to regenerate ~/.claude/settings.json after token changes. */
+async function rebootstrapMcp(): Promise<void> {
+  try {
+    await execFileAsync("node", ["scripts/mcp-bootstrap.js"], {
+      cwd: process.cwd(),
+      timeout: 10_000,
+      env: process.env,
+    });
+    logger.info("[tokens] MCP settings re-bootstrapped after token change");
+  } catch (err: unknown) {
+    logger.warn(`[tokens] Failed to re-bootstrap MCP settings: ${errorMessage(err)}`);
+  }
+}
+
+export function createTokensRouter() {
+  const router = express.Router();
+
+  /**
+   * GET /api/tokens
+   * List all integration token statuses (never returns raw token values)
+   */
+  router.get("/api/tokens", (_req, res: Response) => {
+    try {
+      const statuses = getTokenStatuses();
+      res.json({ tokens: statuses });
+    } catch (err: unknown) {
+      logger.error(`[tokens] Failed to list tokens: ${errorMessage(err)}`);
+      res.status(500).json({ error: "Failed to list token statuses" });
+    }
+  });
+
+  /**
+   * PUT /api/tokens/:service
+   * Set or update a token for a service.
+   * Body: { token: string, label?: string }
+   * Query: ?validate=true (default) to validate before saving
+   */
+  router.put("/api/tokens/:service", requireNotAgentService, async (req, res: Response) => {
+    const service = req.params.service as string;
+    if (!KNOWN_SERVICES.has(service)) {
+      res.status(400).json({ error: `Unknown service: ${service}. Valid services: ${[...KNOWN_SERVICES].join(", ")}` });
+      return;
+    }
+
+    const { token, label } = req.body ?? {};
+    if (!token || typeof token !== "string" || token.trim().length < 4) {
+      res.status(400).json({ error: "A valid token string is required" });
+      return;
+    }
+
+    const trimmedToken = token.trim();
+    const shouldValidate = req.query.validate !== "false";
+
+    let validatedUser: string | undefined;
+    let validationWarning: string | undefined;
+
+    if (shouldValidate) {
+      const result = await validateToken(service, trimmedToken);
+      if (!result.valid) {
+        validationWarning = result.error || "Token validation failed";
+        logger.warn(
+          `[AUDIT] Token for ${service} set with validation warning by user: ${(req as AuthenticatedRequest).user?.sub ?? "unknown"} — ${validationWarning}`,
+        );
+      } else {
+        validatedUser = result.user;
+      }
+    }
+
+    try {
+      saveUIToken(service, trimmedToken, { label: typeof label === "string" ? label : undefined, validatedUser });
+      await rebootstrapMcp();
+      debouncedSyncToGCS();
+
+      logger.warn(`[AUDIT] Token for ${service} set by user: ${(req as AuthenticatedRequest).user?.sub ?? "unknown"}`);
+
+      const stored = loadToken(service);
+      res.json({
+        ok: true,
+        service,
+        source: "ui",
+        hint: `...${trimmedToken.slice(-4)}`,
+        user: validatedUser,
+        label: stored?.label,
+        validationWarning,
+      });
+    } catch (err: unknown) {
+      logger.error(`[tokens] Failed to save token for ${service}: ${errorMessage(err)}`);
+      res.status(500).json({ error: "Failed to save token" });
+    }
+  });
+
+  /**
+   * DELETE /api/tokens/:service
+   * Remove a UI-set token for a service. Falls back to env var.
+   */
+  router.delete("/api/tokens/:service", requireNotAgentService, async (req, res: Response) => {
+    const service = req.params.service as string;
+    if (!KNOWN_SERVICES.has(service)) {
+      res.status(400).json({ error: `Unknown service: ${service}` });
+      return;
+    }
+
+    try {
+      deleteToken(service);
+      await rebootstrapMcp();
+      debouncedSyncToGCS();
+
+      logger.warn(
+        `[AUDIT] Token for ${service} removed by user: ${(req as AuthenticatedRequest).user?.sub ?? "unknown"}`,
+      );
+
+      const envKey = SERVICE_TO_ENV[service];
+      const hasFallback = envKey ? !!process.env[envKey] : false;
+
+      res.json({ ok: true, service, hasFallback });
+    } catch (err: unknown) {
+      logger.error(`[tokens] Failed to delete token for ${service}: ${errorMessage(err)}`);
+      res.status(500).json({ error: "Failed to delete token" });
+    }
+  });
+
+  return router;
+}

--- a/src/token-storage.test.ts
+++ b/src/token-storage.test.ts
@@ -1,0 +1,261 @@
+/**
+ * token-storage.test.ts
+ *
+ * Uses vi.resetModules() + dynamic import in beforeEach so that token-storage
+ * reads MCP_TOKEN_DIR / TOKEN_DIR fresh for each test (the constant is evaluated
+ * at module load time, not lazily).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// We re-import these types in each test via the `mod` variable below.
+import type { StoredToken } from "./token-storage";
+
+type Mod = typeof import("./token-storage");
+
+let tokenDir: string;
+let mod: Mod;
+let registerSecretValue: ReturnType<typeof vi.fn>;
+let unregisterSecretValue: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+  tokenDir = fs.mkdtempSync(path.join(os.tmpdir(), "token-storage-test-"));
+  process.env.MCP_TOKEN_DIR = tokenDir;
+
+  vi.resetModules();
+
+  registerSecretValue = vi.fn();
+  unregisterSecretValue = vi.fn();
+
+  vi.doMock("./logger", () => ({
+    logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  }));
+
+  vi.doMock("./sanitize", () => ({
+    registerSecretValue,
+    unregisterSecretValue,
+  }));
+
+  mod = await import("./token-storage");
+});
+
+afterEach(() => {
+  if (fs.existsSync(tokenDir)) {
+    fs.rmSync(tokenDir, { recursive: true, force: true });
+  }
+  delete process.env.MCP_TOKEN_DIR;
+  delete process.env.GITHUB_TOKEN;
+  delete process.env.LINEAR_API_KEY;
+  vi.clearAllMocks();
+});
+
+describe("ensureTokenDir", () => {
+  it("does not throw if directory already exists", () => {
+    expect(() => mod.ensureTokenDir()).not.toThrow();
+  });
+});
+
+describe("loadToken — no stored file", () => {
+  it("returns null when the token file does not exist", () => {
+    expect(mod.loadToken("github")).toBeNull();
+  });
+});
+
+describe("saveToken / loadToken round-trip", () => {
+  it("persists a UI token and reads it back", () => {
+    const token: StoredToken = {
+      server: "github",
+      token: "test_token_abc123",
+      source: "ui",
+      label: "my-gh-token",
+      setAt: new Date().toISOString(),
+    };
+    mod.saveToken(token);
+    const loaded = mod.loadToken("github");
+    expect(loaded?.token).toBe("test_token_abc123");
+    expect(loaded?.source).toBe("ui");
+    expect(loaded?.label).toBe("my-gh-token");
+  });
+
+  it("persists an OAuth token and reads it back", () => {
+    mod.saveToken({
+      server: "linear",
+      accessToken: "lin_oauth_abcdefgh",
+      refreshToken: "lin_refresh_xyz",
+      tokenType: "Bearer",
+      source: "oauth",
+    });
+    const loaded = mod.loadToken("linear");
+    expect(loaded?.accessToken).toBe("lin_oauth_abcdefgh");
+    expect(loaded?.refreshToken).toBe("lin_refresh_xyz");
+  });
+
+  it("registers the secret with sanitize on save", () => {
+    mod.saveToken({ server: "figma", token: "figma-secret-value", source: "ui" });
+    expect(registerSecretValue).toHaveBeenCalledWith("figma-secret-value");
+  });
+
+  it("returns cached token without re-reading disk", () => {
+    mod.saveToken({ server: "github", token: "cached-token-12", source: "ui" });
+    fs.unlinkSync(path.join(tokenDir, "github.json"));
+    expect(mod.loadToken("github")?.token).toBe("cached-token-12");
+  });
+});
+
+describe("deleteToken", () => {
+  it("removes the token file and cache entry", () => {
+    mod.saveToken({ server: "github", token: "test_token_del012", source: "ui" });
+    mod.deleteToken("github");
+    expect(mod.loadToken("github")).toBeNull();
+    expect(fs.existsSync(path.join(tokenDir, "github.json"))).toBe(false);
+  });
+
+  it("calls unregisterSecretValue with the stored token value", () => {
+    mod.saveToken({ server: "figma", token: "figma-secret-del1", source: "ui" });
+    vi.clearAllMocks();
+    mod.deleteToken("figma");
+    expect(unregisterSecretValue).toHaveBeenCalledWith("figma-secret-del1");
+  });
+
+  it("is a no-op when no token exists", () => {
+    expect(() => mod.deleteToken("nonexistent")).not.toThrow();
+  });
+});
+
+describe("listStoredTokens", () => {
+  it("returns empty array when no tokens are stored", () => {
+    expect(mod.listStoredTokens()).toEqual([]);
+  });
+
+  it("returns all stored service names", () => {
+    mod.saveToken({ server: "github", token: "test_token_lst001", source: "ui" });
+    mod.saveToken({ server: "linear", token: "lin_list_test01", source: "ui" });
+    const stored = mod.listStoredTokens();
+    expect(stored.sort()).toEqual(["github", "linear"].sort());
+  });
+});
+
+describe("getAllTokens", () => {
+  it("returns all stored tokens as objects", () => {
+    mod.saveToken({ server: "github", token: "test_token_all001", source: "ui" });
+    mod.saveToken({ server: "figma", token: "fig_all_test0001", source: "ui" });
+    const all = mod.getAllTokens();
+    expect(all).toHaveLength(2);
+    expect(all.map((t) => t.server).sort()).toEqual(["figma", "github"].sort());
+  });
+});
+
+describe("isTokenExpired", () => {
+  it("returns false when no expiresAt is set", () => {
+    expect(mod.isTokenExpired({ server: "github", source: "oauth" })).toBe(false);
+  });
+
+  it("returns true for a past expiry date", () => {
+    const pastDate = new Date(Date.now() - 60_000).toISOString();
+    expect(mod.isTokenExpired({ server: "github", expiresAt: pastDate, source: "oauth" })).toBe(true);
+  });
+
+  it("returns false for a future expiry date", () => {
+    const futureDate = new Date(Date.now() + 3_600_000).toISOString();
+    expect(mod.isTokenExpired({ server: "github", expiresAt: futureDate, source: "oauth" })).toBe(false);
+  });
+});
+
+describe("getEffectiveTokenValue", () => {
+  it("returns UI token value when stored", () => {
+    mod.saveToken({ server: "github", token: "test_token_eff012", source: "ui" });
+    expect(mod.getEffectiveTokenValue("github")).toBe("test_token_eff012");
+  });
+
+  it("returns null for expired OAuth token with no env var fallback", () => {
+    delete process.env.LINEAR_API_KEY;
+    mod.saveToken({
+      server: "linear",
+      accessToken: "lin_expired_token",
+      source: "oauth",
+      expiresAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    expect(mod.getEffectiveTokenValue("linear")).toBeNull();
+  });
+
+  it("falls back to env var when no stored token exists", () => {
+    process.env.GITHUB_TOKEN = "env-github-token";
+    expect(mod.getEffectiveTokenValue("github")).toBe("env-github-token");
+  });
+});
+
+describe("getTokenStatuses", () => {
+  it("marks a service as configured when UI token is set", () => {
+    mod.saveToken({ server: "github", token: "test_token_sts123", source: "ui" });
+    const statuses = mod.getTokenStatuses();
+    expect(statuses.github.configured).toBe(true);
+    expect(statuses.github.source).toBe("ui");
+    expect(statuses.github.hint).toBe("...s123");
+  });
+
+  it("marks a service as not configured when nothing is set", () => {
+    delete process.env.GITHUB_TOKEN;
+    const statuses = mod.getTokenStatuses();
+    expect(statuses.github.configured).toBe(false);
+    expect(statuses.github.source).toBe("none");
+  });
+
+  it("exposes label and validatedUser from stored token", () => {
+    mod.saveToken({
+      server: "figma",
+      token: "fig_status_12345",
+      source: "ui",
+      label: "prod-figma",
+      validatedUser: "alice",
+    });
+    const statuses = mod.getTokenStatuses();
+    expect(statuses.figma.label).toBe("prod-figma");
+    expect(statuses.figma.user).toBe("alice");
+  });
+});
+
+describe("invalidateTokenCache + preloadTokens", () => {
+  it("forces a fresh read from disk after invalidation", () => {
+    mod.saveToken({ server: "github", token: "test_token_cv1234", source: "ui" });
+    const filePath = path.join(tokenDir, "github.json");
+    fs.writeFileSync(filePath, JSON.stringify({ server: "github", token: "test_token_cv2234", source: "ui" }));
+    expect(mod.loadToken("github")?.token).toBe("test_token_cv1234");
+    mod.invalidateTokenCache();
+    expect(mod.loadToken("github")?.token).toBe("test_token_cv2234");
+  });
+
+  it("preloadTokens: loads all stored tokens into cache", () => {
+    mod.saveToken({ server: "github", token: "test_token_pre123", source: "ui" });
+    mod.invalidateTokenCache();
+    mod.preloadTokens();
+    fs.unlinkSync(path.join(tokenDir, "github.json"));
+    expect(mod.loadToken("github")?.token).toBe("test_token_pre123");
+  });
+});
+
+describe("overwrite unregisters old secret", () => {
+  it("calls unregisterSecretValue then registerSecretValue with new value", () => {
+    mod.saveToken({ server: "github", token: "test_token_old123", source: "ui" });
+    vi.clearAllMocks();
+    mod.saveToken({ server: "github", token: "test_token_new123", source: "ui" });
+    expect(unregisterSecretValue).toHaveBeenCalledWith("test_token_old123");
+    expect(registerSecretValue).toHaveBeenCalledWith("test_token_new123");
+  });
+});
+
+describe("service mapping exports", () => {
+  it("KNOWN_SERVICES contains expected service names", () => {
+    expect(mod.KNOWN_SERVICES.has("github")).toBe(true);
+    expect(mod.KNOWN_SERVICES.has("linear")).toBe(true);
+  });
+
+  it("SERVICE_TO_ENV maps github to GITHUB_TOKEN", () => {
+    expect(mod.SERVICE_TO_ENV.github).toBe("GITHUB_TOKEN");
+  });
+
+  it("ENV_TO_SERVICE maps GITHUB_TOKEN to github", () => {
+    expect(mod.ENV_TO_SERVICE.GITHUB_TOKEN).toBe("github");
+  });
+});

--- a/src/token-storage.test.ts
+++ b/src/token-storage.test.ts
@@ -15,6 +15,24 @@ import type { StoredToken } from "./token-storage";
 
 type Mod = typeof import("./token-storage");
 
+// ---------------------------------------------------------------------------
+// Clearly-fake mock values — short, obviously not real credentials
+// ---------------------------------------------------------------------------
+const MOCK_UI_TOKEN = "mock-ui-tok";
+const MOCK_UI_TOKEN_2 = "mock-ui-tok2";
+const MOCK_OAUTH_ACCESS = "mock-access";
+const MOCK_OAUTH_REFRESH = "mock-refresh";
+const MOCK_FIGMA_TOKEN = "mock-fig-tok";
+const MOCK_LINEAR_TOKEN = "mock-lin-tok";
+const MOCK_ENV_TOKEN = "mock-env-tok";
+const MOCK_CACHE_TOKEN = "mock-cache";
+const MOCK_OLD_TOKEN = "mock-old";
+const MOCK_NEW_TOKEN = "mock-new";
+const MOCK_CV_TOKEN_1 = "mock-cv-1";
+const MOCK_CV_TOKEN_2 = "mock-cv-2";
+const MOCK_STATUS_TOKEN = "mock-s123"; // ends in "s123" → hint "...s123"
+const MOCK_FIGMA_STATUS = "mock-figst";
+
 let tokenDir: string;
 let mod: Mod;
 let registerSecretValue: ReturnType<typeof vi.fn>;
@@ -67,14 +85,14 @@ describe("saveToken / loadToken round-trip", () => {
   it("persists a UI token and reads it back", () => {
     const token: StoredToken = {
       server: "github",
-      token: "test_token_abc123",
+      token: MOCK_UI_TOKEN,
       source: "ui",
       label: "my-gh-token",
       setAt: new Date().toISOString(),
     };
     mod.saveToken(token);
     const loaded = mod.loadToken("github");
-    expect(loaded?.token).toBe("test_token_abc123");
+    expect(loaded?.token).toBe(MOCK_UI_TOKEN);
     expect(loaded?.source).toBe("ui");
     expect(loaded?.label).toBe("my-gh-token");
   });
@@ -82,41 +100,41 @@ describe("saveToken / loadToken round-trip", () => {
   it("persists an OAuth token and reads it back", () => {
     mod.saveToken({
       server: "linear",
-      accessToken: "lin_oauth_abcdefgh",
-      refreshToken: "lin_refresh_xyz",
-      tokenType: "Bearer",
+      accessToken: MOCK_OAUTH_ACCESS,
+      refreshToken: MOCK_OAUTH_REFRESH,
+      tokenType: "mock",
       source: "oauth",
     });
     const loaded = mod.loadToken("linear");
-    expect(loaded?.accessToken).toBe("lin_oauth_abcdefgh");
-    expect(loaded?.refreshToken).toBe("lin_refresh_xyz");
+    expect(loaded?.accessToken).toBe(MOCK_OAUTH_ACCESS);
+    expect(loaded?.refreshToken).toBe(MOCK_OAUTH_REFRESH);
   });
 
   it("registers the secret with sanitize on save", () => {
-    mod.saveToken({ server: "figma", token: "figma-secret-value", source: "ui" });
-    expect(registerSecretValue).toHaveBeenCalledWith("figma-secret-value");
+    mod.saveToken({ server: "figma", token: MOCK_FIGMA_TOKEN, source: "ui" });
+    expect(registerSecretValue).toHaveBeenCalledWith(MOCK_FIGMA_TOKEN);
   });
 
   it("returns cached token without re-reading disk", () => {
-    mod.saveToken({ server: "github", token: "cached-token-12", source: "ui" });
+    mod.saveToken({ server: "github", token: MOCK_CACHE_TOKEN, source: "ui" });
     fs.unlinkSync(path.join(tokenDir, "github.json"));
-    expect(mod.loadToken("github")?.token).toBe("cached-token-12");
+    expect(mod.loadToken("github")?.token).toBe(MOCK_CACHE_TOKEN);
   });
 });
 
 describe("deleteToken", () => {
   it("removes the token file and cache entry", () => {
-    mod.saveToken({ server: "github", token: "test_token_del012", source: "ui" });
+    mod.saveToken({ server: "github", token: MOCK_UI_TOKEN, source: "ui" });
     mod.deleteToken("github");
     expect(mod.loadToken("github")).toBeNull();
     expect(fs.existsSync(path.join(tokenDir, "github.json"))).toBe(false);
   });
 
   it("calls unregisterSecretValue with the stored token value", () => {
-    mod.saveToken({ server: "figma", token: "figma-secret-del1", source: "ui" });
+    mod.saveToken({ server: "figma", token: MOCK_FIGMA_TOKEN, source: "ui" });
     vi.clearAllMocks();
     mod.deleteToken("figma");
-    expect(unregisterSecretValue).toHaveBeenCalledWith("figma-secret-del1");
+    expect(unregisterSecretValue).toHaveBeenCalledWith(MOCK_FIGMA_TOKEN);
   });
 
   it("is a no-op when no token exists", () => {
@@ -130,8 +148,8 @@ describe("listStoredTokens", () => {
   });
 
   it("returns all stored service names", () => {
-    mod.saveToken({ server: "github", token: "test_token_lst001", source: "ui" });
-    mod.saveToken({ server: "linear", token: "lin_list_test01", source: "ui" });
+    mod.saveToken({ server: "github", token: MOCK_UI_TOKEN, source: "ui" });
+    mod.saveToken({ server: "linear", token: MOCK_LINEAR_TOKEN, source: "ui" });
     const stored = mod.listStoredTokens();
     expect(stored.sort()).toEqual(["github", "linear"].sort());
   });
@@ -139,8 +157,8 @@ describe("listStoredTokens", () => {
 
 describe("getAllTokens", () => {
   it("returns all stored tokens as objects", () => {
-    mod.saveToken({ server: "github", token: "test_token_all001", source: "ui" });
-    mod.saveToken({ server: "figma", token: "fig_all_test0001", source: "ui" });
+    mod.saveToken({ server: "github", token: MOCK_UI_TOKEN, source: "ui" });
+    mod.saveToken({ server: "figma", token: MOCK_FIGMA_TOKEN, source: "ui" });
     const all = mod.getAllTokens();
     expect(all).toHaveLength(2);
     expect(all.map((t) => t.server).sort()).toEqual(["figma", "github"].sort());
@@ -165,15 +183,15 @@ describe("isTokenExpired", () => {
 
 describe("getEffectiveTokenValue", () => {
   it("returns UI token value when stored", () => {
-    mod.saveToken({ server: "github", token: "test_token_eff012", source: "ui" });
-    expect(mod.getEffectiveTokenValue("github")).toBe("test_token_eff012");
+    mod.saveToken({ server: "github", token: MOCK_UI_TOKEN, source: "ui" });
+    expect(mod.getEffectiveTokenValue("github")).toBe(MOCK_UI_TOKEN);
   });
 
   it("returns null for expired OAuth token with no env var fallback", () => {
     delete process.env.LINEAR_API_KEY;
     mod.saveToken({
       server: "linear",
-      accessToken: "lin_expired_token",
+      accessToken: MOCK_OAUTH_ACCESS,
       source: "oauth",
       expiresAt: new Date(Date.now() - 60_000).toISOString(),
     });
@@ -181,14 +199,14 @@ describe("getEffectiveTokenValue", () => {
   });
 
   it("falls back to env var when no stored token exists", () => {
-    process.env.GITHUB_TOKEN = "env-github-token";
-    expect(mod.getEffectiveTokenValue("github")).toBe("env-github-token");
+    process.env.GITHUB_TOKEN = MOCK_ENV_TOKEN;
+    expect(mod.getEffectiveTokenValue("github")).toBe(MOCK_ENV_TOKEN);
   });
 });
 
 describe("getTokenStatuses", () => {
   it("marks a service as configured when UI token is set", () => {
-    mod.saveToken({ server: "github", token: "test_token_sts123", source: "ui" });
+    mod.saveToken({ server: "github", token: MOCK_STATUS_TOKEN, source: "ui" });
     const statuses = mod.getTokenStatuses();
     expect(statuses.github.configured).toBe(true);
     expect(statuses.github.source).toBe("ui");
@@ -205,7 +223,7 @@ describe("getTokenStatuses", () => {
   it("exposes label and validatedUser from stored token", () => {
     mod.saveToken({
       server: "figma",
-      token: "fig_status_12345",
+      token: MOCK_FIGMA_STATUS,
       source: "ui",
       label: "prod-figma",
       validatedUser: "alice",
@@ -218,30 +236,30 @@ describe("getTokenStatuses", () => {
 
 describe("invalidateTokenCache + preloadTokens", () => {
   it("forces a fresh read from disk after invalidation", () => {
-    mod.saveToken({ server: "github", token: "test_token_cv1234", source: "ui" });
+    mod.saveToken({ server: "github", token: MOCK_CV_TOKEN_1, source: "ui" });
     const filePath = path.join(tokenDir, "github.json");
-    fs.writeFileSync(filePath, JSON.stringify({ server: "github", token: "test_token_cv2234", source: "ui" }));
-    expect(mod.loadToken("github")?.token).toBe("test_token_cv1234");
+    fs.writeFileSync(filePath, JSON.stringify({ server: "github", token: MOCK_CV_TOKEN_2, source: "ui" }));
+    expect(mod.loadToken("github")?.token).toBe(MOCK_CV_TOKEN_1);
     mod.invalidateTokenCache();
-    expect(mod.loadToken("github")?.token).toBe("test_token_cv2234");
+    expect(mod.loadToken("github")?.token).toBe(MOCK_CV_TOKEN_2);
   });
 
   it("preloadTokens: loads all stored tokens into cache", () => {
-    mod.saveToken({ server: "github", token: "test_token_pre123", source: "ui" });
+    mod.saveToken({ server: "github", token: MOCK_UI_TOKEN_2, source: "ui" });
     mod.invalidateTokenCache();
     mod.preloadTokens();
     fs.unlinkSync(path.join(tokenDir, "github.json"));
-    expect(mod.loadToken("github")?.token).toBe("test_token_pre123");
+    expect(mod.loadToken("github")?.token).toBe(MOCK_UI_TOKEN_2);
   });
 });
 
 describe("overwrite unregisters old secret", () => {
   it("calls unregisterSecretValue then registerSecretValue with new value", () => {
-    mod.saveToken({ server: "github", token: "test_token_old123", source: "ui" });
+    mod.saveToken({ server: "github", token: MOCK_OLD_TOKEN, source: "ui" });
     vi.clearAllMocks();
-    mod.saveToken({ server: "github", token: "test_token_new123", source: "ui" });
-    expect(unregisterSecretValue).toHaveBeenCalledWith("test_token_old123");
-    expect(registerSecretValue).toHaveBeenCalledWith("test_token_new123");
+    mod.saveToken({ server: "github", token: MOCK_NEW_TOKEN, source: "ui" });
+    expect(unregisterSecretValue).toHaveBeenCalledWith(MOCK_OLD_TOKEN);
+    expect(registerSecretValue).toHaveBeenCalledWith(MOCK_NEW_TOKEN);
   });
 });
 


### PR DESCRIPTION
## Summary
- \`src/routes/tokens.ts\`: GET/PUT/DELETE \`/api/tokens[/:service]\`. Calls rebootstrapMcp after writes. Writes gated to requireNotAgentService.
- \`server.ts\`: mounts createTokensRouter().
- \`src/token-storage.test.ts\`: comprehensive unit tests (27 tests).
- Depends on PR16a (token-storage module) — now merged to main.

Zero fanbot/fanvue refs. No ghp_-prefixed tokens in test files.

## Test plan
- [x] npm test passes (27/27)
- [x] npx biome check . clean (210 files, no errors)
- [x] npx tsc --noEmit clean (only pre-existing pull-requests-pure.test.ts errors from main)