### PR TITLE
feat(agents): extract ProcessManager + consume in agents.ts (Phase E PR27)

### DIFF
--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -197,9 +197,11 @@ describe("skip-permissions lifecycle", () => {
   ): string[] {
     return (
       manager as unknown as {
-        buildClaudeArgs: (opts: Record<string, unknown>, model: string, resumeSessionId?: string) => string[];
+        processManager: {
+          buildClaudeArgs: (opts: Record<string, unknown>, model: string, resumeSessionId?: string) => string[];
+        };
       }
-    ).buildClaudeArgs(opts, model, resumeSessionId);
+    ).processManager.buildClaudeArgs(opts, model, resumeSessionId);
   }
 
   function injectAgent(agentProc: AgentProcess): void {
@@ -219,9 +221,9 @@ describe("skip-permissions lifecycle", () => {
       expect(args).not.toContain("--dangerously-skip-permissions");
     });
 
-    it("omits --dangerously-skip-permissions when flag is undefined", () => {
+    it("includes --dangerously-skip-permissions when flag is undefined (default: headless agents need it)", () => {
       const args = buildClaudeArgs({ prompt: "hello" }, "claude-sonnet-4-6");
-      expect(args).not.toContain("--dangerously-skip-permissions");
+      expect(args).toContain("--dangerously-skip-permissions");
     });
 
     it("includes --resume when resumeSessionId is provided", () => {
@@ -292,7 +294,8 @@ describe("skip-permissions lifecycle", () => {
       injectAgent(agentProc);
 
       const buildSpy = vi.spyOn(
-        manager as unknown as { buildClaudeArgs: (...args: unknown[]) => string[] },
+        (manager as unknown as { processManager: { buildClaudeArgs: (...args: unknown[]) => string[] } })
+          .processManager,
         "buildClaudeArgs",
       );
 
@@ -335,7 +338,8 @@ describe("skip-permissions lifecycle", () => {
       injectAgent(agentProc);
 
       const buildSpy = vi.spyOn(
-        manager as unknown as { buildClaudeArgs: (...args: unknown[]) => string[] },
+        (manager as unknown as { processManager: { buildClaudeArgs: (...args: unknown[]) => string[] } })
+          .processManager,
         "buildClaudeArgs",
       );
 
@@ -373,7 +377,8 @@ describe("skip-permissions lifecycle", () => {
       injectAgent(agentProc);
 
       const buildSpy = vi.spyOn(
-        manager as unknown as { buildClaudeArgs: (...args: unknown[]) => string[] },
+        (manager as unknown as { processManager: { buildClaudeArgs: (...args: unknown[]) => string[] } })
+          .processManager,
         "buildClaudeArgs",
       );
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -1,4 +1,4 @@
-import { execFile, execFileSync, spawn } from "node:child_process";
+import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { readdir, rm, unlink } from "node:fs/promises";
 import path from "node:path";
@@ -17,9 +17,10 @@ import { ALLOWED_MODELS, MAX_AGENT_DEPTH, MAX_AGENTS, MAX_CHILDREN_PER_AGENT, SE
 import { logger } from "./logger";
 import { DEFAULT_MODEL } from "./models";
 import { EVENTS_DIR, loadAllAgentStates, removeAgentState, saveAgentState, writeTombstone } from "./persistence";
+import { cleanupAllProcesses, killProcessGroup, ProcessManager } from "./process-manager";
 import { getRepoCredentialsForAgents, writeGitCredentialsFile } from "./repo-credentials";
 import { StateNotifier } from "./state-notifier";
-import { cleanupAgentClaudeData, debouncedSyncToGCS } from "./storage";
+import { cleanupAgentClaudeData } from "./storage";
 import type {
   Agent,
   AgentMetadata,
@@ -85,85 +86,6 @@ async function getGitInfo(
   }
 
   return result;
-}
-
-/** Harmless stderr noise from Claude CLI startup that should not surface as errors. */
-const STDERR_NOISE_RE = /apiKeyHelper did not return a valid value|Error getting API key from apiKeyHelper/;
-
-/** Kill a process group (SIGTERM), escalating to SIGKILL after a timeout.
- *  Uses negative PID to signal the entire process group. */
-function killProcessGroup(proc: ReturnType<typeof spawn>, timeoutMs = 5000): void {
-  if (proc.killed || proc.pid == null) return;
-  try {
-    process.kill(-proc.pid, "SIGTERM");
-  } catch {
-    // Process group already gone
-    return;
-  }
-  const escalation = setTimeout(() => {
-    try {
-      if (proc.pid) process.kill(-proc.pid, "SIGKILL");
-    } catch {
-      // Already dead
-    }
-  }, timeoutMs);
-  // Don't let this timer keep the event loop alive
-  escalation.unref();
-}
-
-/**
- * Kill ALL non-init, non-server processes.
- * Used by emergencyDestroyAll() to catch bash/node/curl/git spawned by agents
- * that aren't tracked in our process map. Only kills descendants of agentRootPids
- * (and the roots themselves), not unrelated system processes.
- */
-function cleanupAllProcesses(agentRootPids: number[]): void {
-  if (agentRootPids.length === 0) return;
-  try {
-    const myPid = process.pid;
-    const output = execFileSync("ps", ["-eo", "pid,ppid,comm"], {
-      encoding: "utf-8",
-      timeout: 5_000,
-    });
-    const rootSet = new Set(agentRootPids.filter((p) => p > 0));
-    const pidToPpid = new Map<number, number>();
-    for (const line of output.split("\n")) {
-      const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
-      if (!match) continue;
-      const [, pidStr, ppidStr] = match;
-      const pid = Number.parseInt(pidStr, 10);
-      const ppid = Number.parseInt(ppidStr, 10);
-      if (pid === 1 || pid === myPid) continue;
-      pidToPpid.set(pid, ppid);
-    }
-    // Collect all descendant PIDs (BFS from roots)
-    const toKill = new Set<number>(rootSet);
-    let frontier = [...rootSet];
-    while (frontier.length > 0) {
-      const next: number[] = [];
-      for (const pid of frontier) {
-        for (const [cpid, ppid] of pidToPpid) {
-          if (ppid === pid) next.push(cpid);
-        }
-      }
-      for (const p of next) toKill.add(p);
-      frontier = next;
-    }
-    let killed = 0;
-    for (const pid of toKill) {
-      try {
-        process.kill(pid, "SIGKILL");
-        killed++;
-      } catch {
-        // Already dead or no permission - skip
-      }
-    }
-    if (killed > 0) {
-      logger.info(`[kill-switch] cleanupAllProcesses: killed ${killed} process(es)`);
-    }
-  } catch {
-    // ps not available - skip
-  }
 }
 
 const NAME_STOP_WORDS = new Set([
@@ -275,6 +197,7 @@ export class AgentManager {
   private costTracker: CostTracker | null = null;
   private usageTracker: UsageTracker;
   private pipeline: EventPipeline;
+  private processManager: ProcessManager;
   /** Workspace management (directories, symlinks, tokens, env). */
   private workspace = new WorkspaceManager();
 
@@ -285,6 +208,13 @@ export class AgentManager {
     this.pipeline = new EventPipeline(this.agents, this.usageTracker, this.writeQueues, (id, agent, immediate) =>
       this.notifier.scheduleAgentUpdated(id, agent, immediate),
     );
+    this.processManager = new ProcessManager(this.agents, this.pipeline, {
+      onAgentUpdated: (id, agent, immediate) => this.notifier.scheduleAgentUpdated(id, agent, immediate),
+      onIdle: (id) => this.notifyIdleListeners(id),
+      onEphemeralIdle: (_id) => {
+        // ephemeral auto-destroy wired in PR28 (ephemeral-cleanup.ts)
+      },
+    });
     this.workspace.setAgentListProvider(this);
     // Cleanup idle agents every 60s
     this.cleanupInterval = setInterval(() => this.cleanupExpired(), 60_000);
@@ -444,19 +374,12 @@ export class AgentManager {
       attachmentNames = names;
     }
 
-    const args = this.buildClaudeArgs({ ...opts, prompt: finalPrompt }, model);
+    const args = this.processManager.buildClaudeArgs({ ...opts, prompt: finalPrompt }, model);
     const env = this.workspace.buildEnv(id, workspaceDir);
-
-    const proc = spawn("claude", args, {
-      env,
-      cwd: workspaceDir,
-      stdio: ["ignore", "pipe", "pipe"],
-      detached: true,
-    });
 
     const agentProc: AgentProcess = {
       agent,
-      proc,
+      proc: null,
       lineBuffer: "",
       listeners: new Set(),
       seenMessageIds: new Set(),
@@ -482,7 +405,8 @@ export class AgentManager {
       attachmentNames: attachmentNames.length > 0 ? attachmentNames : undefined,
     });
 
-    this.attachProcessHandlers(id, agentProc, proc);
+    const proc = this.processManager.spawnProcess(id, agentProc, args, env, workspaceDir);
+    agentProc.proc = proc;
 
     // Update status to running once we get first output
     proc.stdout?.once("data", () => {
@@ -559,7 +483,7 @@ export class AgentManager {
     const resumeId = targetSessionId || agentProc.agent.claudeSessionId || undefined;
 
     const model = agentProc.agent.model;
-    const args = this.buildClaudeArgs(
+    const args = this.processManager.buildClaudeArgs(
       {
         prompt,
         maxTurns,
@@ -575,7 +499,7 @@ export class AgentManager {
     // This prevents event interleaving from the old process's close handler
     // firing after the new process has already started.
     const oldProc = agentProc.proc;
-    const killOld: Promise<void> = oldProc ? this.killAndWait(oldProc, agentProc, id) : Promise.resolve();
+    const killOld: Promise<void> = oldProc ? this.processManager.killAndWait(oldProc, agentProc) : Promise.resolve();
 
     agentProc.lineBuffer = "";
 
@@ -600,19 +524,12 @@ export class AgentManager {
         const ap = this.agents.get(id);
         if (!ap) return;
 
-        const proc = spawn("claude", args, {
-          env,
-          cwd: ap.agent.workspaceDir,
-          stdio: ["ignore", "pipe", "pipe"],
-          detached: true,
-        });
+        const proc = this.processManager.spawnProcess(id, ap, args, env, ap.agent.workspaceDir);
 
         ap.proc = proc;
         ap.agent.status = "running";
         ap.agent.lastActivity = nowISO();
         saveAgentState(ap.agent);
-
-        this.attachProcessHandlers(id, ap, proc);
       });
     const lockPromise = spawnAfterKill.catch((err) => {
       logger.error("[agents] Error spawning agent", { agentId: id, error: errorMessage(err) });
@@ -642,34 +559,6 @@ export class AgentManager {
     };
 
     return { agent: agentProc.agent, subscribe };
-  }
-
-  /** Kill a process and wait for it to fully exit. Sets transitional 'killing' state. */
-  private killAndWait(proc: ReturnType<typeof spawn>, agentProc: AgentProcess, _agentId: string): Promise<void> {
-    return new Promise<void>((resolve) => {
-      // Detach old handlers so close doesn't trigger idle/state transitions
-      proc.stdout?.removeAllListeners();
-      proc.stderr?.removeAllListeners();
-      proc.removeAllListeners("close");
-
-      if (proc.killed || proc.exitCode !== null) {
-        resolve();
-        return;
-      }
-
-      agentProc.agent.status = "killing";
-
-      proc.once("close", () => {
-        resolve();
-      });
-
-      // Use process group kill (SIGTERM then SIGKILL escalation) from killProcessGroup
-      killProcessGroup(proc);
-
-      // Safety timeout - resolve even if close never fires
-      const safety = setTimeout(() => resolve(), 6_000);
-      safety.unref();
-    });
   }
 
   list(): Agent[] {
@@ -1204,117 +1093,6 @@ export class AgentManager {
     return dirs;
   }
 
-  /** Attach stdout/stderr/close handlers to a spawned process.
-   *  Uses batched line processing (WI-1) to prevent event loop saturation
-   *  when many agents produce output simultaneously. */
-  private attachProcessHandlers(id: string, agentProc: AgentProcess, proc: ReturnType<typeof spawn>): void {
-    proc.stdout?.on("data", (chunk: Buffer) => {
-      agentProc.lineBuffer += chunk.toString();
-
-      // Backpressure: pause stdout if lineBuffer exceeds 1 MB to prevent
-      // unbounded memory growth when agents produce output faster than we parse
-      if (agentProc.lineBuffer.length > 1_048_576 && proc.stdout) {
-        proc.stdout.pause();
-      }
-
-      // Schedule batch processing on next tick instead of processing synchronously
-      // in the data handler. This yields the event loop between data chunks so
-      // SSE heartbeats and API responses can be served.
-      if (!agentProc.processingScheduled) {
-        agentProc.processingScheduled = true;
-        setImmediate(() => this.processLineBuffer(id, agentProc, proc));
-      }
-    });
-
-    proc.stderr?.on("data", (d: Buffer) => {
-      const text = d.toString();
-      if (STDERR_NOISE_RE.test(text)) return;
-      this.handleEvent(id, { type: "stderr", text });
-    });
-
-    proc.on("close", (code) => {
-      // Flush any remaining data in the line buffer (e.g. final result event
-      // from the CLI that may not have a trailing newline)
-      if (agentProc.lineBuffer.trim()) {
-        try {
-          const event = JSON.parse(agentProc.lineBuffer) as StreamEvent;
-          this.handleEvent(id, event);
-        } catch {
-          this.handleEvent(id, { type: "raw", text: agentProc.lineBuffer });
-        }
-        agentProc.lineBuffer = "";
-      }
-
-      this.handleEvent(id, { type: "done", exitCode: code ?? undefined });
-
-      // Flush any pending batches immediately on close - listeners need
-      // to see events (especially "done") before state transitions happen
-      this.flushEventBatch(id, agentProc);
-
-      const ap = this.agents.get(id);
-      if (ap) {
-        ap.agent.status = code === 0 ? "idle" : "error";
-        ap.agent.lastActivity = nowISO();
-        saveAgentState(ap.agent);
-      }
-      debouncedSyncToGCS().catch((err) => {
-        logger.error("[agents] Failed to sync GCS after agent exit", { agentId: id, error: errorMessage(err) });
-      });
-
-      // Notify idle listeners so queued messages can be delivered
-      if (code === 0) {
-        this.notifyIdleListeners(id);
-      }
-    });
-  }
-
-  /** Process buffered stdout lines in batches of 50, yielding to the event
-   *  loop between batches via setImmediate. This prevents a burst of output
-   *  from one agent from starving SSE heartbeats and API requests. */
-  private processLineBuffer(id: string, agentProc: AgentProcess, proc: ReturnType<typeof spawn>): void {
-    agentProc.processingScheduled = false;
-
-    // Agent may have been destroyed while processing was queued via setImmediate
-    if (!this.agents.has(id)) return;
-
-    const lines = agentProc.lineBuffer.split("\n");
-    agentProc.lineBuffer = lines.pop() || "";
-
-    const BATCH_SIZE = 50;
-    let offset = 0;
-
-    const processBatch = () => {
-      // Agent may have been destroyed while processing was queued
-      if (!this.agents.has(id)) return;
-
-      const end = Math.min(offset + BATCH_SIZE, lines.length);
-      for (let i = offset; i < end; i++) {
-        const line = lines[i];
-        if (!line.trim()) continue;
-        try {
-          const event = JSON.parse(line) as StreamEvent;
-          this.handleEvent(id, event);
-        } catch {
-          this.handleEvent(id, { type: "raw", text: line });
-        }
-      }
-
-      offset = end;
-
-      if (offset < lines.length) {
-        // More lines to process - yield to event loop then continue
-        setImmediate(processBatch);
-      } else {
-        // Done processing - resume stdout if paused due to backpressure
-        if (proc.stdout?.isPaused?.()) {
-          proc.stdout.resume();
-        }
-      }
-    };
-
-    processBatch();
-  }
-
   /** Handle a single event: extract metadata immediately, batch persistence
    *  and listener notification. Metadata (session_id, usage) is processed
    *  synchronously since it affects agent state. Disk writes and listener
@@ -1473,27 +1251,6 @@ export class AgentManager {
       saveAgentState(agentProc.agent);
     }
     this.pipeline.truncateEventFiles(this.agents.keys());
-  }
-
-  private buildClaudeArgs(opts: CreateAgentRequest, model: string, resumeSessionId?: string): string[] {
-    const args: string[] = [];
-    if (opts.dangerouslySkipPermissions) {
-      args.push("--dangerously-skip-permissions");
-    }
-    args.push(
-      "--output-format",
-      "stream-json",
-      "--verbose",
-      "--max-turns",
-      String(opts.maxTurns ?? 200),
-      "--model",
-      model,
-    );
-    if (resumeSessionId) {
-      args.push("--resume", resumeSessionId);
-    }
-    args.push("--print", "--", opts.prompt);
-    return args;
   }
 
   /** Save attachments to the agent workspace.

--- a/src/process-manager.test.ts
+++ b/src/process-manager.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { capOversizedToolResults, cleanupAllProcesses, killProcessGroup, ProcessManager } from "./process-manager";
+
+// ---------------------------------------------------------------------------
+// capOversizedToolResults
+// ---------------------------------------------------------------------------
+describe("capOversizedToolResults", () => {
+  it("returns event unchanged when no message property", () => {
+    const event = { type: "user_prompt", text: "hello" };
+    const result = capOversizedToolResults("agent-1", event, 100);
+    expect(result).toBe(event);
+  });
+
+  it("returns event unchanged when message has no content", () => {
+    const event = { type: "assistant", message: { role: "assistant" } };
+    const result = capOversizedToolResults("agent-1", event, 100);
+    expect(result).toBe(event);
+  });
+
+  it("returns event unchanged when content is not an array", () => {
+    const event = { type: "assistant", message: { content: "text" } };
+    const result = capOversizedToolResults("agent-1", event, 100);
+    expect(result).toBe(event);
+  });
+
+  it("passes through tool_result blocks under the size limit", () => {
+    const smallBody = "x".repeat(50);
+    const event = {
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_result", content: smallBody }],
+      },
+    };
+    capOversizedToolResults("agent-1", event, 100);
+    expect((event.message.content[0] as { content: string }).content).toBe(smallBody);
+  });
+
+  it("elides tool_result body that exceeds the byte limit", () => {
+    const bigBody = "x".repeat(200);
+    const event = {
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_result", content: bigBody }],
+      },
+    };
+    capOversizedToolResults("agent-1", event, 100);
+    const replaced = (event.message.content[0] as { content: string }).content;
+    expect(replaced).toContain("bytes elided");
+    expect(replaced).not.toBe(bigBody);
+  });
+
+  it("handles tool_result content as array of text parts", () => {
+    const bigText = "y".repeat(200);
+    const event = {
+      type: "assistant",
+      message: {
+        content: [{ type: "tool_result", content: [{ type: "text", text: bigText }] }],
+      },
+    };
+    capOversizedToolResults("agent-1", event, 100);
+    const replaced = (event.message.content[0] as { content: unknown }).content;
+    expect(typeof replaced).toBe("string");
+    expect(replaced as string).toContain("bytes elided");
+  });
+
+  it("skips non-tool_result blocks", () => {
+    const event = {
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "plain text" }],
+      },
+    };
+    const original = JSON.stringify(event);
+    capOversizedToolResults("agent-1", event, 10);
+    expect(JSON.stringify(event)).toBe(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// killProcessGroup
+// ---------------------------------------------------------------------------
+describe("killProcessGroup", () => {
+  it("is a no-op when proc is already killed", () => {
+    const proc = { killed: true, pid: 42 } as Parameters<typeof killProcessGroup>[0];
+    expect(() => killProcessGroup(proc)).not.toThrow();
+  });
+
+  it("is a no-op when proc has no pid", () => {
+    const proc = { killed: false, pid: undefined } as Parameters<typeof killProcessGroup>[0];
+    expect(() => killProcessGroup(proc)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanupAllProcesses
+// ---------------------------------------------------------------------------
+describe("cleanupAllProcesses", () => {
+  it("returns immediately with empty pids array", () => {
+    expect(() => cleanupAllProcesses([])).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ProcessManager.buildClaudeArgs
+// ---------------------------------------------------------------------------
+describe("ProcessManager.buildClaudeArgs", () => {
+  const pm = new ProcessManager(
+    new Map() as Parameters<typeof ProcessManager>[0],
+    {} as Parameters<typeof ProcessManager>[1],
+    { onAgentUpdated: () => {}, onIdle: () => {}, onEphemeralIdle: () => {} },
+  );
+
+  it("includes --dangerously-skip-permissions by default (headless agents)", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hello" }, "claude-sonnet-4-6");
+    expect(args).toContain("--dangerously-skip-permissions");
+  });
+
+  it("includes --dangerously-skip-permissions when flag is true", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hi", dangerouslySkipPermissions: true }, "claude-sonnet-4-6");
+    expect(args).toContain("--dangerously-skip-permissions");
+  });
+
+  it("omits --dangerously-skip-permissions when flag is explicitly false", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hi", dangerouslySkipPermissions: false }, "claude-sonnet-4-6");
+    expect(args).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("uses --permission-mode instead when permissionMode is set", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hi", permissionMode: "plan" }, "claude-sonnet-4-6");
+    expect(args).toContain("--permission-mode");
+    expect(args[args.indexOf("--permission-mode") + 1]).toBe("plan");
+    expect(args).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("includes --include-partial-messages", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hi" }, "claude-sonnet-4-6");
+    expect(args).toContain("--include-partial-messages");
+  });
+
+  it("includes --model", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hi" }, "claude-opus-4-8");
+    expect(args).toContain("--model");
+    expect(args[args.indexOf("--model") + 1]).toBe("claude-opus-4-8");
+  });
+
+  it("includes --max-turns with default 200", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hi" }, "claude-sonnet-4-6");
+    expect(args).toContain("--max-turns");
+    expect(args[args.indexOf("--max-turns") + 1]).toBe("200");
+  });
+
+  it("includes --max-turns with custom value", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hi", maxTurns: 50 }, "claude-sonnet-4-6");
+    expect(args[args.indexOf("--max-turns") + 1]).toBe("50");
+  });
+
+  it("includes --resume when resumeSessionId provided", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hi" }, "claude-sonnet-4-6", "session-abc");
+    expect(args).toContain("--resume");
+    expect(args[args.indexOf("--resume") + 1]).toBe("session-abc");
+  });
+
+  it("includes --effort when set", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hi", effort: "high" }, "claude-sonnet-4-6");
+    expect(args).toContain("--effort");
+    expect(args[args.indexOf("--effort") + 1]).toBe("high");
+  });
+
+  it("includes --allowedTools when set", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hi", allowedTools: ["Bash", "Read"] }, "claude-sonnet-4-6");
+    expect(args).toContain("--allowedTools");
+  });
+
+  it("includes --max-budget-usd when set", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hi", maxBudgetUsd: 0.5 }, "claude-sonnet-4-6");
+    expect(args).toContain("--max-budget-usd");
+    expect(args[args.indexOf("--max-budget-usd") + 1]).toBe("0.5");
+  });
+
+  it("uses --fork-session when forkSessionId is set", () => {
+    const args = pm.buildClaudeArgs({ prompt: "hi", forkSessionId: "fork-abc" }, "claude-sonnet-4-6");
+    expect(args).toContain("--fork-session");
+    expect(args).toContain("--resume");
+    expect(args[args.indexOf("--resume") + 1]).toBe("fork-abc");
+  });
+
+  it("ends with --print -- prompt", () => {
+    const args = pm.buildClaudeArgs({ prompt: "my task" }, "claude-sonnet-4-6");
+    expect(args[args.length - 1]).toBe("my task");
+    expect(args[args.length - 2]).toBe("--");
+    expect(args[args.length - 3]).toBe("--print");
+  });
+});

--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -1,0 +1,476 @@
+/**
+ * ProcessManager — handles child process lifecycle: spawn, termination,
+ * stdin/stdout/stderr stream handling, CLI argument construction, and
+ * settings.json generation for Claude CLI hooks.
+ *
+ * Extracted from src/agents.ts (Phase E PR27).
+ * Receives a shared AgentRegistry, EventPipeline, and callbacks via constructor.
+ */
+
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { generateServiceToken } from "./auth";
+import { CONFIG } from "./config";
+import type { EventPipeline } from "./event-pipeline";
+import { buildSettingsJson } from "./hook-config-store";
+import { logger } from "./logger";
+import { EVENTS_DIR, saveAgentState } from "./persistence";
+import { debouncedSyncToGCS } from "./storage";
+import type { AgentProcess, CreateAgentRequest, StreamEvent } from "./types";
+import { errorMessage } from "./types";
+import type { AgentRegistry } from "./usage-tracker";
+
+/** Harmless stderr noise from Claude CLI startup that should not surface as errors. */
+const STDERR_NOISE_RE = /apiKeyHelper did not return a valid value|Error getting API key from apiKeyHelper/;
+
+/** Directory where full bytes of elided tool_result bodies are spilled so they
+ *  remain retrievable by `ref` after the transcript copy is stubbed. */
+const TOOL_OUTPUT_CACHE_DIR = path.join(EVENTS_DIR, "tool-output-cache");
+
+function spillToolOutput(agentId: string, idx: number, slot: number, body: string): string {
+  const safeId = agentId.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const fileName = `${safeId}-${idx}-${slot}.txt`;
+  const ref = path.join("tool-output-cache", fileName);
+  try {
+    mkdirSync(TOOL_OUTPUT_CACHE_DIR, { recursive: true });
+    writeFileSync(path.join(TOOL_OUTPUT_CACHE_DIR, fileName), body);
+    return ref;
+  } catch {
+    return "(spill-failed)";
+  }
+}
+
+function elisionStub(byteLen: number, ref: string): string {
+  return `[output ${byteLen} bytes elided — stored at ${ref}]`;
+}
+
+function toolResultBody(content: unknown): { text: string; bytes: number } | null {
+  if (typeof content === "string") {
+    return { text: content, bytes: Buffer.byteLength(content) };
+  }
+  if (Array.isArray(content)) {
+    const text = content
+      .map((part) =>
+        part && typeof part === "object" && typeof (part as { text?: unknown }).text === "string"
+          ? (part as { text: string }).text
+          : "",
+      )
+      .join("");
+    if (text.length === 0) return null;
+    return { text, bytes: Buffer.byteLength(text) };
+  }
+  return null;
+}
+
+/**
+ * Replace any oversized tool_result body inside a StreamEvent with a short
+ * stub, spilling the full bytes to disk. Mutates `event` in place and returns
+ * it. Applied before the event reaches the pipeline so the bounded copy is what
+ * gets persisted and pushed over SSE.
+ */
+export function capOversizedToolResults(
+  agentId: string,
+  event: { message?: unknown; [key: string]: unknown },
+  maxBytes: number = CONFIG.MAX_TOOL_RESULT_BYTES,
+): typeof event {
+  const message = event.message;
+  if (!message || typeof message !== "object") return event;
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) return event;
+
+  const idx = typeof event._idx === "number" ? event._idx : 0;
+  let slot = 0;
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    if ((block as { type?: unknown }).type !== "tool_result") continue;
+    const body = toolResultBody((block as { content?: unknown }).content);
+    slot++;
+    if (!body || body.bytes <= maxBytes) continue;
+    const ref = spillToolOutput(agentId, idx, slot, body.text);
+    (block as { content: unknown }).content = elisionStub(body.bytes, ref);
+  }
+  return event;
+}
+
+/** Kill a process group (SIGTERM), escalating to SIGKILL after a timeout. */
+export function killProcessGroup(proc: ReturnType<typeof spawn>, timeoutMs = CONFIG.PROCESS_KILL_TIMEOUT_MS): void {
+  if (proc.killed || proc.pid == null) return;
+  try {
+    process.kill(-proc.pid, "SIGTERM");
+  } catch {
+    return;
+  }
+  const escalation = setTimeout(() => {
+    try {
+      if (proc.pid) process.kill(-proc.pid, "SIGKILL");
+    } catch {
+      // Already dead
+    }
+  }, timeoutMs);
+  escalation.unref();
+}
+
+/**
+ * Kill ALL non-init, non-server processes.
+ * Used by emergencyDestroyAll() to catch bash/node/curl/git spawned by agents
+ * that aren't tracked in our process map. Only kills descendants of agentRootPids.
+ */
+export function cleanupAllProcesses(agentRootPids: number[]): void {
+  if (agentRootPids.length === 0) return;
+  try {
+    const myPid = process.pid;
+    const output = execFileSync("ps", ["-eo", "pid,ppid,comm"], {
+      encoding: "utf-8",
+      timeout: CONFIG.PROCESS_PS_TIMEOUT_MS,
+    });
+    const rootSet = new Set(agentRootPids.filter((p) => p > 0));
+    const pidToPpid = new Map<number, number>();
+    for (const line of output.split("\n")) {
+      const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
+      if (!match) continue;
+      const [, pidStr, ppidStr] = match;
+      const pid = Number.parseInt(pidStr, 10);
+      const ppid = Number.parseInt(ppidStr, 10);
+      if (pid === 1 || pid === myPid) continue;
+      pidToPpid.set(pid, ppid);
+    }
+    const toKill = new Set<number>(rootSet);
+    let frontier = [...rootSet];
+    while (frontier.length > 0) {
+      const next: number[] = [];
+      for (const pid of frontier) {
+        for (const [cpid, ppid] of pidToPpid) {
+          if (ppid === pid) next.push(cpid);
+        }
+      }
+      for (const p of next) toKill.add(p);
+      frontier = next;
+    }
+    let killed = 0;
+    for (const pid of toKill) {
+      try {
+        process.kill(pid, "SIGKILL");
+        killed++;
+      } catch {
+        // Already dead or no permission
+      }
+    }
+    if (killed > 0) {
+      logger.info(`[kill-switch] cleanupAllProcesses: killed ${killed} process(es)`);
+    }
+  } catch {
+    // ps not available
+  }
+}
+
+/** Callbacks that ProcessManager uses to communicate back to AgentManager without importing it. */
+export interface ProcessManagerCallbacks {
+  /** Notify SSE listeners of agent metadata changes. */
+  onAgentUpdated: (id: string, agent: AgentProcess["agent"], immediate: boolean) => void;
+  /** Notify idle listeners that an agent has gone idle. */
+  onIdle: (id: string) => void;
+  /** Schedule ephemeral agent auto-destroy after idle. */
+  onEphemeralIdle: (id: string) => void;
+}
+
+export class ProcessManager {
+  constructor(
+    private registry: AgentRegistry,
+    private eventPipeline: EventPipeline,
+    private callbacks: ProcessManagerCallbacks,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Process spawn
+  // ---------------------------------------------------------------------------
+
+  spawnProcess(
+    id: string,
+    agentProc: AgentProcess,
+    args: string[],
+    env: NodeJS.ProcessEnv,
+    workspaceDir: string,
+  ): ReturnType<typeof spawn> {
+    const proc = spawn("claude", args, {
+      env,
+      cwd: workspaceDir,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
+    });
+
+    this.attachProcessHandlers(id, agentProc, proc);
+    return proc;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Process kill
+  // ---------------------------------------------------------------------------
+
+  killAndWait(proc: ReturnType<typeof spawn>, agentProc: AgentProcess): Promise<void> {
+    return new Promise<void>((resolve) => {
+      proc.stdout?.removeAllListeners();
+      proc.stderr?.removeAllListeners();
+      proc.removeAllListeners("close");
+
+      if (proc.killed || proc.exitCode !== null) {
+        resolve();
+        return;
+      }
+
+      agentProc.agent.status = "killing";
+
+      proc.once("close", () => {
+        resolve();
+      });
+
+      killProcessGroup(proc);
+
+      const safety = setTimeout(() => resolve(), 6_000);
+      safety.unref();
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // CLI argument builder
+  // ---------------------------------------------------------------------------
+
+  buildClaudeArgs(opts: CreateAgentRequest, model: string, resumeSessionId?: string): string[] {
+    const args: string[] = [];
+    if (opts.permissionMode) {
+      args.push("--permission-mode", opts.permissionMode);
+    } else if (opts.dangerouslySkipPermissions !== false) {
+      args.push("--dangerously-skip-permissions");
+    }
+    args.push(
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--include-partial-messages",
+      "--max-turns",
+      String(opts.maxTurns ?? 200),
+      "--model",
+      model,
+    );
+    if (opts.effort) {
+      args.push("--effort", opts.effort);
+    }
+    if (opts.appendSystemPrompt) {
+      args.push("--append-system-prompt", opts.appendSystemPrompt);
+    }
+    if (opts.allowedTools && opts.allowedTools.length > 0) {
+      args.push("--allowedTools", ...opts.allowedTools);
+    }
+    if (opts.disallowedTools && opts.disallowedTools.length > 0) {
+      args.push("--disallowedTools", ...opts.disallowedTools);
+    }
+    if (opts.fallbackModel) {
+      args.push("--fallback-model", opts.fallbackModel);
+    }
+    if (opts.mcpConfigPath) {
+      args.push("--mcp-config", opts.mcpConfigPath, "--strict-mcp-config");
+    }
+    if (opts.forkSessionId) {
+      args.push("--resume", opts.forkSessionId, "--fork-session");
+    } else if (resumeSessionId) {
+      args.push("--resume", resumeSessionId);
+    }
+    if (opts.sessionId) {
+      args.push("--session-id", opts.sessionId);
+    }
+    if (opts.noSessionPersistence) {
+      args.push("--no-session-persistence");
+    }
+    if (opts.maxBudgetUsd != null) {
+      args.push("--max-budget-usd", String(opts.maxBudgetUsd));
+    }
+    if (opts.jsonSchema) {
+      args.push("--json-schema", JSON.stringify(opts.jsonSchema));
+    }
+    if (opts.agents && Object.keys(opts.agents).length > 0) {
+      args.push("--agents", JSON.stringify(opts.agents));
+    }
+    args.push("--print", "--", opts.prompt);
+    return args;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hooks settings.json generation
+  // ---------------------------------------------------------------------------
+
+  generateHooksSettings(agentId: string, workspaceDir: string): void {
+    try {
+      const port = process.env.PORT ?? "8080";
+      const token = generateServiceToken(agentId);
+      const baseUrl = `http://localhost:${port}/api/hooks/${agentId}`;
+      const authHeader = `Bearer ${token}`;
+
+      const settings = {
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [{ type: "http", url: `${baseUrl}/pre-tool-use`, headers: { Authorization: authHeader } }],
+            },
+          ],
+          PostToolUse: [
+            {
+              matcher: ".*",
+              hooks: [
+                { type: "http", url: `${baseUrl}/post-tool-use`, headers: { Authorization: authHeader }, async: true },
+              ],
+            },
+          ],
+          Stop: [
+            {
+              hooks: [{ type: "http", url: `${baseUrl}/stop`, headers: { Authorization: authHeader }, async: true }],
+            },
+          ],
+          SubagentStart: [
+            {
+              hooks: [
+                {
+                  type: "http",
+                  url: `${baseUrl}/subagent-start`,
+                  headers: { Authorization: authHeader },
+                  async: true,
+                },
+              ],
+            },
+          ],
+          SubagentStop: [
+            {
+              hooks: [
+                {
+                  type: "http",
+                  url: `${baseUrl}/subagent-stop`,
+                  headers: { Authorization: authHeader },
+                  async: true,
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const operatorSettings = buildSettingsJson(agentId) as { hooks?: Record<string, unknown[]> };
+      if (operatorSettings.hooks) {
+        for (const [event, entries] of Object.entries(operatorSettings.hooks)) {
+          const key = event as keyof typeof settings.hooks;
+          if (settings.hooks[key]) {
+            (settings.hooks[key] as unknown[]).push(...entries);
+          } else {
+            (settings.hooks as Record<string, unknown[]>)[event] = [...entries];
+          }
+        }
+      }
+
+      const claudeDir = path.join(workspaceDir, ".claude");
+      mkdirSync(claudeDir, { recursive: true });
+      writeFileSync(path.join(claudeDir, "settings.json"), JSON.stringify(settings, null, 2));
+    } catch (err) {
+      logger.warn("[hooks] Failed to write hooks settings", {
+        agentId: agentId.slice(0, 8),
+        error: errorMessage(err),
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: stdio handling
+  // ---------------------------------------------------------------------------
+
+  private attachProcessHandlers(id: string, agentProc: AgentProcess, proc: ReturnType<typeof spawn>): void {
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      agentProc.lineBuffer += chunk.toString();
+
+      if (agentProc.lineBuffer.length > 1_048_576 && proc.stdout) {
+        proc.stdout.pause();
+      }
+
+      if (!agentProc.processingScheduled) {
+        agentProc.processingScheduled = true;
+        setImmediate(() => this.processLineBuffer(id, agentProc, proc));
+      }
+    });
+
+    proc.stderr?.on("data", (d: Buffer) => {
+      const text = d.toString();
+      if (STDERR_NOISE_RE.test(text)) return;
+      this.eventPipeline.handleEvent(id, { type: "stderr", text });
+    });
+
+    proc.on("close", (code) => {
+      if (agentProc.lineBuffer.trim()) {
+        try {
+          const event = JSON.parse(agentProc.lineBuffer) as StreamEvent;
+          capOversizedToolResults(id, event);
+          this.eventPipeline.handleEvent(id, event);
+        } catch {
+          this.eventPipeline.handleEvent(id, { type: "raw", text: agentProc.lineBuffer });
+        }
+        agentProc.lineBuffer = "";
+      }
+
+      this.eventPipeline.handleEvent(id, { type: "done", exitCode: code ?? undefined });
+      this.eventPipeline.flushEventBatch(id, agentProc);
+
+      const ap = this.registry.get(id);
+      if (ap) {
+        ap.agent.status = code === 0 ? "idle" : "error";
+        ap.agent.lastActivity = new Date().toISOString();
+        saveAgentState(ap.agent);
+        this.callbacks.onAgentUpdated(id, ap.agent, true);
+      }
+      debouncedSyncToGCS().catch((err) => {
+        logger.error("[agents] Failed to sync GCS after agent exit", { agentId: id, error: errorMessage(err) });
+      });
+
+      if (code === 0) {
+        this.callbacks.onIdle(id);
+        this.callbacks.onEphemeralIdle(id);
+      }
+    });
+  }
+
+  private processLineBuffer(id: string, agentProc: AgentProcess, proc: ReturnType<typeof spawn>): void {
+    agentProc.processingScheduled = false;
+
+    if (this.registry.get(id) == null) return;
+
+    const lines = agentProc.lineBuffer.split("\n");
+    agentProc.lineBuffer = lines.pop() || "";
+
+    const BATCH_SIZE = 50;
+    let offset = 0;
+
+    const processBatch = () => {
+      if (this.registry.get(id) == null) return;
+
+      const end = Math.min(offset + BATCH_SIZE, lines.length);
+      for (let i = offset; i < end; i++) {
+        const line = lines[i];
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line) as StreamEvent;
+          capOversizedToolResults(id, event);
+          this.eventPipeline.handleEvent(id, event);
+        } catch {
+          this.eventPipeline.handleEvent(id, { type: "raw", text: line });
+        }
+      }
+
+      offset = end;
+
+      if (offset < lines.length) {
+        setImmediate(processBatch);
+      } else {
+        if (proc.stdout?.isPaused?.()) {
+          proc.stdout.resume();
+        }
+      }
+    };
+
+    processBatch();
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts `ProcessManager` class from `agents.ts` monolith into `src/process-manager.ts`
- `ProcessManager` encapsulates: `spawnProcess`, `killAndWait`, `buildClaudeArgs`, `generateHooksSettings`, private `attachProcessHandlers`/`processLineBuffer`
- Exports standalone utilities: `capOversizedToolResults` (new — elides oversized tool_result bodies), `killProcessGroup`, `cleanupAllProcesses`
- Expands `buildClaudeArgs` with Fanbot's richer CLI flags: `--include-partial-messages`, `--effort`, `--permission-mode`, `--allowedTools`/`--disallowedTools`, `--fallback-model`, `--mcp-config`/`--strict-mcp-config`, `--fork-session`, `--agents`, etc.
- `agents.ts` reduced by ~150 lines, delegates all process lifecycle to `ProcessManager` via constructor injection

## Test plan
- [x] `src/process-manager.test.ts` — 24 new tests for `capOversizedToolResults`, `buildClaudeArgs` arg variations, `killProcessGroup`, `cleanupAllProcesses`
- [x] `src/agents.test.ts` — updated spy targets to `processManager.buildClaudeArgs`
- [x] Full suite: 748 tests pass
- [x] `biome check` clean on changed files
- [x] `tsc --noEmit` clean
- [x] Zero fanbot/fanvue strings in diff