### PR TITLE
feat: extract workflow-routes-helpers module (PR22b — types + pure logic)

### DIFF
--- a/src/workflow-routes-helpers.test.ts
+++ b/src/workflow-routes-helpers.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSafeLinearUrl,
+  evictStaleWorkflows,
+  isValidGithubPat,
+  isValidLinearApiKey,
+  MAX_STORED_WORKFLOWS,
+  MAX_WORKFLOWS,
+  parseLinearUrl,
+  RUNNING_WALL_CLOCK_TIMEOUT_MS,
+} from "./workflow-routes-helpers";
+
+describe("constants", () => {
+  it("MAX_WORKFLOWS is 5", () => {
+    expect(MAX_WORKFLOWS).toBe(5);
+  });
+
+  it("MAX_STORED_WORKFLOWS is 50", () => {
+    expect(MAX_STORED_WORKFLOWS).toBe(50);
+  });
+
+  it("RUNNING_WALL_CLOCK_TIMEOUT_MS is 1 hour", () => {
+    expect(RUNNING_WALL_CLOCK_TIMEOUT_MS).toBe(60 * 60_000);
+  });
+});
+
+describe("isValidLinearApiKey", () => {
+  it("accepts valid lin_api_ key with 32+ chars", () => {
+    expect(isValidLinearApiKey("lin_api_" + "a".repeat(32))).toBe(true);
+  });
+
+  it("rejects key missing lin_api_ prefix", () => {
+    expect(isValidLinearApiKey("not_linear_" + "a".repeat(32))).toBe(false);
+  });
+
+  it("rejects key with fewer than 32 chars after prefix", () => {
+    expect(isValidLinearApiKey("lin_api_short")).toBe(false);
+  });
+
+  it("accepts key with underscores and digits after prefix", () => {
+    expect(isValidLinearApiKey("lin_api_abc123_DEF456_" + "x".repeat(18))).toBe(true);
+  });
+});
+
+describe("isValidGithubPat", () => {
+  it("accepts classic PAT with ghp_ prefix (36+ chars)", () => {
+    expect(isValidGithubPat("ghp_" + "a".repeat(36))).toBe(true);
+  });
+
+  it("accepts fine-grained PAT with github_pat_ prefix", () => {
+    expect(isValidGithubPat("github_pat_" + "a".repeat(40))).toBe(true);
+  });
+
+  it("accepts legacy 40-char hex PAT", () => {
+    expect(isValidGithubPat("a".repeat(40))).toBe(true);
+  });
+
+  it("rejects short token", () => {
+    expect(isValidGithubPat("ghp_short")).toBe(false);
+  });
+
+  it("rejects random string", () => {
+    expect(isValidGithubPat("not-a-pat")).toBe(false);
+  });
+});
+
+describe("parseLinearUrl", () => {
+  it("parses issue URL", () => {
+    const result = parseLinearUrl("https://linear.app/myteam/issue/TEAM-123");
+    expect(result).not.toBeNull();
+    expect(result?.entityType).toBe("issue");
+    expect(result?.entityId).toBe("TEAM-123");
+    expect(result?.workspace).toBe("myteam");
+    expect(result?.team).toBe("TEAM");
+  });
+
+  it("parses project URL", () => {
+    const result = parseLinearUrl("https://linear.app/myteam/project/my-project-slug");
+    expect(result?.entityType).toBe("project");
+    expect(result?.entityId).toBe("my-project-slug");
+  });
+
+  it("parses cycle URL", () => {
+    const result = parseLinearUrl("https://linear.app/myteam/cycle/abc-123");
+    expect(result?.entityType).toBe("cycle");
+  });
+
+  it("parses view URL", () => {
+    const result = parseLinearUrl("https://linear.app/myteam/view/view-id");
+    expect(result?.entityType).toBe("view");
+  });
+
+  it("returns null for non-Linear URL", () => {
+    expect(parseLinearUrl("https://github.com/org/repo")).toBeNull();
+  });
+
+  it("returns null for spoofed linear.app domain", () => {
+    expect(parseLinearUrl("https://evil-linear.app/myteam/issue/TEAM-1")).toBeNull();
+  });
+});
+
+describe("buildSafeLinearUrl", () => {
+  it("reconstructs issue URL", () => {
+    const url = buildSafeLinearUrl({ workspace: "ws", entityType: "issue", entityId: "ENG-42" });
+    expect(url).toBe("https://linear.app/ws/issue/ENG-42");
+  });
+
+  it("reconstructs project URL", () => {
+    const url = buildSafeLinearUrl({ workspace: "ws", entityType: "project", entityId: "proj-slug" });
+    expect(url).toBe("https://linear.app/ws/project/proj-slug");
+  });
+});
+
+describe("evictStaleWorkflows", () => {
+  function makeWorkflow(id: string, status: string, createdAt: string) {
+    return {
+      id,
+      linearUrl: "https://linear.app/w/issue/T-1",
+      repository: "org/repo",
+      status: status as "completed",
+      agents: [],
+      createdAt,
+      updatedAt: createdAt,
+    };
+  }
+
+  it("does not evict when under limit", () => {
+    const workflows = new Map();
+    workflows.set("a", makeWorkflow("a", "completed", "2026-01-01T00:00:00Z"));
+    evictStaleWorkflows(workflows);
+    expect(workflows.size).toBe(1);
+  });
+
+  it("evicts oldest terminal workflows when over MAX_STORED_WORKFLOWS", () => {
+    const workflows = new Map();
+    for (let i = 0; i <= MAX_STORED_WORKFLOWS; i++) {
+      const date = new Date(2026, 0, i + 1).toISOString();
+      workflows.set(`wf-${i}`, makeWorkflow(`wf-${i}`, "completed", date));
+    }
+    expect(workflows.size).toBe(MAX_STORED_WORKFLOWS + 1);
+    evictStaleWorkflows(workflows);
+    expect(workflows.size).toBe(MAX_STORED_WORKFLOWS);
+    // Oldest (wf-0) should be evicted
+    expect(workflows.has("wf-0")).toBe(false);
+  });
+
+  it("does not evict running workflows", () => {
+    const workflows = new Map();
+    for (let i = 0; i <= MAX_STORED_WORKFLOWS; i++) {
+      const date = new Date(2026, 0, i + 1).toISOString();
+      workflows.set(`wf-${i}`, makeWorkflow(`wf-${i}`, "running", date));
+    }
+    const sizeBefore = workflows.size;
+    evictStaleWorkflows(workflows);
+    expect(workflows.size).toBe(sizeBefore); // nothing evicted — all running
+  });
+});

--- a/src/workflow-routes-helpers.ts
+++ b/src/workflow-routes-helpers.ts
@@ -1,0 +1,121 @@
+import type { GradeResult } from "./grading";
+
+/**
+ * Shared types, constants, and pure helpers for the engine-backed workflow routes.
+ * Extracted from routes/workflows.ts to keep the route file ≤400 lines.
+ */
+
+export interface LinearWorkflow {
+  id: string;
+  linearUrl: string;
+  repository: string;
+  status:
+    | "validating"
+    | "rejected"
+    | "starting"
+    | "running"
+    | "awaiting_confirm"
+    | "grading"
+    | "needs_human"
+    | "completed"
+    | "failed"
+    | "cancelled";
+  agents: Array<{ id: string; name: string; role: string }>;
+  hasCredentials?: boolean;
+  metadata?: Record<string, unknown>;
+  prUrl?: string;
+  error?: string;
+  costEstimate?: number;
+  triageAgentId?: string;
+  graderAgentId?: string;
+  validation?: {
+    verdict: "accept" | "accept_with_caveats" | "reject";
+    clarity: "high" | "medium" | "low";
+    missing: string[];
+    suggestions: string[];
+    readError?: "not_found" | "forbidden" | "auth_failed" | "rate_limited" | "multi_issue_empty";
+    evaluatedAt: string;
+  };
+  grade?: GradeResult;
+  confidence?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Max concurrent active workflows */
+export const MAX_WORKFLOWS = 5;
+
+/** Max total stored workflows (evict oldest terminal workflows beyond this) */
+export const MAX_STORED_WORKFLOWS = 50;
+
+/** Wall-clock terminal timeout — prevents a hung manager from pinning a slot forever. */
+export const RUNNING_WALL_CLOCK_TIMEOUT_MS = 60 * 60_000;
+
+/** Supported Linear entity types */
+export type LinearEntityType = "issue" | "project" | "cycle" | "view";
+
+export interface ParsedLinearUrl {
+  workspace: string;
+  entityType: LinearEntityType;
+  entityId: string;
+  team?: string;
+}
+
+/** Validate a Linear API key format (lin_api_ prefix, min 32 chars after prefix). */
+export function isValidLinearApiKey(key: string): boolean {
+  return /^lin_api_[A-Za-z0-9_]{32,}$/.test(key);
+}
+
+/** Validate a GitHub PAT format (classic ghp_, fine-grained github_pat_, or legacy 40-char hex). */
+export function isValidGithubPat(pat: string): boolean {
+  return /^(ghp_[A-Za-z0-9]{36,}|ghs_[A-Za-z0-9]{36,}|gho_[A-Za-z0-9]{36,}|github_pat_[A-Za-z0-9_]{40,}|[a-f0-9]{40})$/.test(
+    pat,
+  );
+}
+
+/**
+ * Parse a broad set of Linear URLs — issues, projects, cycles, views.
+ * Anchored to https://linear.app to prevent spoofed domains.
+ */
+export function parseLinearUrl(url: string): ParsedLinearUrl | null {
+  const issueMatch = url.match(/^https:\/\/linear\.app\/([\w-]+)\/issue\/([\w]+-\d+)/);
+  if (issueMatch) {
+    const workspace = issueMatch[1];
+    const entityId = issueMatch[2];
+    return { workspace, entityType: "issue", entityId, team: entityId.split("-")[0] };
+  }
+
+  const projectMatch = url.match(/^https:\/\/linear\.app\/([\w-]+)\/project\/([\w-]+)/);
+  if (projectMatch) {
+    return { workspace: projectMatch[1], entityType: "project", entityId: projectMatch[2] };
+  }
+
+  const cycleMatch = url.match(/^https:\/\/linear\.app\/([\w-]+)\/cycle\/([\w-]+)/);
+  if (cycleMatch) {
+    return { workspace: cycleMatch[1], entityType: "cycle", entityId: cycleMatch[2] };
+  }
+
+  const viewMatch = url.match(/^https:\/\/linear\.app\/([\w-]+)\/view\/([\w-]+)/);
+  if (viewMatch) {
+    return { workspace: viewMatch[1], entityType: "view", entityId: viewMatch[2] };
+  }
+
+  return null;
+}
+
+/** Reconstruct a clean Linear URL from parsed components (prevents prompt injection via URL). */
+export function buildSafeLinearUrl(parsed: ParsedLinearUrl): string {
+  return `https://linear.app/${parsed.workspace}/${parsed.entityType}/${parsed.entityId}`;
+}
+
+/** Evict oldest terminal workflows when the store exceeds MAX_STORED_WORKFLOWS. */
+export function evictStaleWorkflows(workflows: Map<string, LinearWorkflow>): void {
+  if (workflows.size <= MAX_STORED_WORKFLOWS) return;
+  const terminal = Array.from(workflows.entries())
+    .filter(([, w]) => w.status === "completed" || w.status === "failed" || w.status === "cancelled")
+    .sort((a, b) => new Date(a[1].createdAt).getTime() - new Date(b[1].createdAt).getTime());
+  while (workflows.size > MAX_STORED_WORKFLOWS && terminal.length > 0) {
+    const oldest = terminal.shift();
+    if (oldest) workflows.delete(oldest[0]);
+  }
+}


### PR DESCRIPTION
## Summary

Extracts pure types, constants, and helper functions from the engine-backed workflow routes into a standalone module:

- **src/workflow-routes-helpers.ts** (121L): `LinearWorkflow` interface, `ParsedLinearUrl` interface, constants (`MAX_WORKFLOWS`, `MAX_STORED_WORKFLOWS`, `RUNNING_WALL_CLOCK_TIMEOUT_MS`), pure functions (`isValidLinearApiKey`, `isValidGithubPat`, `parseLinearUrl`, `buildSafeLinearUrl`, `evictStaleWorkflows`)
- **src/workflow-routes-helpers.test.ts** (157L): 23 tests covering all exports

Part of PR #167 split series. This module is imported by PR22c (engine-backed routes/workflows.ts).

## Dependencies
- None beyond existing AM modules

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` 703 tests pass (48 files)
- [x] `npx biome check .` clean