### PR TITLE
feat(agents): add AgentQueryService + episodic-memory (Phase E PR29)

### DIFF
--- a/src/agent-query.test.ts
+++ b/src/agent-query.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import type { QueryRegistry } from "./agent-query";
+import { AgentQueryService, getGitInfo } from "./agent-query";
+import type { EventPipeline } from "./event-pipeline";
+import type { AgentProcess } from "./types";
+import type { UsageTracker } from "./usage-tracker";
+
+vi.mock("node:child_process", async (orig) => {
+  const actual = await orig<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    execFile: vi.fn((_cmd: unknown, _args: unknown, _opts: unknown, cb: (e: Error) => void) => {
+      cb(new Error("no git"));
+    }),
+  };
+});
+
+function makeReg(has = true): QueryRegistry {
+  const ap: AgentProcess = {
+    agent: {
+      id: "a1",
+      name: "t",
+      status: "idle",
+      workspaceDir: "/tmp/t",
+      createdAt: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+      model: "claude-sonnet-4-6",
+      depth: 1,
+    },
+    proc: null,
+    lineBuffer: "",
+    listeners: new Set(),
+    seenMessageIds: new Set(),
+    processingScheduled: false,
+    persistBatch: "",
+    persistTimer: null,
+    listenerBatch: [],
+    stallCount: 0,
+    eventBuffer: [],
+    eventBufferTotal: 0,
+  };
+  return {
+    get: vi.fn().mockReturnValue(has ? ap : undefined),
+    has: vi.fn().mockReturnValue(has),
+    entries: vi.fn().mockReturnValue([][Symbol.iterator]()),
+    values: vi.fn().mockReturnValue([][Symbol.iterator]()),
+    keys: vi.fn().mockReturnValue([][Symbol.iterator]()),
+    size: 0,
+  } as unknown as QueryRegistry;
+}
+
+const makeTracker = () =>
+  ({
+    getUsage: vi.fn().mockReturnValue(null),
+    getAllUsage: vi.fn().mockReturnValue({ agents: [] }),
+    resetAllUsage: vi.fn(),
+    upsertCostTracker: vi.fn(),
+  }) as unknown as UsageTracker;
+const makePipeline = () =>
+  ({ readPersistedEvents: vi.fn().mockResolvedValue({ events: [] }) }) as unknown as EventPipeline;
+
+describe("getGitInfo", () => {
+  it("returns nulls when workspace does not exist", async () => {
+    const info = await getGitInfo("/nonexistent/path/xyz");
+    expect(info.repo).toBeNull();
+    expect(info.branch).toBeNull();
+    expect(info.worktreePath).toBeNull();
+  });
+});
+
+describe("AgentQueryService", () => {
+  it("getEvents returns empty array for unknown agent", async () => {
+    const svc = new AgentQueryService(makeReg(false), makeTracker(), makePipeline());
+    expect(await svc.getEvents("missing")).toEqual([]);
+  });
+
+  it("getUsage delegates to usageTracker", () => {
+    const tracker = makeTracker();
+    new AgentQueryService(makeReg(), tracker, makePipeline()).getUsage("a1");
+    expect(tracker.getUsage).toHaveBeenCalledWith("a1");
+  });
+
+  it("getAllUsage delegates to usageTracker", () => {
+    const tracker = makeTracker();
+    new AgentQueryService(makeReg(), tracker, makePipeline()).getAllUsage();
+    expect(tracker.getAllUsage).toHaveBeenCalled();
+  });
+
+  it("getLogs returns empty when no events", async () => {
+    const svc = new AgentQueryService(makeReg(), makeTracker(), makePipeline());
+    const result = await svc.getLogs("a1");
+    expect(result.total).toBe(0);
+  });
+});

--- a/src/agent-query.ts
+++ b/src/agent-query.ts
@@ -1,0 +1,179 @@
+/**
+ * AgentQueryService — read-only query surface over agent state.
+ *
+ * Extracted from src/agents.ts (Phase E PR29).
+ * Groups the read/metadata methods (metadata, usage, logs, events, git info)
+ * plus git-info helpers. Receives shared agents Map, UsageTracker, and EventPipeline.
+ */
+
+import { execFile } from "node:child_process";
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { EventPipeline } from "./event-pipeline";
+import type { AgentMetadata, AgentUsage, StreamEvent } from "./types";
+import type { AgentRegistry, UsageTracker } from "./usage-tracker";
+
+const execFileAsync = promisify(execFile);
+
+async function gitCmd(cwd: string, args: string[]): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("git", args, { cwd, encoding: "utf-8", timeout: 3_000 });
+    return stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+export async function getGitInfo(
+  workspaceDir: string,
+): Promise<{ repo: string | null; branch: string | null; worktreePath: string | null }> {
+  const result = { repo: null as string | null, branch: null as string | null, worktreePath: null as string | null };
+
+  const topLevel = await gitCmd(workspaceDir, ["rev-parse", "--show-toplevel"]);
+  if (topLevel) {
+    result.branch = await gitCmd(topLevel, ["rev-parse", "--abbrev-ref", "HEAD"]);
+    result.repo = await gitCmd(topLevel, ["remote", "get-url", "origin"]);
+    const commonDir = await gitCmd(topLevel, ["rev-parse", "--git-common-dir"]);
+    const gitDir = await gitCmd(topLevel, ["rev-parse", "--git-dir"]);
+    if (commonDir && gitDir && path.resolve(topLevel, commonDir) !== path.resolve(topLevel, gitDir)) {
+      result.worktreePath = topLevel;
+    }
+    return result;
+  }
+
+  try {
+    const entries = await readdir(workspaceDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+      const subdir = path.join(workspaceDir, entry.name);
+      const branch = await gitCmd(subdir, ["rev-parse", "--abbrev-ref", "HEAD"]);
+      if (branch) {
+        result.branch = branch;
+        result.repo = await gitCmd(subdir, ["remote", "get-url", "origin"]);
+        result.worktreePath = subdir;
+        return result;
+      }
+    }
+  } catch {
+    // readdir may fail if workspace doesn't exist
+  }
+
+  return result;
+}
+
+/** Minimal registry interface for reading agent presence + data.
+ *  The AgentManager `Map<string, AgentProcess>` satisfies this structurally. */
+export interface QueryRegistry extends AgentRegistry {
+  has(id: string): boolean;
+}
+
+export class AgentQueryService {
+  constructor(
+    private readonly agents: QueryRegistry,
+    private readonly usageTracker: UsageTracker,
+    private readonly eventPipeline: EventPipeline,
+  ) {}
+
+  async getEvents(id: string): Promise<StreamEvent[]> {
+    if (!this.agents.has(id)) return [];
+    return this.eventPipeline.readPersistedEvents(id).then(({ events }) => events);
+  }
+
+  /** Return token usage and estimated cost for a single agent. */
+  getUsage(id: string): AgentUsage | null {
+    return this.usageTracker.getUsage(id);
+  }
+
+  /** Refresh cached git info on an agent (async, fire-and-forget safe). */
+  async refreshGitInfo(id: string): Promise<void> {
+    const agentProc = this.agents.get(id);
+    if (!agentProc) return;
+    const gitInfo = await getGitInfo(agentProc.agent.workspaceDir);
+    agentProc.agent.gitBranch = gitInfo.branch ?? undefined;
+    agentProc.agent.gitRepo = gitInfo.repo ?? undefined;
+    agentProc.agent.gitWorktree = gitInfo.worktreePath ?? undefined;
+  }
+
+  /** Return runtime metadata for a single agent (PID, git info, uptime, etc.). */
+  async getMetadata(id: string): Promise<AgentMetadata | null> {
+    const agentProc = this.agents.get(id);
+    if (!agentProc) return null;
+    const { agent, proc } = agentProc;
+    const uptimeMs = Date.now() - new Date(agent.createdAt).getTime();
+    const gitInfo = await getGitInfo(agent.workspaceDir);
+    // Update cached git info on the agent object
+    agent.gitBranch = gitInfo.branch ?? undefined;
+    agent.gitRepo = gitInfo.repo ?? undefined;
+    agent.gitWorktree = gitInfo.worktreePath ?? undefined;
+    return {
+      pid: proc?.pid ?? null,
+      uptime: uptimeMs,
+      workingDir: agent.workspaceDir,
+      repo: gitInfo.repo,
+      branch: gitInfo.branch,
+      worktreePath: gitInfo.worktreePath,
+      tokensIn: agent.usage?.tokensIn ?? 0,
+      tokensOut: agent.usage?.tokensOut ?? 0,
+      estimatedCost: Math.round((agent.usage?.estimatedCost ?? 0) * 1e6) / 1e6,
+      model: agent.model,
+      sessionId: agent.claudeSessionId ?? null,
+      lastTurnTokensIn: agent.usage?.lastTurnTokensIn ?? 0,
+    };
+  }
+
+  /** Return token usage for all agents, keyed by agent ID. */
+  getAllUsage(): { agents: Array<{ id: string; name: string; usage: AgentUsage }> } {
+    return this.usageTracker.getAllUsage();
+  }
+
+  /** Return session logs for an agent in a readable format.
+   *  Supports filtering by event type and limiting to the last N entries. */
+  async getLogs(id: string, opts?: { types?: string[]; tail?: number }): Promise<{ lines: string[]; total: number }> {
+    const { events } = await this.eventPipeline.readPersistedEvents(id);
+    if (events.length === 0) return { lines: [], total: 0 };
+
+    const typeFilter = opts?.types;
+    let lines: string[] = [];
+
+    for (const event of events) {
+      if (typeFilter && !typeFilter.includes(event.type)) continue;
+
+      const line = AgentQueryService.formatLogEvent(event);
+      if (line) lines.push(line);
+    }
+
+    const total = lines.length;
+    if (opts?.tail && opts.tail > 0) {
+      lines = lines.slice(-opts.tail);
+    }
+
+    return { lines, total };
+  }
+
+  /** Format a single event into a readable log line. */
+  private static formatLogEvent(event: StreamEvent): string | null {
+    switch (event.type) {
+      case "user_prompt":
+        return `[user] ${event.text}`;
+      case "assistant":
+        if (event.subtype === "text") return `[assistant] ${event.text}`;
+        if (event.subtype === "tool_use") return `[tool_call] ${event.tool}: ${event.content || ""}`;
+        if (event.subtype === "tool_result")
+          return `[tool_result] ${event.tool}: ${(event.result || event.content || "").toString().slice(0, 500)}`;
+        return `[assistant:${event.subtype || "unknown"}] ${event.text || event.content || ""}`;
+      case "system":
+        return `[system:${event.subtype || ""}] ${event.message || event.text || ""}`;
+      case "raw":
+        return `[raw] ${event.text}`;
+      case "stderr":
+        return `[stderr] ${event.text}`;
+      case "done":
+        return `[done] exit_code=${event.exitCode ?? "unknown"}`;
+      case "result":
+        return `[result] ${event.text || event.result || ""}`;
+      default:
+        return `[${event.type}${event.subtype ? `:${event.subtype}` : ""}] ${event.text || event.content || event.message || JSON.stringify(event)}`;
+    }
+  }
+}

--- a/src/episodic-memory.test.ts
+++ b/src/episodic-memory.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn().mockReturnValue("[]"),
+}));
+vi.mock("node:fs/promises", () => ({
+  rename: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("episodic-memory module", () => {
+  it("exports core functions", async () => {
+    const mod = await import("./episodic-memory");
+    expect(mod.getEpisodicLog).toBeDefined();
+    expect(mod.appendEpisode).toBeDefined();
+    expect(mod.buildResumeContext).toBeDefined();
+    expect(mod.queryEpisodes).toBeDefined();
+    expect(mod.clearEpisodicLog).toBeDefined();
+  });
+
+  it("getEpisodicLog returns an empty log for unknown agent", async () => {
+    const { getEpisodicLog } = await import("./episodic-memory");
+    const log = getEpisodicLog("unknown-agent");
+    expect(log.agentId).toBe("unknown-agent");
+    expect(log.entries).toEqual([]);
+  });
+
+  it("appendEpisode returns entry with correct fields", async () => {
+    const { appendEpisode } = await import("./episodic-memory");
+    const entry = await appendEpisode("agent-1", { kind: "task", summary: "did something" });
+    expect(entry.agentId).toBe("agent-1");
+    expect(entry.kind).toBe("task");
+    expect(entry.summary).toBe("did something");
+    expect(typeof entry.id).toBe("string");
+  });
+
+  it("queryEpisodes filters by kind", async () => {
+    const { queryEpisodes, appendEpisode } = await import("./episodic-memory");
+    await appendEpisode("agent-filter", { kind: "task", summary: "a task" });
+    await appendEpisode("agent-filter", { kind: "note", summary: "a note" });
+    const tasks = queryEpisodes("agent-filter", { kinds: ["task"] });
+    expect(tasks.every((e) => e.kind === "task")).toBe(true);
+  });
+
+  it("buildResumeContext returns a string", async () => {
+    const { buildResumeContext } = await import("./episodic-memory");
+    const ctx = buildResumeContext("agent-ctx");
+    expect(typeof ctx).toBe("string");
+  });
+});

--- a/src/episodic-memory.ts
+++ b/src/episodic-memory.ts
@@ -1,0 +1,170 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { logger } from "./logger";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type EpisodeKind = "task" | "result" | "decision" | "note";
+
+export interface EpisodicEntry {
+  id: string;
+  agentId: string;
+  ts: string; // ISO-8601
+  kind: EpisodeKind;
+  summary: string;
+  detail?: string;
+}
+
+export interface AgentEpisodicLog {
+  agentId: string;
+  entries: EpisodicEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Storage config (mirrors hook-config-store.ts pattern)
+// ---------------------------------------------------------------------------
+
+const PERSISTENT_BASE = "/persistent";
+const PERSISTENT_AVAILABLE = existsSync(PERSISTENT_BASE);
+const EPISODIC_DIR = PERSISTENT_AVAILABLE ? `${PERSISTENT_BASE}/episodic-logs` : "/tmp/episodic-logs";
+
+mkdirSync(EPISODIC_DIR, { recursive: true });
+
+export const MAX_ENTRIES = 500;
+
+function logPath(agentId: string): string {
+  return path.join(EPISODIC_DIR, `${agentId}.json`);
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+export function getEpisodicLog(agentId: string): AgentEpisodicLog {
+  const filePath = logPath(agentId);
+  if (!existsSync(filePath)) {
+    return { agentId, entries: [] };
+  }
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    return JSON.parse(raw) as AgentEpisodicLog;
+  } catch (err: unknown) {
+    logger.warn(
+      `[episodic-memory] Failed to read log for ${agentId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { agentId, entries: [] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Write (atomic: temp file + rename)
+// ---------------------------------------------------------------------------
+
+async function persistLog(agentId: string, log: AgentEpisodicLog): Promise<void> {
+  const filePath = logPath(agentId);
+  const tmpPath = `${filePath}.tmp`;
+  await writeFile(tmpPath, JSON.stringify(log), "utf-8");
+  await rename(tmpPath, filePath);
+}
+
+// ---------------------------------------------------------------------------
+// Append
+// ---------------------------------------------------------------------------
+
+export async function appendEpisode(
+  agentId: string,
+  entry: Pick<EpisodicEntry, "kind" | "summary" | "detail">,
+): Promise<EpisodicEntry> {
+  const full: EpisodicEntry = {
+    id: randomUUID(),
+    agentId,
+    ts: new Date().toISOString(),
+    kind: entry.kind,
+    summary: entry.summary,
+    ...(entry.detail !== undefined ? { detail: entry.detail } : {}),
+  };
+
+  const log = getEpisodicLog(agentId);
+  log.entries.push(full);
+
+  // Trim oldest entries when over cap
+  if (log.entries.length > MAX_ENTRIES) {
+    log.entries = log.entries.slice(log.entries.length - MAX_ENTRIES);
+  }
+
+  await persistLog(agentId, log);
+  return full;
+}
+
+// ---------------------------------------------------------------------------
+// Query
+// ---------------------------------------------------------------------------
+
+export function queryEpisodes(
+  agentId: string,
+  opts?: { kinds?: EpisodeKind[]; since?: string; limit?: number },
+): EpisodicEntry[] {
+  const log = getEpisodicLog(agentId);
+  let results = log.entries;
+
+  if (opts?.kinds && opts.kinds.length > 0) {
+    const kindSet = new Set(opts.kinds);
+    results = results.filter((e) => kindSet.has(e.kind));
+  }
+
+  if (opts?.since) {
+    const sinceDate = new Date(opts.since).getTime();
+    results = results.filter((e) => new Date(e.ts).getTime() >= sinceDate);
+  }
+
+  // Most-recent-first
+  results = results.slice().reverse();
+
+  if (opts?.limit !== undefined && opts.limit > 0) {
+    results = results.slice(0, opts.limit);
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Build resume context (pure helper)
+// ---------------------------------------------------------------------------
+
+export function buildResumeContext(agentId: string, opts?: { maxEntries?: number; maxChars?: number }): string {
+  const maxEntries = opts?.maxEntries ?? 50;
+  const maxChars = opts?.maxChars ?? 4000;
+
+  const recent = queryEpisodes(agentId, { limit: maxEntries });
+  if (recent.length === 0) return "";
+
+  // Build from most recent → oldest, stop when char budget exhausted
+  const lines: string[] = ["## Episodic Memory (most recent first)", ""];
+  let chars = lines[0].length + 1; // include newline
+
+  for (const entry of recent) {
+    const line = `- **[${entry.kind}]** ${entry.ts.slice(0, 19).replace("T", " ")} — ${entry.summary}`;
+    const lineChars = line.length + 1;
+    if (chars + lineChars > maxChars) break;
+    lines.push(line);
+    chars += lineChars;
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Clear
+// ---------------------------------------------------------------------------
+
+export async function clearEpisodicLog(agentId: string): Promise<void> {
+  const filePath = logPath(agentId);
+  if (existsSync(filePath)) {
+    const { unlink } = await import("node:fs/promises");
+    await unlink(filePath);
+  }
+}


### PR DESCRIPTION
## Summary
- Add AgentQueryService (read-only query surface: getEvents, getUsage, getMetadata, getLogs, getAllUsage, refreshGitInfo + getGitInfo helper)
- Add episodic-memory.ts (episodic log store writing to /persistent/episodic-logs/)
- 2 test files, 10 tests, tsc+biome clean, no fanbot/fanvue strings

## Test plan
- [x] 10 tests pass
- [x] tsc --noEmit clean
- [x] biome check clean