### PR TITLE
fix: organize imports in event-pipeline-wiring.test.ts

### DIFF
--- a/src/event-pipeline-wiring.test.ts
+++ b/src/event-pipeline-wiring.test.ts
@@ -1,5 +1,6 @@
 /// <reference types="vitest/globals" />
 import { EventPipeline } from "./event-pipeline";
+
 // Smoke: EventPipeline is constructible and exposes required public methods.
 describe("EventPipeline smoke", () => {
   const ep = new EventPipeline(


### PR DESCRIPTION
Fixes organizeImports lint error in event-pipeline-wiring.test.ts that is blocking CI Lint on every PR.