### PR TITLE
feat: mount engine-backed /api/workflows router (D1 namespace swap, PR22d)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -37,6 +37,7 @@ import { createTasksRouter } from "./src/routes/tasks";
 import { createTokensRouter } from "./src/routes/tokens";
 import { createUsageRouter } from "./src/routes/usage";
 import { createWorkflowsRouter } from "./src/routes/workflows";
+import { createWorkflowsEngineRouter } from "./src/routes/workflows-engine";
 import { Scheduler } from "./src/scheduler";
 import { loadSecretsIntoEnv } from "./src/secrets-store";
 import {
@@ -212,8 +213,11 @@ app.use(createMcpRouter());
 app.use(createCostRouter(agentManager, costTracker, messageBus));
 app.use(createTasksRouter(taskGraph, orchestrator, gradeStore));
 app.use(createSchedulerRouter(scheduler));
-app.use(createWorkflowsRouter(agentManager, messageBus));
+// Engine-backed workflow routes are primary at /api/workflows (D1: namespace swap).
+// AM's original Linear spawner moved to /api/linear-workflows (PR22a #200).
+app.use(createWorkflowsEngineRouter(agentManager, messageBus));
 app.use(createLinearWorkflowsRouter(agentManager, messageBus));
+app.use(createWorkflowsRouter(agentManager, messageBus));
 app.use(createRepoGateConfigRouter());
 app.use(createMergeGateRouter(agentManager));
 app.use(createRepositoriesRouter(agentManager));

--- a/src/process-manager.test.ts
+++ b/src/process-manager.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { EventPipeline } from "./event-pipeline";
 import { capOversizedToolResults, cleanupAllProcesses, killProcessGroup, ProcessManager } from "./process-manager";
+import type { AgentRegistry } from "./usage-tracker";
 
 // ---------------------------------------------------------------------------
 // capOversizedToolResults
@@ -104,11 +106,11 @@ describe("cleanupAllProcesses", () => {
 // ProcessManager.buildClaudeArgs
 // ---------------------------------------------------------------------------
 describe("ProcessManager.buildClaudeArgs", () => {
-  const pm = new ProcessManager(
-    new Map() as Parameters<typeof ProcessManager>[0],
-    {} as Parameters<typeof ProcessManager>[1],
-    { onAgentUpdated: () => {}, onIdle: () => {}, onEphemeralIdle: () => {} },
-  );
+  const pm = new ProcessManager(new Map() as unknown as AgentRegistry, {} as unknown as EventPipeline, {
+    onAgentUpdated: () => {},
+    onIdle: () => {},
+    onEphemeralIdle: () => {},
+  });
 
   it("includes --dangerously-skip-permissions by default (headless agents)", () => {
     const args = pm.buildClaudeArgs({ prompt: "hello" }, "claude-sonnet-4-6");

--- a/src/routes/workflows-engine-mount.test.ts
+++ b/src/routes/workflows-engine-mount.test.ts
@@ -1,0 +1,83 @@
+import http from "node:http";
+import express from "express";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("../auth", () => ({
+  requireNotAgentService: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+vi.mock("../workflow-resource-manager", () => ({
+  checkWorkflowAgentLimit: vi.fn().mockReturnValue(null),
+  checkMemoryForNewWorkflow: vi.fn().mockReturnValue(null),
+  detectWorkflowStall: vi.fn(),
+  enforceWorkflowCostCap: vi.fn(),
+  WORKFLOW_MAX_AGENTS: 10,
+}));
+vi.mock("../workflow-triage", () => ({
+  buildTriagePrompt: vi.fn().mockReturnValue("prompt"),
+  buildValidationResult: vi.fn(),
+  clarityFromChecks: vi.fn(),
+  verdictFromClarity: vi.fn(),
+}));
+
+import { createWorkflowsEngineRouter } from "./workflows-engine";
+
+/**
+ * Smoke tests verifying the engine router mounts correctly at /api/workflows.
+ * This mirrors what server.ts does: app.use(createWorkflowsEngineRouter(...)).
+ */
+const mockAm = {
+  create: vi.fn().mockReturnValue({ agent: { id: "a1", name: "test" } }),
+  destroy: vi.fn().mockResolvedValue(undefined),
+  pause: vi.fn(),
+  list: vi.fn().mockReturnValue([]),
+  on: vi.fn(),
+  setWorkflowMembershipChecker: vi.fn(),
+};
+const mockBus = { post: vi.fn(), subscribe: vi.fn() };
+
+let server: http.Server;
+let base: string;
+
+beforeAll(
+  () =>
+    new Promise<void>((resolve) => {
+      const app = express();
+      app.use(express.json());
+      // biome-ignore lint/suspicious/noExplicitAny: test mock cast
+      app.use(createWorkflowsEngineRouter(mockAm as any, mockBus as any));
+      server = app.listen(0, "127.0.0.1", () => {
+        base = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+        resolve();
+      });
+    }),
+);
+
+afterAll(() => server?.close());
+
+async function get(path: string): Promise<{ status: number }> {
+  return new Promise((resolve, reject) => {
+    http
+      .get(`${base}${path}`, (res) => {
+        res.resume();
+        res.on("end", () => resolve({ status: res.statusCode ?? 0 }));
+      })
+      .on("error", reject);
+  });
+}
+
+describe("engine router mount verification", () => {
+  it("GET /api/workflows returns 200 (engine router mounted)", async () => {
+    const { status } = await get("/api/workflows");
+    expect(status).toBe(200);
+  });
+
+  it("GET /api/workflows/unknown returns 404 (engine router handles :id)", async () => {
+    const { status } = await get("/api/workflows/does-not-exist");
+    expect(status).toBe(404);
+  });
+
+  it("engine router does not intercept unrelated paths", async () => {
+    const { status } = await get("/api/health");
+    expect(status).toBe(404); // not registered in this test app
+  });
+});


### PR DESCRIPTION
## Summary

Final piece of PR #167 split: mounts the engine-backed workflow router as PRIMARY at `/api/workflows` (operator decision D1).

Changes:
- **server.ts**: adds `createWorkflowsEngineRouter` mount at `/api/workflows` (engine-backed, full triage/grade/spawn workflow state machine). AM's original Linear spawner kept alongside for backwards compatibility.
- **src/routes/workflows-engine-mount.test.ts** (81L): 3 smoke tests verifying the engine router is correctly mounted and responds to `/api/workflows` endpoints.

## Namespace after this PR
| Route | Handler |
|---|---|
| `POST /api/workflows/linear` | Engine-backed (triage + basicMode + spawn) |
| `GET /api/workflows` | Engine-backed (list all engine workflows) |
| `GET /api/workflows/:id` | Engine-backed |
| `DELETE /api/workflows/:id` | Engine-backed |
| `POST /api/linear-workflows/linear` | AM Linear spawner (preserved, PR22a #200) |

## Part of PR22 series
- ✅ PR22a #200: `/api/linear-workflows` (AM Linear spawner moved)
- ✅ PR22b #203: `workflow-routes-helpers` module
- ✅ PR22c #205: `workflows-engine.ts` (route implementation)
- ➡️ **PR22d (this)**: server.ts namespace swap

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` 781 tests pass (55 files)
- [x] `npx biome check .` clean (4 warnings, 0 errors)