### PR TITLE
fix: exclude test/spec files from secrets scan in confidence scorer

### DIFF
--- a/scripts/pr-confidence-score.sh
+++ b/scripts/pr-confidence-score.sh
@@ -190,9 +190,22 @@ if [ "$IMPORT_PENALTY" -gt 15 ]; then IMPORT_PENALTY=15; fi
 
 MAGIC_URLS=$(grep '^\+' "$DIFF_FILE" | grep -v '^\+\s*//' | grep -v '^\+\s*\*' | grep -v '^\+\s*#' | grep -cE 'https?://[^ ]+\.(com|io|org|net|dev)' || true)
 
+# Scan only non-test source files for hardcoded secrets/tokens.
+# Test files legitimately contain fake credentials (mock tokens, fixture PATs) —
+# scanning them produces false positives that penalise well-tested security routes.
+# URL scanning (above) uses the full diff since URLs in tests are usually real endpoints.
+SRC_DIFF_FILE=$(mktemp)
+trap 'rm -f "$DIFF_FILE" "$SRC_DIFF_FILE"' EXIT
+awk '
+  /^diff --git / {
+    skip = ($0 ~ /\.(test|spec)\.(ts|tsx|js|jsx)|\/__tests__\/|\.spec\.|__fixtures__|vitest\.config/)
+  }
+  !skip { print }
+' "$DIFF_FILE" > "$SRC_DIFF_FILE"
+
 # Use shell variable for single-quote matching (POSIX ERE does not support \x27)
 SQ="'"
-HARDCODED_KEYS=$(grep '^\+' "$DIFF_FILE" | grep -ciE "(api[_-]?key|secret|token|password)\s*[:=]\s*[\"${SQ}][^\"${SQ}]{8,}" || true)
+HARDCODED_KEYS=$(grep '^\+' "$SRC_DIFF_FILE" | grep -ciE "(api[_-]?key|secret|token|password)\s*[:=]\s*[\"${SQ}][^\"${SQ}]{8,}" || true)
 
 MAGIC_PENALTY=0
 if [ "$HARDCODED_KEYS" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- Filters `*.test.ts`, `*.spec.ts`, `/__tests__/`, `__fixtures__`, and `vitest.config` paths from the \`HARDCODED_KEYS\` secrets scan in \`scripts/pr-confidence-score.sh\`
- Test fixtures legitimately contain mock tokens/PATs and should not be penalised — the flat -20 penalty was a false-positive blocking security-route PRs from reaching \`confidence:high\`
- Source files are **still fully scanned** — only test/fixture paths are excluded from the secrets check
- URL scanning uses the full diff (unchanged)

**Root cause:** PRs #199 (tokens route) and #166 scored medium purely due to mock token strings in test files triggering the scorer's \`HARDCODED_KEYS\` regex, applying a flat -20 penalty regardless of context.

**Verified:**
- \`bash -n\` syntax check passes
- Source-file secrets (real API keys in \`config.ts\`) still detected: ✓
- Test-file mock tokens excluded from penalty: ✓

## Test plan
- [ ] \`bash -n scripts/pr-confidence-score.sh\` — syntax clean
- [ ] This PR itself scores \`confidence:high\` (small focused change, no secrets, no TODOs)
- [ ] After merge, PRs #199 and #166 should re-score ≥80 on next CI run