### PR TITLE
fix: add per-line biome-ignore for noExplicitAny in event-pipeline-wiring.test.ts

### DIFF
--- a/src/event-pipeline-wiring.test.ts
+++ b/src/event-pipeline-wiring.test.ts
@@ -2,9 +2,10 @@
 import { EventPipeline } from "./event-pipeline";
 // Smoke: EventPipeline is constructible and exposes required public methods.
 describe("EventPipeline smoke", () => {
-  // biome-ignore lint/suspicious/noExplicitAny: test stub
   const ep = new EventPipeline(
+    // biome-ignore lint/suspicious/noExplicitAny: test stub
     { get: () => undefined } as any,
+    // biome-ignore lint/suspicious/noExplicitAny: test stub
     { upsertCostTracker: () => {} } as any,
     new Map(),
     () => {},


### PR DESCRIPTION
Fixes biome lint errors in src/event-pipeline-wiring.test.ts blocking CI on every PR. The existing biome-ignore comment was only suppressing one line; added per-line suppression for both `as any` instances.